### PR TITLE
Added documentation link button to header

### DIFF
--- a/apps/webview-ui/src/app/(main)/header.tsx
+++ b/apps/webview-ui/src/app/(main)/header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { User } from '@rustrak/client';
-import { LogOut, Settings, Terminal } from 'lucide-react';
+import { LogOut, Settings, Terminal, Book } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useTransition } from 'react';
@@ -14,6 +14,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface HeaderProps {
   user: User;
@@ -46,6 +47,21 @@ export function Header({ user }: HeaderProps) {
 
       {/* User Menu */}
       <div className="flex items-center gap-4">
+        {/* Documentation Link */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" asChild>
+              <a href="https://abians.github.io/rustrak" 
+                target="_blank"
+                rel="noopener noreferrer">
+                  <Book className="size-4" />
+                  <span className="sr-only">Documentation</span>
+              </a>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Documentation</TooltipContent>
+        </Tooltip>
+
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button


### PR DESCRIPTION
### Quick Summary

Added a documentation link to the webview-ui header for quick access to rustrak docs.

### Changes made
- Added a documentation icon button to the header
- Opens the documentation in a new tab

Fixes #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Documentation link button in the header with tooltip functionality for quick access to external documentation resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->