### PR TITLE
fix(ingest): raise payload limit to match decompression max (100MB)

### DIFF
--- a/apps/server/src/ingest/mod.rs
+++ b/apps/server/src/ingest/mod.rs
@@ -3,7 +3,7 @@ pub mod envelope;
 pub mod parser;
 pub mod storage;
 
-pub use decompression::{decompress_body, get_content_encoding};
+pub use decompression::{decompress_body, get_content_encoding, MAX_COMPRESSED_SIZE};
 pub use envelope::EventMetadata;
 pub use parser::EnvelopeParser;
 pub use storage::{delete_event, get_ingest_dir, read_event, store_event};

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -9,7 +9,7 @@ use crate::digest;
 use crate::error::{AppError, AppResult};
 use crate::ingest::{
     decompress_body, get_content_encoding, get_ingest_dir, store_event, EnvelopeParser,
-    EventMetadata,
+    EventMetadata, MAX_COMPRESSED_SIZE,
 };
 use crate::services::RateLimitService;
 
@@ -144,6 +144,7 @@ pub async fn options() -> HttpResponse {
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/api/{project_id}")
+            .app_data(web::PayloadConfig::new(MAX_COMPRESSED_SIZE))
             .route("/envelope/", web::post().to(ingest_envelope))
             .route(
                 "/envelope/",

--- a/apps/server/tests/integration/ingest_test.rs
+++ b/apps/server/tests/integration/ingest_test.rs
@@ -528,6 +528,67 @@ async fn test_ingest_response_has_cors_headers() {
 }
 
 // =============================================================================
+// Payload Size Tests
+// =============================================================================
+
+#[actix_web::test]
+async fn test_ingest_large_payload_above_256kb_is_accepted() {
+    let db = TestDb::new().await;
+    let (project_id, sentry_key) = create_test_project(&db.pool, "Large Payload Project").await;
+    let config = create_test_config();
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(web::Data::new(config))
+            .configure(routes::ingest::configure),
+    )
+    .await;
+
+    let event_id = Uuid::new_v4().to_string().replace("-", "");
+    // Build an event whose JSON exceeds actix-web's default 256KB body limit.
+    // Without an explicit PayloadConfig, the framework rejects this before the
+    // handler runs, returning 413 instead of 200.
+    let padding = "x".repeat(300_000);
+    let event_json = json!({
+        "event_id": event_id,
+        "timestamp": 1704801600.0,
+        "level": "error",
+        "platform": "python",
+        "exception": {
+            "values": [{"type": "ValueError", "value": "large stack trace"}]
+        },
+        "_padding": padding
+    })
+    .to_string();
+
+    assert!(
+        event_json.len() > 256 * 1024,
+        "test payload must exceed 256KB, got {} bytes",
+        event_json.len()
+    );
+
+    let envelope = create_envelope(&event_id, &event_json);
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/api/{}/envelope/", project_id))
+        .insert_header((
+            "X-Sentry-Auth",
+            format!("Sentry sentry_key={}, sentry_version=7", sentry_key),
+        ))
+        .insert_header(("Content-Type", "application/x-sentry-envelope"))
+        .set_payload(envelope)
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        200,
+        "payloads above 256KB must be accepted by the ingest endpoint"
+    );
+}
+
+// =============================================================================
 // Legacy Store Endpoint Tests
 // =============================================================================
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Increased maximum payload size limit for event ingestion to support larger event submissions (now accepts payloads exceeding 256KB).

* **Tests**
  * Added integration test to verify large payload handling works correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbianS/rustrak/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->