### PR TITLE
fix(digest): delete temp file when process_event fails

### DIFF
--- a/apps/server/src/digest/worker.rs
+++ b/apps/server/src/digest/worker.rs
@@ -12,8 +12,28 @@ use crate::services::{
     DenormalizedFields, EventService, ProjectService, RateLimitService,
 };
 
-/// Processes an event from temporary storage
+/// Processes an event from temporary storage.
+/// Guarantees the temp file is deleted on both success and failure.
 pub async fn process_event(
+    pool: &DbPool,
+    metadata: &EventMetadata,
+    ingest_dir: &Path,
+    rate_limit_config: &RateLimitConfig,
+) -> AppResult<()> {
+    let result = process_event_impl(pool, metadata, ingest_dir, rate_limit_config).await;
+    if result.is_err() {
+        if let Err(e) = delete_event(ingest_dir, &metadata.event_id).await {
+            log::warn!(
+                "Failed to clean up orphaned event file {}: {:?}",
+                metadata.event_id,
+                e
+            );
+        }
+    }
+    result
+}
+
+async fn process_event_impl(
     pool: &DbPool,
     metadata: &EventMetadata,
     ingest_dir: &Path,

--- a/apps/server/src/ingest/storage.rs
+++ b/apps/server/src/ingest/storage.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 use uuid::Uuid;
@@ -48,8 +49,11 @@ pub async fn read_event(base_dir: &Path, event_id: &str) -> AppResult<Vec<u8>> {
 pub async fn delete_event(base_dir: &Path, event_id: &str) -> AppResult<()> {
     let path = get_event_path(base_dir, event_id)?;
 
-    // Ignore error if the file doesn't exist (may have been processed twice)
-    let _ = fs::remove_file(&path).await;
+    match fs::remove_file(&path).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => log::warn!("Failed to delete event file {:?}: {}", path, e),
+    }
 
     Ok(())
 }

--- a/apps/server/tests/integration/digest_test.rs
+++ b/apps/server/tests/integration/digest_test.rs
@@ -620,6 +620,51 @@ async fn test_digest_updates_project_counters() {
 }
 
 // =============================================================================
+// Temp File Cleanup Tests
+// =============================================================================
+
+#[actix_web::test]
+async fn test_process_event_cleans_up_temp_file_on_failure() {
+    let db = TestDb::new().await;
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let ingest_dir = temp_dir.path();
+    let rate_limit_config = create_rate_limit_config();
+
+    let event_id = Uuid::new_v4().to_string().replace("-", "");
+    let event_json = create_event_json(&event_id);
+    let event_bytes = serde_json::to_vec(&event_json).unwrap();
+
+    store_event(ingest_dir, &event_id, &event_bytes)
+        .await
+        .expect("Failed to store event");
+
+    let event_path = ingest_dir.join(format!("{}.json", event_id));
+    assert!(
+        event_path.exists(),
+        "file must exist before calling process_event"
+    );
+
+    // project_id 99999 does not exist → process_event returns Err immediately
+    let metadata = EventMetadata {
+        event_id: event_id.clone(),
+        project_id: 99999,
+        ingested_at: Utc::now(),
+        remote_addr: None,
+    };
+
+    let result = process_event(&db.pool, &metadata, ingest_dir, &rate_limit_config).await;
+    assert!(
+        result.is_err(),
+        "process_event must fail for non-existent project"
+    );
+
+    assert!(
+        !event_path.exists(),
+        "temp file must be deleted even when process_event fails"
+    );
+}
+
+// =============================================================================
 // Edge Cases
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- `process_event` now guarantees the temp `.json` file is deleted on **both** success and failure. Previously only the happy path called `delete_event`; any error path (missing project, DB failure, etc.) left the file on disk indefinitely.
- `delete_event` tightened to only swallow `NotFound` errors silently — other I/O errors are now logged as `warn` instead of being discarded with `let _ = ...`.

## How it works

The existing body of `process_event` was extracted into a private `process_event_impl`. The public function calls the impl and, if it returns `Err`, calls `delete_event` before propagating the error:

```rust
pub async fn process_event(...) -> AppResult<()> {
    let result = process_event_impl(...).await;
    if result.is_err() {
        if let Err(e) = delete_event(ingest_dir, &metadata.event_id).await {
            log::warn!("Failed to clean up orphaned event file {}: {:?}", ...);
        }
    }
    result
}
```

## What was NOT done (and why)

- **Startup scan to reprocess orphans** — orphaned files lack `project_id` (stored separately from the event JSON), so they can't be reprocessed without changing the storage format.
- **`.processing` marker files** — unnecessary; the existing `EventService::exists` dedup check handles crash-mid-processing safely.

## Test plan

- [x] `test_process_event_cleans_up_temp_file_on_failure` — new test: stores a file, calls `process_event` with a non-existent `project_id`, asserts the file is gone after the error
- [x] All 13 existing digest integration tests pass (happy paths, grouping, dedup, cleanup)

Closes #51