### PR TITLE
feat: add password strength validation to registration and password changing

### DIFF
--- a/apps/server/src/auth/mod.rs
+++ b/apps/server/src/auth/mod.rs
@@ -1,8 +1,10 @@
 pub mod extractors;
+pub mod password;
 pub mod sentry_auth;
 pub mod session;
 pub mod token;
 
 pub use extractors::{BearerAuth, SentryAuth};
+pub use password::validate_password_strength;
 pub use session::{clear_session, get_user_id_from_session, set_user_session, AuthenticatedUser};
 pub use token::generate_token;

--- a/apps/server/src/auth/password.rs
+++ b/apps/server/src/auth/password.rs
@@ -1,0 +1,175 @@
+//! Password validation module
+//!
+//! Provides password strength validation for registration and password changes.
+
+/// Common passwords that should be rejected (top 100 most common)
+const COMMON_PASSWORDS: &[&str] = &[
+    "password", "123456", "12345678", "qwerty", "abc123", "monkey", "1234567",
+    "letmein", "trustno1", "dragon", "baseball", "iloveyou", "master", "sunshine",
+    "ashley", "bailey", "passw0rd", "shadow", "123123", "654321", "superman",
+    "qazwsx", "michael", "football", "password1", "password123", "batman", "login",
+    "admin", "admin123", "welcome", "welcome1", "p@ssw0rd", "qwerty123", "solo",
+    "princess", "starwars", "cheese", "tigger", "whatever", "fuckyou", "donald",
+    "pokemon", "soccer", "access", "mustang", "pepper", "joshua", "jennifer",
+    "george", "houston", "rangers", "matrix", "biteme", "killer", "charlie",
+    "corvette", "summer", "jessica", "robert", "maverick", "harley", "asshole",
+    "buster", "andrew", "yellow", "smokey", "jordan", "cowboy", "william",
+    "secret", "orange", "cookie", "coffee", "silver", "nicole", "richard",
+    "dakota", "martin", "maggie", "guitar", "runner", "jasper", "102030",
+    "lakers", "soccer1", "winter", "bonnie", "hockey", "merlin", "diamond",
+    "forever", "angels", "ginger", "hammer", "banana", "purple", "prince",
+    "flower", "hunter",
+];
+
+/// Password strength validation
+///
+/// Requirements:
+/// - Minimum 8 characters
+/// - At least one uppercase letter
+/// - At least one lowercase letter
+/// - At least one digit
+/// - Not a commonly used password
+///
+/// Returns `Ok(())` if password meets all requirements,
+/// or `Err(Vec<String>)` with a list of validation error messages.
+pub fn validate_password_strength(password: &str) -> Result<(), Vec<String>> {
+    let mut errors = Vec::new();
+
+    // Length check
+    if password.len() < 8 {
+        errors.push("Password must be at least 8 characters long".to_string());
+    }
+
+    // Uppercase check
+    if !password.chars().any(|c| c.is_ascii_uppercase()) {
+        errors.push("Password must contain at least one uppercase letter".to_string());
+    }
+
+    // Lowercase check
+    if !password.chars().any(|c| c.is_ascii_lowercase()) {
+        errors.push("Password must contain at least one lowercase letter".to_string());
+    }
+
+    // Digit check
+    if !password.chars().any(|c| c.is_ascii_digit()) {
+        errors.push("Password must contain at least one digit".to_string());
+    }
+
+    // Common password check (case-insensitive)
+    let password_lower = password.to_lowercase();
+    if COMMON_PASSWORDS.contains(&password_lower.as_str()) {
+        errors.push("Password is too common, please choose a more unique password".to_string());
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_password() {
+        assert!(validate_password_strength("SecureP@ss1").is_ok());
+        assert!(validate_password_strength("MyStr0ngPwd").is_ok());
+        assert!(validate_password_strength("Test1234A").is_ok());
+    }
+
+    #[test]
+    fn test_too_short() {
+        let result = validate_password_strength("Short1A");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("at least 8 characters")));
+    }
+
+    #[test]
+    fn test_missing_uppercase() {
+        let result = validate_password_strength("lowercase123");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("uppercase letter")));
+    }
+
+    #[test]
+    fn test_missing_lowercase() {
+        let result = validate_password_strength("UPPERCASE123");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("lowercase letter")));
+    }
+
+    #[test]
+    fn test_missing_digit() {
+        let result = validate_password_strength("NoDigitsHere");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("digit")));
+    }
+
+    #[test]
+    fn test_common_password() {
+        let result = validate_password_strength("Password1");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("too common")));
+    }
+
+    #[test]
+    fn test_common_password_case_insensitive() {
+        // "password" is in the list, "PASSWORD1" should also be rejected
+        let result = validate_password_strength("PASSWORD1");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("too common")));
+    }
+
+    #[test]
+    fn test_multiple_errors() {
+        // "a" fails all requirements
+        let result = validate_password_strength("a");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.len() >= 3); // at least: too short, no uppercase, no digit
+    }
+
+    #[test]
+    fn test_exact_minimum_length() {
+        // Exactly 8 characters with all requirements met
+        assert!(validate_password_strength("Abcdefg1").is_ok());
+    }
+
+    #[test]
+    fn test_unicode_does_not_count() {
+        // Unicode characters don't satisfy ASCII requirements
+        let result = validate_password_strength("pässwörd123");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("uppercase letter")));
+    }
+
+    #[test]
+    fn test_various_common_passwords() {
+        // Test several common passwords as-is (they may fail other checks too)
+        for &common in &["password", "qwerty", "admin", "letmein", "dragon"] {
+            let result = validate_password_strength(common);
+            assert!(
+                result.is_err(),
+                "Password '{}' should be rejected",
+                common
+            );
+            // Specifically check that the common password error is present
+            let errors = result.unwrap_err();
+            assert!(
+                errors.iter().any(|e| e.contains("too common")),
+                "Password '{}' should be flagged as too common, errors: {:?}",
+                common,
+                errors
+            );
+        }
+    }
+}

--- a/apps/server/src/models/mod.rs
+++ b/apps/server/src/models/mod.rs
@@ -18,4 +18,4 @@ pub use grouping::Grouping;
 pub use installation::Installation;
 pub use issue::{Issue, IssueResponse, UpdateIssueState};
 pub use project::{CreateProject, Project, ProjectResponse, UpdateProject};
-pub use user::{CreateUserRequest, LoginRequest, User};
+pub use user::{ChangePasswordRequest, CreateUserRequest, LoginRequest, User};

--- a/apps/server/src/models/user.rs
+++ b/apps/server/src/models/user.rs
@@ -34,6 +34,13 @@ pub struct LoginRequest {
     pub password: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ChangePasswordRequest {
+    pub current_password: String,
+    pub new_password: String,
+}
+
 impl User {
     /// Hash a password using Argon2id
     pub fn hash_password(password: &str) -> Result<String, AppError> {

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -2,9 +2,9 @@ use actix_session::Session;
 use actix_web::{web, HttpResponse, Responder};
 use serde::Serialize;
 
-use crate::auth::{self, AuthenticatedUser};
+use crate::auth::{self, validate_password_strength, AuthenticatedUser};
 use crate::error::{AppError, AppResult};
-use crate::models::{CreateUserRequest, LoginRequest, User};
+use crate::models::{ChangePasswordRequest, CreateUserRequest, LoginRequest, User};
 use crate::services::UsersService;
 
 #[cfg(feature = "openapi")]
@@ -99,9 +99,9 @@ pub async fn register(
         return Err(AppError::Validation("Invalid email format".to_string()));
     }
 
-    // Validate password is provided
-    if req.password.is_empty() {
-        return Err(AppError::Validation("Password is required".to_string()));
+    // Validate password strength
+    if let Err(errors) = validate_password_strength(&req.password) {
+        return Err(AppError::Validation(errors.join("; ")));
     }
 
     // Create user (non-admin by default)
@@ -187,13 +187,50 @@ pub async fn get_current_user(user: AuthenticatedUser) -> impl Responder {
     HttpResponse::Ok().json(UserResponse::from(user.0))
 }
 
+#[cfg_attr(feature = "openapi", utoipa::path(
+    post,
+    path = "/auth/change-password",
+    tag = "Auth",
+    request_body = ChangePasswordRequest,
+    responses(
+        (status = 204, description = "Password changed successfully"),
+        (status = 400, description = "Validation error (password too weak)", body = crate::error::ErrorResponse),
+        (status = 401, description = "Invalid current password", body = crate::error::ErrorResponse),
+    ),
+    security(("session_cookie" = [])),
+))]
+/// POST /auth/change-password
+/// Change current user's password
+pub async fn change_password(
+    pool: web::Data<crate::db::DbPool>,
+    user: AuthenticatedUser,
+    req: web::Json<ChangePasswordRequest>,
+) -> AppResult<impl Responder> {
+    // Verify current password
+    if !user.0.verify_password(&req.current_password)? {
+        return Err(AppError::Unauthorized("Invalid current password".to_string()));
+    }
+
+    // Validate new password strength
+    if let Err(errors) = validate_password_strength(&req.new_password) {
+        return Err(AppError::Validation(errors.join("; ")));
+    }
+
+    // Hash and update password
+    let new_hash = User::hash_password(&req.new_password)?;
+    UsersService::update_password(pool.get_ref(), user.0.id, &new_hash).await?;
+
+    Ok(HttpResponse::NoContent().finish())
+}
+
 #[cfg(feature = "openapi")]
 #[derive(OpenApi)]
 #[openapi(
-    paths(register, login, logout, get_current_user),
+    paths(register, login, logout, get_current_user, change_password),
     components(schemas(
         crate::models::CreateUserRequest,
         crate::models::LoginRequest,
+        crate::models::ChangePasswordRequest,
         AuthResponse,
         UserResponse,
     ))
@@ -207,6 +244,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             .route("/register", web::post().to(register))
             .route("/login", web::post().to(login))
             .route("/logout", web::post().to(logout))
-            .route("/me", web::get().to(get_current_user)),
+            .route("/me", web::get().to(get_current_user))
+            .route("/change-password", web::post().to(change_password)),
     );
 }

--- a/apps/server/src/services/users.rs
+++ b/apps/server/src/services/users.rs
@@ -96,4 +96,21 @@ impl UsersService {
 
         Ok(count.0)
     }
+
+    /// Updates the password for a user
+    pub async fn update_password(pool: &DbPool, user_id: i32, new_password_hash: &str) -> AppResult<()> {
+        sqlx::query(
+            r#"
+            UPDATE users
+            SET password_hash = $1
+            WHERE id = $2
+            "#,
+        )
+        .bind(new_password_hash)
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
 }

--- a/apps/webview-ui/src/actions/auth.ts
+++ b/apps/webview-ui/src/actions/auth.ts
@@ -1,6 +1,11 @@
 'use server';
 
-import type { LoginRequest, User } from '@rustrak/client';
+import type {
+  ChangePasswordRequest,
+  LoginRequest,
+  RegisterRequest,
+  User,
+} from '@rustrak/client';
 import { RustrakError } from '@rustrak/client';
 import {
   applySetCookies,
@@ -11,6 +16,14 @@ import {
 export type LoginResult =
   | { success: true; user: User }
   | { success: false; error: 'invalid_credentials' | 'unknown' };
+
+export type RegisterResult =
+  | { success: true; user: User }
+  | { success: false; error: 'email_exists' | 'weak_password' | 'unknown'; message?: string };
+
+export type ChangePasswordResult =
+  | { success: true }
+  | { success: false; error: 'invalid_current_password' | 'weak_password' | 'unknown'; message?: string };
 
 /**
  * Login with email and password.
@@ -68,5 +81,63 @@ export async function getCurrentUser(): Promise<User | null> {
     // to avoid breaking the app on transient errors
     console.error('Failed to get current user:', err);
     return null;
+  }
+}
+
+/**
+ * Register a new user account.
+ * Sets the session cookie automatically on success.
+ *
+ * @param credentials - Email and password for the new account
+ * @returns Result object with success status and user or error type
+ */
+export async function register(credentials: RegisterRequest): Promise<RegisterResult> {
+  try {
+    const client = await createClient();
+    const result = await client.auth.register(credentials);
+
+    // Apply session cookies from backend response
+    await applySetCookies(result.cookies);
+
+    return { success: true, user: result.user };
+  } catch (err) {
+    if (err instanceof RustrakError) {
+      // Email already exists (409 Conflict or validation error)
+      if (err.statusCode === 409 || (err.statusCode === 400 && err.message.includes('Email already exists'))) {
+        return { success: false, error: 'email_exists' };
+      }
+      // Weak password (400 with password validation message)
+      if (err.statusCode === 400 && err.message.includes('Password')) {
+        return { success: false, error: 'weak_password', message: err.message };
+      }
+    }
+    return { success: false, error: 'unknown' };
+  }
+}
+
+/**
+ * Change the current user's password.
+ * Requires the correct current password.
+ *
+ * @param request - Current password and new password
+ * @returns Result object with success status or error type
+ */
+export async function changePassword(request: ChangePasswordRequest): Promise<ChangePasswordResult> {
+  try {
+    const client = await createClient();
+    await client.auth.changePassword(request);
+    return { success: true };
+  } catch (err) {
+    if (err instanceof RustrakError) {
+      // Invalid current password (401)
+      if (err.statusCode === 401) {
+        return { success: false, error: 'invalid_current_password' };
+      }
+      // Weak password (400 with password validation message)
+      if (err.statusCode === 400 && err.message.includes('Password')) {
+        return { success: false, error: 'weak_password', message: err.message };
+      }
+    }
+    return { success: false, error: 'unknown' };
   }
 }

--- a/apps/webview-ui/src/app/(main)/settings/account/change-password-form.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/account/change-password-form.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Check, X } from 'lucide-react';
+import { useState, useTransition } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { z } from 'zod';
+import { changePassword } from '@/actions/auth';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  checkPasswordRequirements,
+  passwordSchema,
+} from '@/lib/password-validation';
+
+const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, 'Current password is required'),
+    newPassword: passwordSchema,
+    confirmPassword: z.string().min(1, 'Please confirm your new password'),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ['confirmPassword'],
+  });
+
+type ChangePasswordFormData = z.infer<typeof changePasswordSchema>;
+
+function PasswordRequirement({ met, label }: { met: boolean; label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      {met ? (
+        <Check className="size-3 text-green-500" />
+      ) : (
+        <X className="size-3 text-muted-foreground" />
+      )}
+      <span className={met ? 'text-green-500' : 'text-muted-foreground'}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export function ChangePasswordForm() {
+  const [isPending, startTransition] = useTransition();
+  const [success, setSuccess] = useState(false);
+
+  const form = useForm<ChangePasswordFormData>({
+    resolver: zodResolver(changePasswordSchema),
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+    mode: 'onChange',
+  });
+
+  const newPassword = useWatch({
+    control: form.control,
+    name: 'newPassword',
+  });
+  const requirements = checkPasswordRequirements(newPassword || '');
+
+  const onSubmit = (data: ChangePasswordFormData) => {
+    form.clearErrors();
+    setSuccess(false);
+
+    startTransition(async () => {
+      const result = await changePassword({
+        current_password: data.currentPassword,
+        new_password: data.newPassword,
+      });
+
+      if (result.success) {
+        setSuccess(true);
+        form.reset();
+      } else if (result.error === 'invalid_current_password') {
+        form.setError('currentPassword', {
+          type: 'server',
+          message: 'Current password is incorrect',
+        });
+      } else if (result.error === 'weak_password') {
+        form.setError('newPassword', {
+          type: 'server',
+          message: result.message || 'Password does not meet requirements',
+        });
+      } else {
+        form.setError('newPassword', {
+          type: 'server',
+          message: 'An unexpected error occurred. Please try again.',
+        });
+      }
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        {success && (
+          <div className="rounded-md bg-green-500/10 border border-green-500/20 p-3 text-sm text-green-500">
+            Password changed successfully.
+          </div>
+        )}
+
+        <FormField
+          control={form.control}
+          name="currentPassword"
+          render={({ field }) => (
+            <FormItem className="space-y-2">
+              <FormLabel>Current Password</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder="Enter your current password"
+                  autoComplete="current-password"
+                  disabled={isPending}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="newPassword"
+          render={({ field }) => (
+            <FormItem className="space-y-2">
+              <FormLabel>New Password</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder="Enter your new password"
+                  autoComplete="new-password"
+                  disabled={isPending}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+              {/* Password requirements */}
+              {newPassword && (
+                <div className="space-y-1.5 pt-2">
+                  <PasswordRequirement
+                    met={requirements.minLength}
+                    label="At least 8 characters"
+                  />
+                  <PasswordRequirement
+                    met={requirements.hasUppercase}
+                    label="One uppercase letter (A-Z)"
+                  />
+                  <PasswordRequirement
+                    met={requirements.hasLowercase}
+                    label="One lowercase letter (a-z)"
+                  />
+                  <PasswordRequirement
+                    met={requirements.hasDigit}
+                    label="One digit (0-9)"
+                  />
+                  <PasswordRequirement
+                    met={requirements.notCommon}
+                    label="Not a common password"
+                  />
+                </div>
+              )}
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="confirmPassword"
+          render={({ field }) => (
+            <FormItem className="space-y-2">
+              <FormLabel>Confirm New Password</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder="Confirm your new password"
+                  autoComplete="new-password"
+                  disabled={isPending}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? 'Changing password...' : 'Change password'}
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/settings/account/page.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/account/page.tsx
@@ -9,6 +9,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
+import { ChangePasswordForm } from './change-password-form';
 
 export const metadata: Metadata = {
   title: 'Account | Rustrak',
@@ -48,6 +49,18 @@ export default async function AccountPage() {
                 <p className="text-sm font-medium">Administrator</p>
               </div>
             )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Change Password</CardTitle>
+            <CardDescription>
+              Update your password to keep your account secure
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ChangePasswordForm />
           </CardContent>
         </Card>
       </div>

--- a/apps/webview-ui/src/app/auth/login/login-form.tsx
+++ b/apps/webview-ui/src/app/auth/login/login-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useTransition } from 'react';
 import { useForm } from 'react-hook-form';
@@ -126,6 +127,16 @@ export function LoginForm() {
           </Button>
         </form>
       </Form>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Don&apos;t have an account?{' '}
+        <Link
+          href="/auth/register"
+          className="text-primary hover:underline font-medium"
+        >
+          Create one
+        </Link>
+      </p>
     </div>
   );
 }

--- a/apps/webview-ui/src/app/auth/register/page.tsx
+++ b/apps/webview-ui/src/app/auth/register/page.tsx
@@ -1,0 +1,89 @@
+import { Terminal } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { APP_VERSION } from '@/lib/constants';
+import { RegisterForm } from './register-form';
+
+export const metadata: Metadata = {
+  title: 'Create account | Rustrak',
+  description: 'Create a new Rustrak account',
+};
+
+export default function RegisterPage() {
+  return (
+    <div className="min-h-screen flex">
+      {/* Left Panel - Decorative (hidden on mobile) */}
+      <div className="hidden lg:flex lg:w-1/2 bg-background flex-col justify-between p-12 relative overflow-hidden">
+        {/* Background gradient */}
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_hsl(var(--card)),_transparent_50%)]" />
+        <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-background to-transparent z-10" />
+
+        {/* Brand */}
+        <Link href="/" className="relative z-20 flex items-center gap-2 w-fit">
+          <div className="size-8 bg-primary rounded-sm flex items-center justify-center shadow-[0_0_15px_hsl(var(--primary)/0.3)]">
+            <Terminal className="size-5 text-primary-foreground" />
+          </div>
+          <span className="text-lg font-extrabold tracking-tight uppercase">
+            Rustrak
+          </span>
+        </Link>
+
+        {/* Welcome message */}
+        <div className="relative z-20 max-w-xl">
+          <h2 className="text-6xl xl:text-7xl font-extrabold tracking-tighter leading-[1.05] mb-8">
+            Start tracking errors today
+            <span className="text-primary">.</span>
+          </h2>
+          <p className="text-muted-foreground text-lg font-medium leading-relaxed max-w-md">
+            Lightweight, self-hosted error tracking. Set up in minutes and start
+            monitoring your applications with enterprise-grade reliability.
+          </p>
+
+          {/* Stats */}
+          <div className="mt-12 flex items-center gap-8">
+            <div>
+              <span className="text-2xl font-bold text-primary">50MB</span>
+              <p className="text-sm text-muted-foreground">Memory footprint</p>
+            </div>
+            <div>
+              <span className="text-2xl font-bold text-primary">&lt;50ms</span>
+              <p className="text-sm text-muted-foreground">Ingestion latency</p>
+            </div>
+            <div>
+              <span className="text-2xl font-bold text-primary">10k+</span>
+              <p className="text-sm text-muted-foreground">Events/second</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="relative z-20 flex justify-between items-end text-xs text-muted-foreground font-mono">
+          <div>
+            <p className="mt-1">v{APP_VERSION}</p>
+          </div>
+          <div className="flex gap-6">
+            <p>&copy; {new Date().getFullYear()} Rustrak</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Right Panel - Form */}
+      <div className="w-full lg:w-1/2 bg-card flex items-center justify-center p-8 lg:p-12">
+        <div className="w-full max-w-[420px] space-y-10">
+          {/* Mobile brand (hidden on desktop) */}
+          <div className="lg:hidden flex items-center gap-2 mb-8">
+            <div className="size-8 bg-primary rounded-sm flex items-center justify-center">
+              <Terminal className="size-5 text-primary-foreground" />
+            </div>
+            <span className="text-lg font-extrabold tracking-tight uppercase">
+              Rustrak
+            </span>
+          </div>
+
+          {/* Form */}
+          <RegisterForm />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/auth/register/register-form.tsx
+++ b/apps/webview-ui/src/app/auth/register/register-form.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Check, X } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useTransition } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { z } from 'zod';
+import { register } from '@/actions/auth';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  checkPasswordRequirements,
+  passwordSchema,
+} from '@/lib/password-validation';
+
+const registerSchema = z.object({
+  email: z.string().email('Please enter a valid email address'),
+  password: passwordSchema,
+  confirmPassword: z.string().min(1, 'Please confirm your password'),
+}).refine((data) => data.password === data.confirmPassword, {
+  message: "Passwords don't match",
+  path: ['confirmPassword'],
+});
+
+type RegisterFormData = z.infer<typeof registerSchema>;
+
+function PasswordRequirement({ met, label }: { met: boolean; label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      {met ? (
+        <Check className="size-3 text-green-500" />
+      ) : (
+        <X className="size-3 text-muted-foreground" />
+      )}
+      <span className={met ? 'text-green-500' : 'text-muted-foreground'}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export function RegisterForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<RegisterFormData>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+      confirmPassword: '',
+    },
+    mode: 'onChange',
+  });
+
+  const password = useWatch({ control: form.control, name: 'password' });
+  const requirements = checkPasswordRequirements(password || '');
+
+  const onSubmit = (data: RegisterFormData) => {
+    form.clearErrors();
+
+    startTransition(async () => {
+      const result = await register({
+        email: data.email,
+        password: data.password,
+      });
+
+      if (result.success) {
+        router.push('/projects');
+      } else if (result.error === 'email_exists') {
+        form.setError('email', {
+          type: 'server',
+          message: 'An account with this email already exists',
+        });
+      } else if (result.error === 'weak_password') {
+        form.setError('password', {
+          type: 'server',
+          message: result.message || 'Password does not meet requirements',
+        });
+      } else {
+        form.setError('password', {
+          type: 'server',
+          message: 'An unexpected error occurred. Please try again.',
+        });
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Create account</h1>
+        <p className="text-muted-foreground">
+          Enter your details to create a new account.
+        </p>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem className="space-y-2">
+                <FormLabel className="text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
+                  Email Address
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="name@company.com"
+                    autoComplete="email"
+                    disabled={isPending}
+                    className="bg-background border-border px-4 py-3.5 text-sm placeholder:text-muted-foreground/30"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem className="space-y-2">
+                <FormLabel className="text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
+                  Password
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="Create a password"
+                    autoComplete="new-password"
+                    disabled={isPending}
+                    className="bg-background border-border px-4 py-3.5 text-sm placeholder:text-muted-foreground/30"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+                {/* Password requirements */}
+                {password && (
+                  <div className="space-y-1.5 pt-2">
+                    <PasswordRequirement
+                      met={requirements.minLength}
+                      label="At least 8 characters"
+                    />
+                    <PasswordRequirement
+                      met={requirements.hasUppercase}
+                      label="One uppercase letter (A-Z)"
+                    />
+                    <PasswordRequirement
+                      met={requirements.hasLowercase}
+                      label="One lowercase letter (a-z)"
+                    />
+                    <PasswordRequirement
+                      met={requirements.hasDigit}
+                      label="One digit (0-9)"
+                    />
+                    <PasswordRequirement
+                      met={requirements.notCommon}
+                      label="Not a common password"
+                    />
+                  </div>
+                )}
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem className="space-y-2">
+                <FormLabel className="text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
+                  Confirm Password
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="Confirm your password"
+                    autoComplete="new-password"
+                    disabled={isPending}
+                    className="bg-background border-border px-4 py-3.5 text-sm placeholder:text-muted-foreground/30"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button
+            type="submit"
+            className="w-full font-extrabold uppercase tracking-widest text-xs py-6 mt-2"
+            disabled={isPending}
+          >
+            {isPending ? 'Creating account...' : 'Create account'}
+          </Button>
+        </form>
+      </Form>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Already have an account?{' '}
+        <Link
+          href="/auth/login"
+          className="text-primary hover:underline font-medium"
+        >
+          Log in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/lib/password-validation.ts
+++ b/apps/webview-ui/src/lib/password-validation.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+
+/**
+ * Common passwords that should be rejected (top 100 most common)
+ * This list matches the server-side validation
+ */
+const COMMON_PASSWORDS = new Set([
+  'password', '123456', '12345678', 'qwerty', 'abc123', 'monkey', '1234567',
+  'letmein', 'trustno1', 'dragon', 'baseball', 'iloveyou', 'master', 'sunshine',
+  'ashley', 'bailey', 'passw0rd', 'shadow', '123123', '654321', 'superman',
+  'qazwsx', 'michael', 'football', 'password1', 'password123', 'batman', 'login',
+  'admin', 'admin123', 'welcome', 'welcome1', 'p@ssw0rd', 'qwerty123', 'solo',
+  'princess', 'starwars', 'cheese', 'tigger', 'whatever', 'fuckyou', 'donald',
+  'pokemon', 'soccer', 'access', 'mustang', 'pepper', 'joshua', 'jennifer',
+  'george', 'houston', 'rangers', 'matrix', 'biteme', 'killer', 'charlie',
+  'corvette', 'summer', 'jessica', 'robert', 'maverick', 'harley', 'asshole',
+  'buster', 'andrew', 'yellow', 'smokey', 'jordan', 'cowboy', 'william',
+  'secret', 'orange', 'cookie', 'coffee', 'silver', 'nicole', 'richard',
+  'dakota', 'martin', 'maggie', 'guitar', 'runner', 'jasper', '102030',
+  'lakers', 'soccer1', 'winter', 'bonnie', 'hockey', 'merlin', 'diamond',
+  'forever', 'angels', 'ginger', 'hammer', 'banana', 'purple', 'prince',
+  'flower', 'hunter',
+]);
+
+/**
+ * Password requirements:
+ * - Minimum 8 characters
+ * - At least one uppercase letter
+ * - At least one lowercase letter
+ * - At least one digit
+ * - Not a commonly used password
+ */
+export const passwordSchema = z
+  .string()
+  .min(8, 'Password must be at least 8 characters long')
+  .refine(
+    (password) => /[A-Z]/.test(password),
+    'Password must contain at least one uppercase letter'
+  )
+  .refine(
+    (password) => /[a-z]/.test(password),
+    'Password must contain at least one lowercase letter'
+  )
+  .refine(
+    (password) => /[0-9]/.test(password),
+    'Password must contain at least one digit'
+  )
+  .refine(
+    (password) => !COMMON_PASSWORDS.has(password.toLowerCase()),
+    'Password is too common, please choose a more unique password'
+  );
+
+/**
+ * Password requirements description for UI display
+ */
+export const PASSWORD_REQUIREMENTS = [
+  'At least 8 characters long',
+  'At least one uppercase letter (A-Z)',
+  'At least one lowercase letter (a-z)',
+  'At least one digit (0-9)',
+  'Not a commonly used password',
+] as const;
+
+/**
+ * Check individual password requirements (for real-time feedback)
+ */
+export function checkPasswordRequirements(password: string) {
+  return {
+    minLength: password.length >= 8,
+    hasUppercase: /[A-Z]/.test(password),
+    hasLowercase: /[a-z]/.test(password),
+    hasDigit: /[0-9]/.test(password),
+    notCommon: !COMMON_PASSWORDS.has(password.toLowerCase()),
+  };
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -33,6 +33,7 @@ export type {
   ApiError,
   // Auth
   AuthResponse,
+  ChangePasswordRequest,
   // Tokens
   AuthToken,
   AuthTokenCreated,

--- a/packages/client/src/resources/auth.ts
+++ b/packages/client/src/resources/auth.ts
@@ -1,10 +1,12 @@
 import {
   authResponseSchema,
+  changePasswordRequestSchema,
   loginRequestSchema,
   registerRequestSchema,
   userSchema,
 } from '../schemas/user.js';
 import type {
+  ChangePasswordRequest,
   LoginRequest,
   LoginResult,
   RegisterRequest,
@@ -87,5 +89,19 @@ export class AuthResource extends BaseResource {
   async getCurrentUser(): Promise<User> {
     const data = await this.http.get('auth/me').json();
     return this.validate(data, userSchema);
+  }
+
+  /**
+   * Change the current user's password
+   * Requires a valid session cookie and the correct current password
+   * @param request - Current password and new password
+   */
+  async changePassword(request: ChangePasswordRequest): Promise<void> {
+    // Validate input
+    const validatedInput = this.validate(request, changePasswordRequestSchema);
+
+    await this.http.post('auth/change-password', {
+      json: validatedInput,
+    });
   }
 }

--- a/packages/client/src/schemas/user.ts
+++ b/packages/client/src/schemas/user.ts
@@ -39,3 +39,11 @@ export const registerRequestSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
 });
+
+/**
+ * Change password request schema
+ */
+export const changePasswordRequestSchema = z.object({
+  current_password: z.string().min(1),
+  new_password: z.string().min(8),
+});

--- a/packages/client/src/types/user.ts
+++ b/packages/client/src/types/user.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod';
 import type {
   authResponseSchema,
+  changePasswordRequestSchema,
   loginRequestSchema,
   loginResultSchema,
   registerRequestSchema,
@@ -32,3 +33,8 @@ export type LoginRequest = z.infer<typeof loginRequestSchema>;
  * RegisterRequest - data needed to create a new user account
  */
 export type RegisterRequest = z.infer<typeof registerRequestSchema>;
+
+/**
+ * ChangePasswordRequest - data needed to change the user's password
+ */
+export type ChangePasswordRequest = z.infer<typeof changePasswordRequestSchema>;


### PR DESCRIPTION
- Server: Add password validation module with requirements (min 8 chars, uppercase, lowercase, digit, not common password)
- Server: Add POST /auth/change-password endpoint
- Client: Add changePassword() method and ChangePasswordRequest type
- WebView: Add registration form with real-time password feedback
- WebView: Add password change form in account settings
- Add comprehensive unit tests for password validation

Closes #48