### PR TITLE
feat(announce): add release announce skill

### DIFF
--- a/.claude/skills/rustrak-release-announce/.gitignore
+++ b/.claude/skills/rustrak-release-announce/.gitignore
@@ -1,0 +1,1 @@
+.announce.config.toml

--- a/.claude/skills/rustrak-release-announce/.gitignore
+++ b/.claude/skills/rustrak-release-announce/.gitignore
@@ -1,1 +1,3 @@
 .announce.config.toml
+__pycache__/
+*.pyc

--- a/.claude/skills/rustrak-release-announce/SKILL.md
+++ b/.claude/skills/rustrak-release-announce/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: rustrak-release-announce
+description: Generates branded release image and posts to Reddit. Use when user says 'announce release', 'create release post', 'nueva version', or 'publicar release'.
+---
+
+# rustrak-release-announce
+
+## Overview
+
+This workflow automates Rustrak release announcements — from extracting changelog data to generating a branded release card image and publishing to Reddit. Act as a release communications assistant: gather what shipped from the CHANGELOG files, craft developer-friendly copy, generate the visual card, get explicit approval, then publish.
+
+The workflow is interactive — approval is required before anything is posted. Config lives in `{skill-root}/.announce.config.toml` (gitignored; create from `assets/announce.config.toml.example`).
+
+## Conventions
+
+- Bare paths (e.g. `references/01-gather.md`) resolve from the skill root.
+- `{project-root}` resolves from the project working directory.
+- Scripts output JSON to stdout.
+
+## On Activation
+
+Greet the user and present the 5-stage flow. Check that `{skill-root}/.announce.config.toml` exists — if not, mention it needs to be created before Stage 5 but don't block the workflow.
+
+## Stages
+
+| # | Stage | Outcome |
+|---|-------|---------|
+| 1 | **Gather** | Version number and changelog data extracted and confirmed |
+| 2 | **Copy** | Post title and body drafted and approved |
+| 3 | **Image** | Release card rendered as PNG at `{project-root}/release-cards/release-card-v{VERSION}.png` |
+| 4 | **Preview** | User sees copy + image + target subreddits and gives explicit go-ahead |
+| 5 | **Publish** | Posted to all configured subreddits, URLs logged |
+
+Load `references/01-gather.md` and follow stages in sequence. Move to the next stage only when the current stage's outcome is met.

--- a/.claude/skills/rustrak-release-announce/assets/announce.config.toml.example
+++ b/.claude/skills/rustrak-release-announce/assets/announce.config.toml.example
@@ -1,5 +1,6 @@
 # Rustrak Release Announcer — Configuration Template
-# Copy to {project-root}/.announce.config.toml (gitignored) and fill in your credentials.
+# Copy to {skill-root}/.announce.config.toml (gitignored) and fill in your credentials.
+# i.e. .claude/skills/rustrak-release-announce/.announce.config.toml
 # See references/reddit-setup.md for how to obtain Reddit API credentials.
 
 [reddit]

--- a/.claude/skills/rustrak-release-announce/assets/announce.config.toml.example
+++ b/.claude/skills/rustrak-release-announce/assets/announce.config.toml.example
@@ -1,0 +1,18 @@
+# Rustrak Release Announcer — Configuration Template
+# Copy to {project-root}/.announce.config.toml (gitignored) and fill in your credentials.
+# See references/reddit-setup.md for how to obtain Reddit API credentials.
+
+[reddit]
+# From https://www.reddit.com/prefs/apps (create a "script" type app)
+client_id = ""
+client_secret = ""
+# Permanent refresh token from PRAW OAuth flow — see references/reddit-setup.md
+refresh_token = ""
+user_agent = "rustrak-announce/1.0 by u/YOUR_REDDIT_USERNAME"
+
+# Subreddits to post to (without the r/ prefix)
+subreddits = [
+  "selfhosted",
+  # "rust",
+  # "opensource",
+]

--- a/.claude/skills/rustrak-release-announce/assets/release-card.html
+++ b/.claude/skills/rustrak-release-announce/assets/release-card.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;700&family=Geist+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { width: 1200px; height: 630px; overflow: hidden; }
+
+    .card {
+      position: relative;
+      width: 1200px;
+      height: 630px;
+      background: #0c0c0c;
+      padding: 56px 80px 52px;
+      display: flex;
+      flex-direction: column;
+      font-family: 'Geist', -apple-system, BlinkMacSystemFont, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    /* Subtle glow near version (bottom-right) */
+    .card::before {
+      content: '';
+      position: absolute;
+      bottom: -60px;
+      right: -30px;
+      width: 720px;
+      height: 600px;
+      background: radial-gradient(ellipse, rgba(197,241,30,0.055) 0%, transparent 55%);
+      pointer-events: none;
+    }
+
+    /* Bottom accent line */
+    .card::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 80px;
+      right: 80px;
+      height: 1px;
+      background: linear-gradient(to right,
+        transparent,
+        rgba(197,241,30,0.4) 15%,
+        rgba(197,241,30,0.4) 85%,
+        transparent
+      );
+    }
+
+    /* ── Header: brand + release label ── */
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-shrink: 0;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 18px;
+    }
+
+    .logo { width: 60px; height: 60px; flex-shrink: 0; }
+
+    .brand-name {
+      font-size: 40px;
+      font-weight: 700;
+      color: #fff;
+      letter-spacing: -1.8px;
+      line-height: 1;
+    }
+
+    .release-label {
+      font-family: 'Geist Mono', monospace;
+      font-size: 11px;
+      font-weight: 400;
+      letter-spacing: 0.2px;
+      color: rgba(255,255,255,0.2);
+    }
+
+    /* ── Separator ── */
+    .sep-line {
+      height: 1px;
+      background: rgba(255,255,255,0.06);
+      margin-top: 32px;
+      flex-shrink: 0;
+    }
+
+    /* ── Body: fills remaining height ── */
+    .body {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding-top: 40px;
+    }
+
+    /* ── Tagline (top of body) ── */
+    .tagline {
+      font-size: 36px;
+      font-weight: 400;
+      color: rgba(255,255,255,0.28);
+      line-height: 1.55;
+      letter-spacing: -0.8px;
+      max-width: 720px;
+    }
+
+    /* ── Bottom row: meta left + version right ── */
+    .bottom-row {
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+    }
+
+    .meta {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding-bottom: 12px; /* align with version baseline */
+    }
+
+    .meta-item {
+      font-family: 'Geist Mono', monospace;
+      font-size: 11.5px;
+      color: rgba(255,255,255,0.18);
+      letter-spacing: 0.1px;
+    }
+
+    .meta-sep {
+      width: 1px;
+      height: 11px;
+      background: rgba(255,255,255,0.1);
+    }
+
+    /* ── Version (hero) ── */
+    .version-block {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+    }
+
+    .version {
+      font-family: 'Geist Mono', monospace;
+      font-size: 160px;
+      font-weight: 700;
+      line-height: 0.87;
+      letter-spacing: -9px;
+      color: #fff;
+      white-space: nowrap;
+    }
+
+    .v { color: #C5F11E; font-weight: 400; }
+  </style>
+</head>
+<body>
+  <div class="card">
+
+    <div class="header">
+      <div class="brand">
+        <svg class="logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" fill="none">
+          <rect width="80" height="80" rx="16" fill="#C5F11E"/>
+          <path d="M24 32L36 44L24 56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M44 56H56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="brand-name">Rustrak</span>
+      </div>
+      <span class="release-label">New Version</span>
+    </div>
+
+    <div class="sep-line"></div>
+
+    <div class="body">
+      <div class="tagline">
+        Self-hosted error tracking.<br>
+        Sentry SDK compatible.
+      </div>
+
+      <div class="bottom-row">
+        <div class="meta">
+          <span class="meta-item">github.com/AbianS/rustrak</span>
+          <div class="meta-sep"></div>
+          <span class="meta-item">Open Source</span>
+        </div>
+        <div class="version-block">
+          <div class="version"><span class="v">v</span>{{VERSION}}</div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/.claude/skills/rustrak-release-announce/references/01-gather.md
+++ b/.claude/skills/rustrak-release-announce/references/01-gather.md
@@ -1,0 +1,23 @@
+# Stage 1: Gather Release Data
+
+**Outcome:** Version number confirmed, per-package changes summarized, user says the data is accurate.
+
+Run:
+
+```bash
+python3 scripts/gather_release_data.py {project-root}
+```
+
+Review the JSON output. Surface to the user:
+
+- The release version (e.g. `0.2.1`)
+- What changed, grouped by type (Major / Minor / Patch), deduped across packages
+- Any packages that had no changes or parsing errors
+
+If a package was skipped or the version looks wrong, ask the user before proceeding.
+
+Present a clean human-readable summary — not the raw JSON. Ask if there's anything missing or context to add (e.g. a migration note, a shoutout to a contributor, a one-liner about motivation).
+
+**Proceed to Stage 2** once the user confirms the data is good. Carry the version string and aggregated changes forward — they're needed in every subsequent stage.
+
+Then load `references/02-generate-copy.md`.

--- a/.claude/skills/rustrak-release-announce/references/02-generate-copy.md
+++ b/.claude/skills/rustrak-release-announce/references/02-generate-copy.md
@@ -1,0 +1,23 @@
+# Stage 2: Generate Announcement Copy
+
+**Outcome:** A Reddit post title and body the user has approved — developer-friendly, no marketing fluff.
+
+Using the release data from Stage 1, draft:
+
+1. **Title** — Short and specific. Include the version. Lead with the most interesting change if there is one.
+   - Good: `Rustrak v0.2.1 — SQLite as default, dependency upgrades`
+   - Bad: `Rustrak v0.2.1 is out! 🎉`
+
+2. **Body** — Markdown, optimized for Reddit. Structure:
+   - One-line project description (for people who don't know Rustrak)
+   - What's new, grouped by impact (breaking changes first and flagged clearly)
+   - Link to GitHub release / CHANGELOG
+   - Optional: link to docs, Docker image, or self-hosting guide
+
+Keep it scannable. Real sentences, not bullet soup. No "I'm excited to announce", no "Please let me know your thoughts", no emojis unless they genuinely aid scannability.
+
+Present one draft. Let the user iterate — they may want a different tone, more/less detail, or a specific phrasing for a technical change.
+
+**Proceed to Stage 3** when the user approves the title and body. Save both — they'll be used in Stages 4 and 5.
+
+Then load `references/03-generate-image.md`.

--- a/.claude/skills/rustrak-release-announce/references/03-generate-image.md
+++ b/.claude/skills/rustrak-release-announce/references/03-generate-image.md
@@ -1,0 +1,21 @@
+# Stage 3: Generate Release Card Image
+
+**Outcome:** `{project-root}/release-cards/release-card-v{VERSION}.png` — a 1200×630 PNG ready for sharing.
+
+Run:
+
+```bash
+uv run scripts/render_release_card.py \
+  --version {VERSION} \
+  --output {project-root}/release-cards/release-card-v{VERSION}.png \
+  --skill-root {skill-root} \
+  --verbose
+```
+
+The script uses Playwright + Chromium to render the HTML template (`assets/release-card.html`). `uv` installs Playwright automatically. Chromium (~150MB) is downloaded on first run only.
+
+Parse the JSON output. If `status` is `fail`, surface the error to the user before proceeding.
+
+**Proceed to Stage 4** once the PNG exists at the expected path.
+
+Then load `references/04-preview-approve.md`.

--- a/.claude/skills/rustrak-release-announce/references/04-preview-approve.md
+++ b/.claude/skills/rustrak-release-announce/references/04-preview-approve.md
@@ -1,0 +1,23 @@
+# Stage 4: Preview & Approve
+
+**Outcome:** The user has seen the post text, the release card image, and the target subreddits — and said yes.
+
+Present everything together:
+
+1. **Post title** (formatted as a Reddit title)
+2. **Post body** (rendered markdown)
+3. **Release card image** — display inline if the environment supports it; otherwise show the path `{project-root}/release-cards/release-card-v{VERSION}.png` and remind the user to open it
+4. **Target subreddits** — read from `{skill-root}/.announce.config.toml`, list them explicitly (e.g. `r/selfhosted`, `r/rust`)
+
+Ask: _"Everything looks good? Confirm to post to these subreddits."_
+
+If the user wants changes:
+- Copy tweaks → loop back to Stage 2
+- Image tweaks → loop back to Stage 3 (edit the HTML template directly if needed)
+- Different subreddits → they edit `.announce.config.toml` directly, then re-confirm
+
+Don't proceed until you have explicit approval.
+
+**Proceed to Stage 5** on explicit yes.
+
+Then load `references/05-publish.md`.

--- a/.claude/skills/rustrak-release-announce/references/05-publish.md
+++ b/.claude/skills/rustrak-release-announce/references/05-publish.md
@@ -1,0 +1,34 @@
+# Stage 5: Publish
+
+**Outcome:** The announcement is live on all configured subreddits, with URLs logged.
+
+**Step 1 — Verify config**
+
+Check that `{skill-root}/.announce.config.toml` exists and has credentials filled in (`client_id`, `client_secret`, `refresh_token` are non-empty). If missing or incomplete, guide the user to `references/reddit-setup.md` before proceeding.
+
+**Step 2 — Write body to file**
+
+Write the approved post body to `/tmp/rustrak-post-body.md` (avoids shell quoting issues).
+
+**Step 3 — Post**
+
+```bash
+uv run scripts/post_to_reddit.py \
+  --config {skill-root}/.announce.config.toml \
+  --title "APPROVED_TITLE" \
+  --body-file /tmp/rustrak-post-body.md
+```
+
+Replace `APPROVED_TITLE` with the approved title from Stage 2.
+
+**Step 4 — Report results**
+
+Parse the JSON output and tell the user:
+- Which subreddits succeeded and their live URLs
+- Which failed and why
+
+If any failed, diagnose the error (auth issue? banned from subreddit? rate limit?) and offer to retry.
+
+Clean up `/tmp/rustrak-post-body.md` when done.
+
+**Workflow complete** when at least one post is live.

--- a/.claude/skills/rustrak-release-announce/references/reddit-setup.md
+++ b/.claude/skills/rustrak-release-announce/references/reddit-setup.md
@@ -1,0 +1,64 @@
+# Reddit API Setup
+
+## Create a Reddit App
+
+1. Go to https://www.reddit.com/prefs/apps
+2. Click **"create another app..."** at the bottom
+3. Fill in:
+   - **Name:** rustrak-announce (or anything)
+   - **Type:** select **script**
+   - **Redirect URI:** `http://localhost:8080`
+4. Click **Create app**
+5. Copy the **client_id** (under the app name, short string) and **client_secret**
+
+## Get a Refresh Token
+
+Run this once from your terminal (needs PRAW installed):
+
+```bash
+uv run --with praw python3 -c "
+import praw, webbrowser
+
+reddit = praw.Reddit(
+    client_id='YOUR_CLIENT_ID',
+    client_secret='YOUR_CLIENT_SECRET',
+    redirect_uri='http://localhost:8080',
+    user_agent='rustrak-setup/1.0'
+)
+
+scopes = ['submit', 'identity']
+url = reddit.auth.url(scopes=scopes, state='setup', duration='permanent')
+print('Open this URL:', url)
+webbrowser.open(url)
+
+code = input('Paste the ?code= value from the redirect URL: ')
+refresh_token = reddit.auth.authorize(code)
+print('Your refresh_token:', refresh_token)
+"
+```
+
+## Fill in `.announce.config.toml`
+
+```toml
+[reddit]
+client_id = "your_client_id_here"
+client_secret = "your_client_secret_here"
+refresh_token = "your_refresh_token_here"
+user_agent = "rustrak-announce/1.0 by u/YOUR_REDDIT_USERNAME"
+
+subreddits = [
+  "selfhosted",
+]
+```
+
+## Test Without Posting
+
+Run with `--dry-run` to verify credentials and subreddit list without submitting:
+
+```bash
+uv run scripts/post_to_reddit.py \
+  --config .announce.config.toml \
+  --title "Test" \
+  --body-file /dev/stdin \
+  --dry-run <<< "Test body"
+```

--- a/.claude/skills/rustrak-release-announce/scripts/gather_release_data.py
+++ b/.claude/skills/rustrak-release-announce/scripts/gather_release_data.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""
+Parses CHANGELOG.md files from Rustrak packages and extracts the latest release data.
+
+Usage:
+  python3 gather_release_data.py [PROJECT_ROOT] [-o OUTPUT] [--verbose]
+
+Outputs JSON with release version, per-package changes, and aggregated change list.
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+CHANGELOG_PATHS = [
+    "apps/server/CHANGELOG.md",
+    "apps/webview-ui/CHANGELOG.md",
+    "apps/docs/CHANGELOG.md",
+    "packages/client/CHANGELOG.md",
+]
+
+VERSION_RE = re.compile(r"^## (\d+\.\d+\.\d+[^\s]*)$")
+SECTION_RE = re.compile(r"^### (.+)$")
+PR_LINK_RE = re.compile(r"\[#\d+\]\(https?://[^)]+\)\s*")
+COMMIT_LINK_RE = re.compile(r"\[`[a-f0-9]+`\]\(https?://[^)]+\)\s*")
+THANKS_RE = re.compile(r"Thanks\s+\[@[^\]]+\]\(https?://[^)]+\)!\s*-?\s*")
+
+
+def _clean_line(line: str) -> str:
+    line = PR_LINK_RE.sub("", line)
+    line = COMMIT_LINK_RE.sub("", line)
+    line = THANKS_RE.sub("", line)
+    return line.strip()
+
+
+def parse_changelog(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    package_name = next(
+        (l[2:].strip() for l in lines if l.startswith("# ")), None
+    )
+
+    version_start = version = None
+    for i, line in enumerate(lines):
+        m = VERSION_RE.match(line)
+        if m:
+            version = m.group(1)
+            version_start = i
+            break
+
+    if version_start is None:
+        return None
+
+    version_end = len(lines)
+    for i in range(version_start + 1, len(lines)):
+        if VERSION_RE.match(lines[i]) or lines[i].startswith("# "):
+            version_end = i
+            break
+
+    section_lines = lines[version_start + 1 : version_end]
+
+    changes: dict[str, list[str]] = {}
+    current_section: str | None = None
+
+    for line in section_lines:
+        sm = SECTION_RE.match(line)
+        if sm:
+            current_section = sm.group(1).strip()
+            changes[current_section] = []
+            continue
+
+        if current_section is None:
+            continue
+
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if stripped.startswith(("- ", "* ")):
+            cleaned = _clean_line(stripped[2:])
+            if cleaned:
+                changes[current_section].append(cleaned)
+        elif changes[current_section] and not stripped.startswith("#"):
+            cleaned = _clean_line(stripped)
+            if cleaned:
+                changes[current_section][-1] += " " + cleaned
+
+    return {
+        "package": package_name,
+        "version": version,
+        "changes": {k: v for k, v in changes.items() if v},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("project_root", nargs="?", default=".", help="Path to project root")
+    parser.add_argument("-o", "--output", help="Output file (default: stdout)")
+    parser.add_argument("--verbose", action="store_true", help="Print diagnostics to stderr")
+    args = parser.parse_args()
+
+    root = Path(args.project_root).resolve()
+    packages = []
+    findings = []
+
+    for rel_path in CHANGELOG_PATHS:
+        path = root / rel_path
+        if args.verbose:
+            print(f"[gather] Reading {path}", file=sys.stderr)
+
+        data = parse_changelog(path)
+        if data:
+            packages.append(data)
+        else:
+            findings.append({
+                "severity": "medium",
+                "category": "structure",
+                "location": {"file": rel_path, "line": 0},
+                "issue": f"Could not parse CHANGELOG.md at {rel_path}",
+                "fix": "Ensure the file exists and has the standard changeset format",
+            })
+
+    # Primary version: server package, fallback to first found
+    release_version = next(
+        (p["version"] for p in packages if p.get("package") == "@rustrak/server"),
+        packages[0]["version"] if packages else None,
+    )
+
+    # Aggregate changes across all packages, deduped
+    aggregated: dict[str, list[str]] = {}
+    seen: set[str] = set()
+
+    for pkg in packages:
+        for section, items in pkg["changes"].items():
+            if section not in aggregated:
+                aggregated[section] = []
+            for item in items:
+                if item and item not in seen:
+                    seen.add(item)
+                    aggregated[section].append(item)
+
+    status = "fail" if any(f["severity"] in ("critical", "high") for f in findings) else "pass"
+
+    result = {
+        "script": "gather_release_data",
+        "version": "1.0.0",
+        "project_root": str(root),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "release": {
+            "version": release_version,
+            "packages": packages,
+            "aggregated_changes": aggregated,
+        },
+        "findings": findings,
+        "summary": {
+            "total": len(findings),
+            "critical": sum(1 for f in findings if f["severity"] == "critical"),
+            "high": sum(1 for f in findings if f["severity"] == "high"),
+            "medium": sum(1 for f in findings if f["severity"] == "medium"),
+            "low": sum(1 for f in findings if f["severity"] == "low"),
+        },
+    }
+
+    output = json.dumps(result, indent=2, ensure_ascii=False)
+
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+        if args.verbose:
+            print(f"[gather] Written to {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+    sys.exit(0 if status == "pass" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/rustrak-release-announce/scripts/post_to_reddit.py
+++ b/.claude/skills/rustrak-release-announce/scripts/post_to_reddit.py
@@ -90,7 +90,7 @@ def main() -> None:
 
     config = load_config(config_path)
 
-    body = args.body if args.body else Path(args.body_file).read_text(encoding="utf-8")
+    body = args.body if args.body is not None else Path(args.body_file).read_text(encoding="utf-8")
 
     if args.verbose:
         print(f"[reddit] Config loaded from {config_path}", file=sys.stderr)

--- a/.claude/skills/rustrak-release-announce/scripts/post_to_reddit.py
+++ b/.claude/skills/rustrak-release-announce/scripts/post_to_reddit.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "praw>=7.7",
+# ]
+# ///
+"""
+Posts a release announcement to configured Reddit subreddits.
+
+Usage:
+  uv run post_to_reddit.py --config .announce.config.toml --title "TITLE" --body-file body.md
+  uv run post_to_reddit.py --config .announce.config.toml --title "TITLE" --body "BODY" --dry-run
+"""
+
+import argparse
+import json
+import sys
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def load_config(path: Path) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def post_to_reddit(config: dict, title: str, body: str, dry_run: bool) -> list[dict]:
+    import praw
+
+    rc = config.get("reddit", {})
+    reddit = praw.Reddit(
+        client_id=rc["client_id"],
+        client_secret=rc["client_secret"],
+        refresh_token=rc["refresh_token"],
+        user_agent=rc.get("user_agent", "rustrak-announce/1.0"),
+    )
+
+    results = []
+    for sub_name in rc.get("subreddits", []):
+        if dry_run:
+            results.append({
+                "subreddit": sub_name,
+                "status": "dry_run",
+                "url": f"https://reddit.com/r/{sub_name} (not posted)",
+            })
+            continue
+        try:
+            sub = reddit.subreddit(sub_name)
+            submission = sub.submit(title=title, selftext=body)
+            results.append({
+                "subreddit": sub_name,
+                "status": "posted",
+                "url": submission.url,
+                "id": submission.id,
+            })
+        except Exception as exc:
+            results.append({
+                "subreddit": sub_name,
+                "status": "error",
+                "error": str(exc),
+            })
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--config", required=True, help="Path to announce.config.toml")
+    parser.add_argument("--title", required=True, help="Post title")
+
+    body_group = parser.add_mutually_exclusive_group(required=True)
+    body_group.add_argument("--body", help="Post body (markdown string)")
+    body_group.add_argument("--body-file", help="Path to file containing post body")
+
+    parser.add_argument("--dry-run", action="store_true", help="Simulate without posting")
+    parser.add_argument("-o", "--output", help="Output file (default: stdout)")
+    parser.add_argument("--verbose", action="store_true", help="Print diagnostics to stderr")
+    args = parser.parse_args()
+
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(json.dumps({
+            "script": "post_to_reddit",
+            "status": "fail",
+            "error": f"Config not found: {config_path}",
+        }))
+        sys.exit(1)
+
+    config = load_config(config_path)
+
+    body = args.body if args.body else Path(args.body_file).read_text(encoding="utf-8")
+
+    if args.verbose:
+        print(f"[reddit] Config loaded from {config_path}", file=sys.stderr)
+        if args.dry_run:
+            print("[reddit] DRY RUN — no posts will be submitted", file=sys.stderr)
+
+    posts = post_to_reddit(config, args.title, body, dry_run=args.dry_run)
+
+    findings = [
+        {
+            "severity": "high",
+            "category": "consistency",
+            "location": {"file": "reddit", "line": 0},
+            "issue": f"Failed to post to r/{p['subreddit']}: {p.get('error')}",
+            "fix": "Check credentials and subreddit posting permissions",
+        }
+        for p in posts
+        if p.get("status") == "error"
+    ]
+
+    status = "fail" if findings else "pass"
+
+    result = {
+        "script": "post_to_reddit",
+        "version": "1.0.0",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "dry_run": args.dry_run,
+        "posts": posts,
+        "findings": findings,
+        "summary": {
+            "total": len(findings),
+            "critical": 0,
+            "high": len(findings),
+            "medium": 0,
+            "low": 0,
+        },
+    }
+
+    output = json.dumps(result, indent=2, ensure_ascii=False)
+
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+    else:
+        print(output)
+
+    sys.exit(0 if status == "pass" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/rustrak-release-announce/scripts/render_release_card.py
+++ b/.claude/skills/rustrak-release-announce/scripts/render_release_card.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "playwright>=1.40",
+# ]
+# ///
+"""
+Renders a Rustrak release card as a 1200×630 PNG using Playwright + HTML template.
+Downloads Chromium automatically on first run (~150MB, one-time).
+
+Usage:
+  uv run render_release_card.py --version 0.2.1 --output /path/to/card.png
+  uv run render_release_card.py --version 0.2.1 --output card.png --skill-root /path/to/skill
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def ensure_browser(verbose: bool = False) -> None:
+    """Install Playwright's Chromium on first use. Idempotent — fast if already installed."""
+    if verbose:
+        print("[render] Ensuring Chromium is available...", file=sys.stderr)
+    subprocess.run(
+        [sys.executable, "-m", "playwright", "install", "chromium"],
+        capture_output=not verbose,
+        check=False,
+    )
+
+
+def render(version: str, template: Path, output: Path, verbose: bool = False) -> None:
+    from playwright.sync_api import sync_playwright
+
+    html = template.read_text(encoding="utf-8").replace("{{VERSION}}", version)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    tmp = output.parent / ".release-card-temp.html"
+    tmp.write_text(html, encoding="utf-8")
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context(
+                viewport={"width": 1200, "height": 630},
+                device_scale_factor=2,
+            )
+            page = context.new_page()
+            page.goto(f"file://{tmp.resolve()}", wait_until="networkidle")
+            page.screenshot(
+                path=str(output),
+                clip={"x": 0, "y": 0, "width": 1200, "height": 630},
+            )
+            browser.close()
+    finally:
+        tmp.unlink(missing_ok=True)
+
+    if verbose:
+        print(f"[render] Saved {output}  (2400×1260px @2x)", file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--version",    required=True, help="Release version (e.g. 0.2.1)")
+    parser.add_argument("--output",     required=True, help="Output PNG path")
+    parser.add_argument("--skill-root", default=None,  help="Skill root dir (default: two levels up from script)")
+    parser.add_argument("--verbose",    action="store_true")
+    args = parser.parse_args()
+
+    skill_root = Path(args.skill_root) if args.skill_root else Path(__file__).parent.parent
+    template   = skill_root / "assets" / "release-card.html"
+    output     = Path(args.output)
+    status, error = "pass", None
+
+    ensure_browser(verbose=args.verbose)
+
+    try:
+        render(args.version, template, output, verbose=args.verbose)
+    except Exception as exc:
+        import traceback
+        status, error = "fail", str(exc)
+        traceback.print_exc(file=sys.stderr)
+
+    result = {
+        "script":    "render_release_card",
+        "version":   "1.0.0",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "status":    status,
+        "output":    str(output) if status == "pass" else None,
+        "findings":  [] if status == "pass" else [{
+            "severity": "critical", "category": "structure",
+            "location": {"file": "render", "line": 0},
+            "issue":    error,
+            "fix":      "Run: uv run --with playwright playwright install chromium",
+        }],
+        "summary": {
+            "total":    0 if status == "pass" else 1,
+            "critical": 0 if status == "pass" else 1,
+            "high": 0, "medium": 0, "low": 0,
+        },
+    }
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    sys.exit(0 if status == "pass" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/rustrak-release-announce/scripts/render_release_card.py
+++ b/.claude/skills/rustrak-release-announce/scripts/render_release_card.py
@@ -26,11 +26,13 @@ def ensure_browser(verbose: bool = False) -> None:
     """Install Playwright's Chromium on first use. Idempotent — fast if already installed."""
     if verbose:
         print("[render] Ensuring Chromium is available...", file=sys.stderr)
-    subprocess.run(
+    result = subprocess.run(
         [sys.executable, "-m", "playwright", "install", "chromium"],
         capture_output=not verbose,
         check=False,
     )
+    if result.returncode != 0 and not verbose:
+        print("[render] Warning: playwright install chromium failed; browser may be missing.", file=sys.stderr)
 
 
 def render(version: str, template: Path, output: Path, verbose: bool = False) -> None:
@@ -87,6 +89,16 @@ def main() -> None:
         status, error = "fail", str(exc)
         traceback.print_exc(file=sys.stderr)
 
+    err_lower = (error or "").lower()
+    if "executable" in err_lower or "playwright" in err_lower or "chromium" in err_lower:
+        fix_hint = "Run: uv run --with playwright playwright install chromium"
+    elif "no such file" in err_lower or "not found" in err_lower:
+        fix_hint = f"Verify the HTML template exists at {template}"
+    elif "permission" in err_lower:
+        fix_hint = f"Check write permissions for {output}"
+    else:
+        fix_hint = "See traceback above for details."
+
     result = {
         "script":    "render_release_card",
         "version":   "1.0.0",
@@ -97,7 +109,7 @@ def main() -> None:
             "severity": "critical", "category": "structure",
             "location": {"file": "render", "line": 0},
             "issue":    error,
-            "fix":      "Run: uv run --with playwright playwright install chromium",
+            "fix":      fix_hint,
         }],
         "summary": {
             "total":    0 if status == "pass" else 1,

--- a/.claude/skills/rustrak-release-announce/scripts/tests/test_gather_release_data.py
+++ b/.claude/skills/rustrak-release-announce/scripts/tests/test_gather_release_data.py
@@ -1,0 +1,116 @@
+"""Tests for gather_release_data.py"""
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from gather_release_data import parse_changelog, main as gather_main
+
+
+SAMPLE_CHANGELOG = """# @rustrak/server
+
+## 0.3.0
+
+### Minor Changes
+
+- SQLite is now the default database backend
+
+### Patch Changes
+
+- Upgrade all dependencies to latest versions
+
+## 0.2.0
+
+### Minor Changes
+
+- Initial release
+"""
+
+SAMPLE_CHANGELOG_WITH_PR_LINKS = """# @rustrak/client
+
+## 1.0.0
+
+### Major Changes
+
+- [#44](https://github.com/AbianS/rustrak/pull/44) [`4a84415`](https://github.com/AbianS/rustrak/commit/4a84415) Thanks [@AbianS](https://github.com/AbianS)! - Added full TypeScript client
+"""
+
+
+def _write_changelog(tmp: Path, content: str) -> Path:
+    path = tmp / "CHANGELOG.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_parse_basic_changelog(tmp_path):
+    path = _write_changelog(tmp_path, SAMPLE_CHANGELOG)
+    result = parse_changelog(path)
+
+    assert result is not None
+    assert result["package"] == "@rustrak/server"
+    assert result["version"] == "0.3.0"
+    assert "Minor Changes" in result["changes"]
+    assert "SQLite is now the default database backend" in result["changes"]["Minor Changes"]
+    assert "Patch Changes" in result["changes"]
+
+
+def test_parse_only_latest_version(tmp_path):
+    path = _write_changelog(tmp_path, SAMPLE_CHANGELOG)
+    result = parse_changelog(path)
+    # Should only return the first (latest) version
+    assert result["version"] == "0.3.0"
+    # The 0.2.0 "Initial release" change should NOT be in the result
+    for items in result["changes"].values():
+        assert "Initial release" not in items
+
+
+def test_parse_strips_pr_links(tmp_path):
+    path = _write_changelog(tmp_path, SAMPLE_CHANGELOG_WITH_PR_LINKS)
+    result = parse_changelog(path)
+    assert result is not None
+    assert result["version"] == "1.0.0"
+    changes = result["changes"].get("Major Changes", [])
+    assert len(changes) == 1
+    assert "Added full TypeScript client" in changes[0]
+    assert "github.com" not in changes[0]
+    assert "Thanks" not in changes[0]
+
+
+def test_parse_missing_file(tmp_path):
+    result = parse_changelog(tmp_path / "nonexistent.md")
+    assert result is None
+
+
+def test_parse_empty_changelog(tmp_path):
+    path = _write_changelog(tmp_path, "# @rustrak/empty\n\nNo releases yet.\n")
+    result = parse_changelog(path)
+    assert result is None
+
+
+def test_main_with_mock_project(tmp_path):
+    """Integration test: main() with a mock project structure."""
+    # Create mock directory structure
+    (tmp_path / "apps" / "server").mkdir(parents=True)
+    (tmp_path / "apps" / "webview-ui").mkdir(parents=True)
+    (tmp_path / "apps" / "docs").mkdir(parents=True)
+    (tmp_path / "packages" / "client").mkdir(parents=True)
+
+    (tmp_path / "apps" / "server" / "CHANGELOG.md").write_text(SAMPLE_CHANGELOG)
+
+    output_file = tmp_path / "output.json"
+
+    sys.argv = ["gather_release_data.py", str(tmp_path), "-o", str(output_file)]
+    try:
+        gather_main()
+    except SystemExit as e:
+        assert e.code in (0, 1)  # 1 because other changelogs are missing (medium findings)
+
+    result = json.loads(output_file.read_text())
+    assert result["release"]["version"] == "0.3.0"
+    assert result["release"]["aggregated_changes"].get("Minor Changes")
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,8 @@ yarn-error.log*
 .DS_Store
 *.pem
 
+# Reddit API credentials for the release-announce skill
+.announce.config.toml
+
 # Generated release card images
 release-cards/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+
+# Generated release card images
+release-cards/

--- a/README.md
+++ b/README.md
@@ -259,10 +259,10 @@ The docs site copies the spec automatically at build time — `apps/docs/public/
 
 Full documentation is available at **[docs](https://abians.github.io/rustrak/)**
 
-- [Getting Started](https://rustrak.dev/getting-started)
-- [Configuration](https://rustrak.dev/configuration)
-- [API Reference](https://rustrak.dev/api)
-- [Self-Hosting Guide](https://rustrak.dev/self-hosting)
+- [Getting Started](https://abians.github.io/rustrak/getting-started)
+- [Configuration](https://abians.github.io/rustrak/configuration)
+- [API Reference](https://abians.github.io/rustrak/api)
+- [Self-Hosting Guide](https://abians.github.io/rustrak/self-hosting)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/rustrak-release-announce` — a 5-stage BMad workflow skill to automate Reddit release announcements
- Generates a branded release card image (Geist/Geist Mono fonts, dark minimal design) via Playwright
- Workflow: gather changelog data → draft copy → render image → preview & approve → publish to Reddit
- Fixes README doc links (`rustrak.dev` → `abians.github.io/rustrak`)
- Adds `release-cards/` to root `.gitignore`

## Test plan

- [ ] Run `/release-announce` in Claude Code to trigger the skill
- [ ] Verify `render_release_card.py` produces a crisp @2x PNG in `release-cards/`
- [ ] Fill in `.announce.config.toml` credentials and verify Reddit posting (Stage 5)
- [ ] Confirm `.announce.config.toml` is gitignored inside the skill folder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive release-announcement workflow: gather release data, draft Reddit copy, generate branded release-card image, preview for approval, and publish to configured subreddits.
  * Included CLI utilities to parse changelogs, render release images, and post announcements.

* **Documentation**
  * Added step-by-step docs for the 5-stage workflow and Reddit API setup; updated README links.

* **Tests**
  * Added tests covering changelog parsing and end-to-end data gathering.

* **Chores**
  * Added config example and updated ignores for generated artifacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbianS/rustrak/pull/56)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->