### PR TITLE
fix(security): address 6 server vulnerabilities (H-1, H-2, H-3, H-4, M-1, M-2)

### DIFF
--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -61,14 +61,28 @@ impl ResponseError for AppError {
             AppError::Conflict(_) => "Conflict",
             AppError::Unauthorized(_) => "Unauthorized",
             AppError::PayloadTooLarge(_) => "PayloadTooLarge",
-            AppError::Database(_) => "DatabaseError",
+            AppError::Database(_) => "InternalError",
             AppError::Internal(_) => "InternalError",
+        };
+
+        // Database and Internal errors must never expose internal details to clients.
+        // Log the full error server-side and return a safe generic message.
+        let message = match self {
+            AppError::Database(e) => {
+                log::error!("Database error: {:?}", e);
+                "An internal error occurred".to_string()
+            }
+            AppError::Internal(msg) => {
+                log::error!("Internal error: {}", msg);
+                "An internal error occurred".to_string()
+            }
+            other => other.to_string(),
         };
 
         let response = ErrorResponse {
             error: ErrorDetail {
                 error_type: error_type.to_string(),
-                message: self.to_string(),
+                message,
             },
         };
 

--- a/apps/server/src/models/user.rs
+++ b/apps/server/src/models/user.rs
@@ -8,6 +8,12 @@ use sqlx::FromRow;
 
 use crate::error::AppError;
 
+// Pre-computed Argon2id hash of a dummy password used to equalize timing
+// when the requested email doesn't exist (H-1: timing oracle prevention).
+// The specific hash value doesn't matter — it's never used to grant access.
+const DUMMY_PASSWORD_HASH: &str =
+    "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHRzb21lc2FsdA$3K5rjsHVK+G7t2t7ZkxjkE6iuHQYCbGfn1y/jNF0dSE";
+
 #[derive(Debug, Clone, FromRow, Serialize)]
 pub struct User {
     pub id: i32,
@@ -52,5 +58,14 @@ impl User {
         Ok(Argon2::default()
             .verify_password(password.as_bytes(), &parsed_hash)
             .is_ok())
+    }
+
+    /// Run Argon2 verification against a dummy hash to equalize timing when the
+    /// requested user does not exist. Always returns false — never grants access.
+    pub fn run_dummy_password_verify(password: &str) -> bool {
+        if let Ok(parsed) = PasswordHash::new(DUMMY_PASSWORD_HASH) {
+            let _ = Argon2::default().verify_password(password.as_bytes(), &parsed);
+        }
+        false
     }
 }

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -99,15 +99,27 @@ pub async fn register(
         return Err(AppError::Validation("Invalid email format".to_string()));
     }
 
-    // Validate password is provided
+    // Validate password
     if req.password.is_empty() {
         return Err(AppError::Validation("Password is required".to_string()));
+    }
+    if req.password.len() < 8 {
+        return Err(AppError::Validation(
+            "Password must be at least 8 characters".to_string(),
+        ));
+    }
+    if req.password.len() > 1024 {
+        return Err(AppError::Validation(
+            "Password must not exceed 1024 characters".to_string(),
+        ));
     }
 
     // Create user (non-admin by default)
     let user = UsersService::create_user(pool.get_ref(), &req, false).await?;
 
-    // Set session
+    // Clear pre-existing data and renew session token on auth (M-2: session fixation prevention)
+    session.clear();
+    session.renew();
     auth::set_user_session(&session, user.id)?;
 
     Ok(HttpResponse::Created().json(AuthResponse { user: user.into() }))
@@ -131,10 +143,21 @@ pub async fn login(
     session: Session,
     req: web::Json<LoginRequest>,
 ) -> AppResult<impl Responder> {
-    // Get user by email
-    let user = UsersService::get_by_email(pool.get_ref(), &req.email)
-        .await?
-        .ok_or_else(|| AppError::Unauthorized("Invalid credentials".to_string()))?;
+    // Reject oversized passwords before any DB or Argon2 work
+    if req.password.len() > 1024 {
+        return Err(AppError::Validation(
+            "Password must not exceed 1024 characters".to_string(),
+        ));
+    }
+
+    // Get user by email; run dummy hash verify when not found to prevent timing oracle (H-1)
+    let user = match UsersService::get_by_email(pool.get_ref(), &req.email).await? {
+        Some(u) => u,
+        None => {
+            User::run_dummy_password_verify(&req.password);
+            return Err(AppError::Unauthorized("Invalid credentials".to_string()));
+        }
+    };
 
     // Check if user is active
     if !user.is_active {
@@ -149,7 +172,9 @@ pub async fn login(
     // Update last login
     UsersService::update_last_login(pool.get_ref(), user.id).await?;
 
-    // Set session
+    // Clear pre-existing data and renew session token on auth (M-2: session fixation prevention)
+    session.clear();
+    session.renew();
     auth::set_user_session(&session, user.id)?;
 
     Ok(HttpResponse::Ok().json(AuthResponse { user: user.into() }))

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -1,6 +1,7 @@
 use actix_web::{web, HttpRequest, HttpResponse};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use chrono::Utc;
+use futures_util::StreamExt as _;
 
 use crate::auth::SentryAuth;
 use crate::config::Config;
@@ -12,6 +13,9 @@ use crate::ingest::{
     EventMetadata,
 };
 use crate::services::RateLimitService;
+
+/// Maximum raw HTTP body the ingest endpoint accepts (100MB, matches decompress limit)
+pub const MAX_INGEST_PAYLOAD_BYTES: usize = 100 * 1024 * 1024;
 
 /// Response for successful ingestion
 #[derive(serde::Serialize)]
@@ -26,8 +30,24 @@ pub async fn ingest_envelope(
     config: web::Data<Config>,
     req: HttpRequest,
     auth: SentryAuth,
-    body: Bytes,
+    mut payload: web::Payload,
 ) -> AppResult<HttpResponse> {
+    // Collect body with explicit size limit so we control the error format (413 JSON)
+    let body: Bytes = {
+        let mut buf = BytesMut::new();
+        while let Some(chunk) = payload.next().await {
+            let chunk =
+                chunk.map_err(|e| AppError::Internal(format!("Payload read error: {e}")))?;
+            if buf.len() + chunk.len() > MAX_INGEST_PAYLOAD_BYTES {
+                return Err(AppError::PayloadTooLarge(
+                    "Payload exceeds maximum size".to_string(),
+                ));
+            }
+            buf.extend_from_slice(&chunk);
+        }
+        buf.freeze()
+    };
+
     // 0. Check rate limits (fail fast before processing)
     if let Some(exceeded) = RateLimitService::check_quota(pool.get_ref(), &auth.project).await? {
         log::warn!(

--- a/apps/server/src/services/notification/webhook.rs
+++ b/apps/server/src/services/notification/webhook.rs
@@ -144,13 +144,184 @@ impl NotificationDispatcher for WebhookNotifier {
             ));
         }
 
+        // Block SSRF: reject private/internal hosts (H-4)
+        if let Some(host) = parsed_url.host() {
+            if is_ssrf_blocked_url_host(&host) {
+                return Err(AppError::Validation(
+                    "Webhook URL must not target internal or private addresses".to_string(),
+                ));
+            }
+        }
+
         Ok(())
     }
+}
+
+/// Returns true if the `url::Host` is a private/internal address that could enable SSRF.
+fn is_ssrf_blocked_url_host(host: &url::Host<&str>) -> bool {
+    match host {
+        url::Host::Ipv4(ip) => is_private_ipv4(*ip),
+        url::Host::Ipv6(ip) => is_private_ipv6(*ip),
+        url::Host::Domain(name) => is_blocked_hostname(name),
+    }
+}
+
+fn is_blocked_hostname(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower == "localhost"
+        || lower == "ip6-localhost"
+        || lower == "ip6-loopback"
+        || lower.ends_with(".local")
+        || lower.ends_with(".internal")
+}
+
+fn is_private_ip(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => is_private_ipv4(v4),
+        std::net::IpAddr::V6(v6) => is_private_ipv6(v6),
+    }
+}
+
+fn is_private_ipv4(ip: std::net::Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    // 127.0.0.0/8 — loopback
+    if octets[0] == 127 {
+        return true;
+    }
+    // 0.0.0.0/8
+    if octets[0] == 0 {
+        return true;
+    }
+    // 10.0.0.0/8 — private class A
+    if octets[0] == 10 {
+        return true;
+    }
+    // 172.16.0.0/12 — private class B (172.16.x.x – 172.31.x.x)
+    if octets[0] == 172 && (16..=31).contains(&octets[1]) {
+        return true;
+    }
+    // 192.168.0.0/16 — private class C
+    if octets[0] == 192 && octets[1] == 168 {
+        return true;
+    }
+    // 169.254.0.0/16 — link-local (AWS/GCP metadata endpoint)
+    if octets[0] == 169 && octets[1] == 254 {
+        return true;
+    }
+    false
+}
+
+fn is_private_ipv6(ip: std::net::Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    // ::1 — loopback
+    if ip == std::net::Ipv6Addr::LOCALHOST {
+        return true;
+    }
+    // fc00::/7 — unique local (fc00:: – fdff::)
+    if segments[0] & 0xFE00 == 0xFC00 {
+        return true;
+    }
+    // fe80::/10 — link-local
+    if segments[0] & 0xFFC0 == 0xFE80 {
+        return true;
+    }
+    // ::ffff:0:0/96 — IPv4-mapped IPv6 (check the embedded IPv4)
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return is_private_ipv4(v4);
+    }
+    false
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =============================================================================
+    // SSRF Prevention Tests (H-4)
+    // =============================================================================
+
+    fn make_webhook_config(url: &str) -> serde_json::Value {
+        serde_json::json!({"url": url, "secret": null})
+    }
+
+    #[test]
+    fn test_rejects_loopback_ipv4() {
+        let notifier = WebhookNotifier::new();
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://127.0.0.1/hook"))
+            .is_err());
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://127.1.2.3/hook"))
+            .is_err());
+    }
+
+    #[test]
+    fn test_rejects_localhost_hostname() {
+        let notifier = WebhookNotifier::new();
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://localhost/hook"))
+            .is_err());
+        assert!(notifier
+            .validate_config(&make_webhook_config("https://LOCALHOST/hook"))
+            .is_err());
+    }
+
+    #[test]
+    fn test_rejects_rfc1918_addresses() {
+        let notifier = WebhookNotifier::new();
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://10.0.0.1/hook"))
+            .is_err());
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://10.255.255.255/hook"))
+            .is_err());
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://172.16.0.1/hook"))
+            .is_err());
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://172.31.255.255/hook"))
+            .is_err());
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://192.168.0.1/hook"))
+            .is_err());
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://192.168.255.255/hook"))
+            .is_err());
+    }
+
+    #[test]
+    fn test_rejects_aws_metadata_ip() {
+        let notifier = WebhookNotifier::new();
+        assert!(notifier
+            .validate_config(&make_webhook_config(
+                "http://169.254.169.254/latest/meta-data/"
+            ))
+            .is_err());
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://169.254.0.1/"))
+            .is_err());
+    }
+
+    #[test]
+    fn test_rejects_ipv6_loopback() {
+        let notifier = WebhookNotifier::new();
+        assert!(notifier
+            .validate_config(&make_webhook_config("http://[::1]/hook"))
+            .is_err());
+    }
+
+    #[test]
+    fn test_accepts_public_urls() {
+        let notifier = WebhookNotifier::new();
+        assert!(notifier
+            .validate_config(&make_webhook_config("https://hooks.example.com/webhook"))
+            .is_ok());
+        assert!(notifier
+            .validate_config(&make_webhook_config(
+                "https://discord.com/api/webhooks/123/abc"
+            ))
+            .is_ok());
+    }
 
     #[test]
     fn test_generate_signature() {

--- a/apps/server/tests/integration/auth_test.rs
+++ b/apps/server/tests/integration/auth_test.rs
@@ -1002,3 +1002,244 @@ async fn test_logout_invalidates_session() {
     let me_resp2 = test::call_service(&app, me_req2).await;
     assert_eq!(me_resp2.status(), 401);
 }
+
+// =============================================================================
+// Password Length Validation Tests (H-2 / M-3)
+// =============================================================================
+
+#[actix_web::test]
+async fn test_register_rejects_password_shorter_than_8_chars() {
+    let db = TestDb::new().await;
+    let session_key = Key::from(&[0u8; 64]);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(web::Data::new(create_test_config()))
+            .wrap(
+                SessionMiddleware::builder(CookieSessionStore::default(), session_key)
+                    .cookie_secure(false)
+                    .build(),
+            )
+            .configure(routes::auth::configure),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/auth/register")
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(json!({ "email": "user@example.com", "password": "short" }))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 400);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["error"]["type"], "ValidationError");
+}
+
+#[actix_web::test]
+async fn test_register_rejects_password_longer_than_1024_chars() {
+    let db = TestDb::new().await;
+    let session_key = Key::from(&[0u8; 64]);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(web::Data::new(create_test_config()))
+            .wrap(
+                SessionMiddleware::builder(CookieSessionStore::default(), session_key)
+                    .cookie_secure(false)
+                    .build(),
+            )
+            .configure(routes::auth::configure),
+    )
+    .await;
+
+    let long_password = "a".repeat(1025);
+    let req = test::TestRequest::post()
+        .uri("/auth/register")
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(json!({ "email": "user@example.com", "password": long_password }))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 400);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["error"]["type"], "ValidationError");
+}
+
+#[actix_web::test]
+async fn test_register_accepts_password_at_exact_boundaries() {
+    let db = TestDb::new().await;
+    let session_key = Key::from(&[0u8; 64]);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(web::Data::new(create_test_config()))
+            .wrap(
+                SessionMiddleware::builder(CookieSessionStore::default(), session_key)
+                    .cookie_secure(false)
+                    .build(),
+            )
+            .configure(routes::auth::configure),
+    )
+    .await;
+
+    // Exactly 8 chars — must be accepted
+    let req = test::TestRequest::post()
+        .uri("/auth/register")
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(json!({ "email": "user@example.com", "password": "exactly8" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201, "8-char password should be accepted");
+
+    // Exactly 1024 chars — must be accepted
+    let max_password = "b".repeat(1024);
+    let req2 = test::TestRequest::post()
+        .uri("/auth/register")
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(json!({ "email": "user2@example.com", "password": max_password }))
+        .to_request();
+    let resp2 = test::call_service(&app, req2).await;
+    assert_eq!(resp2.status(), 201, "1024-char password should be accepted");
+}
+
+#[actix_web::test]
+async fn test_login_rejects_password_longer_than_1024_chars() {
+    let db = TestDb::new().await;
+    let session_key = Key::from(&[0u8; 64]);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(web::Data::new(create_test_config()))
+            .wrap(
+                SessionMiddleware::builder(CookieSessionStore::default(), session_key)
+                    .cookie_secure(false)
+                    .build(),
+            )
+            .configure(routes::auth::configure),
+    )
+    .await;
+
+    // Register a valid user first
+    let reg_req = test::TestRequest::post()
+        .uri("/auth/register")
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(json!({ "email": "user@example.com", "password": "validpassword123" }))
+        .to_request();
+    let reg_resp = test::call_service(&app, reg_req).await;
+    assert_eq!(reg_resp.status(), 201);
+
+    // Login with oversized password — must reject before running Argon2
+    let long_password = "a".repeat(1025);
+    let req = test::TestRequest::post()
+        .uri("/auth/login")
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(json!({ "email": "user@example.com", "password": long_password }))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 400);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["error"]["type"], "ValidationError");
+}
+
+// =============================================================================
+// Session Fixation Prevention Tests (M-2)
+// =============================================================================
+
+#[actix_web::test]
+async fn test_login_clears_pre_existing_session_data() {
+    use actix_session::Session;
+    use actix_web::HttpResponse;
+
+    let db = TestDb::new().await;
+    let config = create_test_config();
+    let session_key = Key::from(&[0u8; 64]);
+
+    create_test_user(&db.pool, "sessfix@example.com", "password123", false).await;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(web::Data::new(config))
+            .wrap(
+                SessionMiddleware::builder(CookieSessionStore::default(), session_key.clone())
+                    .cookie_name("rustrak_session".to_string())
+                    .cookie_secure(false)
+                    .build(),
+            )
+            .configure(routes::auth::configure)
+            .route(
+                "/test/plant-marker",
+                web::post().to(|session: Session| async move {
+                    session.insert("attack_marker", "planted").unwrap();
+                    HttpResponse::Ok().finish()
+                }),
+            )
+            .route(
+                "/test/read-marker",
+                web::get().to(|session: Session| async move {
+                    match session.get::<String>("attack_marker").unwrap_or(None) {
+                        Some(v) => HttpResponse::Ok().body(v),
+                        None => HttpResponse::NotFound().finish(),
+                    }
+                }),
+            ),
+    )
+    .await;
+
+    // Step 1: Plant attacker-controlled data in session (simulates session fixation setup)
+    let plant_req = test::TestRequest::post()
+        .uri("/test/plant-marker")
+        .to_request();
+    let plant_resp = test::call_service(&app, plant_req).await;
+    assert_eq!(plant_resp.status(), 200);
+
+    let session_cookie = plant_resp
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_string();
+
+    // Step 2: Login using the planted session cookie
+    let login_req = test::TestRequest::post()
+        .uri("/auth/login")
+        .insert_header(("Content-Type", "application/json"))
+        .insert_header(("Cookie", session_cookie.clone()))
+        .set_json(json!({
+            "email": "sessfix@example.com",
+            "password": "password123"
+        }))
+        .to_request();
+    let login_resp = test::call_service(&app, login_req).await;
+    assert_eq!(login_resp.status(), 200);
+
+    let new_session_cookie = login_resp
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_string();
+
+    // Step 3: The planted marker must not be readable in the post-login session
+    let read_req = test::TestRequest::get()
+        .uri("/test/read-marker")
+        .insert_header(("Cookie", new_session_cookie))
+        .to_request();
+    let read_resp = test::call_service(&app, read_req).await;
+
+    assert_eq!(
+        read_resp.status(),
+        404,
+        "Session fixation: pre-login session data must be cleared on successful login"
+    );
+}

--- a/apps/server/tests/integration/ingest_test.rs
+++ b/apps/server/tests/integration/ingest_test.rs
@@ -558,3 +558,51 @@ async fn test_store_endpoint_deprecated() {
     // Should return 400 because store is deprecated
     assert_eq!(resp.status(), 400);
 }
+
+// =============================================================================
+// Payload Size Tests (M-1)
+// =============================================================================
+
+#[actix_web::test]
+async fn test_ingest_oversized_body_returns_413_json() {
+    let db = TestDb::new().await;
+    let (project_id, sentry_key) = create_test_project(&db.pool, "Payload Limit Project").await;
+    let config = create_test_config();
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(web::Data::new(config))
+            .configure(routes::ingest::configure),
+    )
+    .await;
+
+    // 300KB plain body — exceeds actix-web default 256KB Bytes extractor limit
+    let large_body = vec![b'x'; 300 * 1024];
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/api/{}/envelope/", project_id))
+        .insert_header((
+            "X-Sentry-Auth",
+            format!("Sentry sentry_key={}, sentry_version=7", sentry_key),
+        ))
+        .set_payload(large_body)
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        413,
+        "Oversized body must return 413, not {}",
+        resp.status()
+    );
+
+    let body = test::read_body(resp).await;
+    let body_str = std::str::from_utf8(&body).unwrap();
+    let json: Value = serde_json::from_str(body_str)
+        .expect(&format!("413 response must be JSON, got: {body_str}"));
+    assert_eq!(
+        json["error"]["type"], "PayloadTooLarge",
+        "Error type must be PayloadTooLarge: {body_str}"
+    );
+}

--- a/apps/server/tests/unit/error_test.rs
+++ b/apps/server/tests/unit/error_test.rs
@@ -1,0 +1,62 @@
+//! Unit tests for AppError HTTP response behavior.
+//!
+//! Verifies that internal error details are never leaked to HTTP clients.
+
+use actix_web::ResponseError;
+use rustrak::error::AppError;
+
+async fn body_string(resp: actix_web::HttpResponse) -> String {
+    let bytes = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+// =============================================================================
+// Error Leakage Tests (H-3)
+// =============================================================================
+
+#[actix_web::test]
+async fn test_database_error_does_not_leak_internal_details() {
+    let app_err = AppError::Database(sqlx::Error::RowNotFound);
+    let body = body_string(app_err.error_response()).await;
+
+    assert!(
+        !body.contains("Database error:"),
+        "Database error prefix leaked: {body}"
+    );
+    assert!(
+        !body.contains("RowNotFound"),
+        "sqlx error variant leaked: {body}"
+    );
+    assert!(
+        body.to_lowercase().contains("internal"),
+        "Expected generic internal error message, got: {body}"
+    );
+}
+
+#[actix_web::test]
+async fn test_internal_error_does_not_leak_internal_details() {
+    let app_err = AppError::Internal(
+        "Failed to create user: duplicate key value violates unique constraint".to_string(),
+    );
+    let body = body_string(app_err.error_response()).await;
+
+    assert!(
+        !body.contains("duplicate key"),
+        "Internal error detail leaked: {body}"
+    );
+    assert!(
+        !body.contains("unique constraint"),
+        "DB constraint name leaked: {body}"
+    );
+}
+
+#[actix_web::test]
+async fn test_validation_error_message_is_preserved() {
+    let app_err = AppError::Validation("Password must be at least 8 characters".to_string());
+    let body = body_string(app_err.error_response()).await;
+
+    assert!(
+        body.contains("Password must be at least 8 characters"),
+        "Validation message should be preserved: {body}"
+    );
+}

--- a/apps/server/tests/unit/mod.rs
+++ b/apps/server/tests/unit/mod.rs
@@ -6,5 +6,7 @@ mod auth_test;
 mod config_test;
 mod decompression_test;
 mod envelope_parser_test;
+mod error_test;
 mod grouping_test;
 mod notification_test;
+mod user_test;

--- a/apps/server/tests/unit/user_test.rs
+++ b/apps/server/tests/unit/user_test.rs
@@ -1,0 +1,24 @@
+//! Unit tests for User model security properties (H-1: timing oracle)
+
+use rustrak::models::User;
+
+// =============================================================================
+// Timing Oracle Prevention Tests (H-1)
+// =============================================================================
+
+#[test]
+fn test_dummy_password_verify_always_returns_false() {
+    // Must never grant access — runs Argon2 to equalize timing with real verify
+    assert!(!User::run_dummy_password_verify("anypassword"));
+}
+
+#[test]
+fn test_dummy_password_verify_with_empty_password() {
+    assert!(!User::run_dummy_password_verify(""));
+}
+
+#[test]
+fn test_dummy_password_verify_with_long_password() {
+    let long_password = "a".repeat(1024);
+    assert!(!User::run_dummy_password_verify(&long_password));
+}


### PR DESCRIPTION
## Summary

Security audit of `apps/server/src/` found 4 HIGH and 4 MEDIUM issues. This PR fixes 6 of them using TDD (failing test written before each fix).

- **H-1 (timing oracle)** — `User::run_dummy_password_verify()` runs Argon2 against a dummy hash when login email doesn't exist, equalizing response time with the wrong-password path
- **H-2/M-3 (password length DoS)** — register enforces 8–1024 char limits; login rejects >1024 before any DB or Argon2 work
- **H-3 (internal error leakage)** — `AppError::Database` and `AppError::Internal` now log full detail server-side and return a generic `"An internal error occurred"` to clients
- **H-4 (SSRF via webhook URLs)** — `validate_config` blocks loopback, RFC1918, link-local (169.254.x.x), and dangerous hostnames (`localhost`, `*.local`, `*.internal`)
- **M-1 (wrong status on oversized body)** — ingest endpoint collects `Payload` manually with a 100MB cap, returning `AppError::PayloadTooLarge` (413 JSON) instead of actix-web's default plain-text response
- **M-2 (session fixation)** — `session.clear() + session.renew()` called before `set_user_session` on both login and register to regenerate the session token

## Test plan

- [ ] Each fix has a failing test written first (red→green)
- [ ] New test files: `tests/unit/error_test.rs`, `tests/unit/user_test.rs`
- [ ] New tests added to: `tests/integration/auth_test.rs`, `tests/integration/ingest_test.rs`, `src/services/notification/webhook.rs` (inline)
- [ ] `cargo test --no-default-features --features postgres` — 135 unit + 97 integration, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling to prevent exposure of internal system details in API responses.

* **New Features**
  * Added password length requirements (8–1024 characters) for authentication.
  * Implemented 100MB payload size limit for data ingestion requests.
  * Added validation to prevent webhook URLs from targeting private or internal network addresses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbianS/rustrak/pull/57)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->