### PR TITLE
fix(ui): replace pnpm global turbo install with pnpm dlx

### DIFF
--- a/apps/webview-ui/Dockerfile
+++ b/apps/webview-ui/Dockerfile
@@ -13,12 +13,10 @@ RUN apk update && apk add --no-cache libc6-compat
 FROM base AS builder
 WORKDIR /app
 
-RUN pnpm add -g turbo
-
 COPY . .
 
 # Genera workspace aislado (json + package.json de subworkspaces)
-RUN turbo prune webview-ui --docker
+RUN pnpm dlx turbo prune webview-ui --docker
 
 # --------- INSTALLER ---------
 FROM base AS installer


### PR DESCRIPTION
## Summary

- `pnpm add -g turbo` fails on pnpm v9+ because global binaries are written to `$PNPM_HOME/bin` but the Dockerfile only added `$PNPM_HOME` to `PATH`
- Replaced `pnpm add -g turbo` + `turbo prune` with `pnpm dlx turbo prune` — no global install needed, no PATH issue

## Test plan

- [ ] `docker compose -f docker-compose.local.yml up --build` completes without error on the UI build stage
- [ ] UI container starts and is reachable at `http://localhost:3000`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration for the webview-ui application to improve build efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbianS/rustrak/pull/58)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->