### PR TITLE
fix(projects): retry slug INSERT on unique violation instead of 409

### DIFF
--- a/apps/server/src/services/project.rs
+++ b/apps/server/src/services/project.rs
@@ -127,33 +127,7 @@ impl ProjectService {
         // Generate sentry_key in application (for cross-DB compatibility)
         let sentry_key = uuid::Uuid::new_v4();
 
-        let project = sqlx::query_as::<_, Project>(
-            r#"
-            INSERT INTO projects (name, slug, sentry_key)
-            VALUES ($1, $2, $3)
-            RETURNING id, name, slug, sentry_key, stored_event_count,
-                      digested_event_count, created_at, updated_at,
-                      quota_exceeded_until, quota_exceeded_reason, next_quota_check
-            "#,
-        )
-        .bind(name)
-        .bind(&slug)
-        .bind(sentry_key)
-        .fetch_one(pool)
-        .await
-        .map_err(|e| {
-            if let sqlx::Error::Database(ref db_err) = e {
-                if db_err.is_unique_violation() {
-                    // On PostgreSQL we can distinguish name vs slug via constraint(),
-                    // but for cross-DB compatibility use a generic message
-                    return AppError::Conflict(format!(
-                        "Project with name '{}' or slug '{}' already exists",
-                        name, slug
-                    ));
-                }
-            }
-            AppError::Database(e)
-        })?;
+        let project = Self::try_insert_with_retry(pool, name, &slug, sentry_key).await?;
 
         Ok(project)
     }
@@ -265,6 +239,74 @@ impl ProjectService {
                     "Could not generate unique slug".to_string(),
                 ));
             }
+        }
+    }
+
+    /// Bypass slug generation and directly try INSERT with a pre-computed
+    /// (possibly stale) slug. Used in integration tests to simulate TOCTOU.
+    #[doc(hidden)]
+    pub async fn create_with_stale_slug(
+        pool: &DbPool,
+        name: &str,
+        stale_slug: &str,
+    ) -> AppResult<Project> {
+        let sentry_key = uuid::Uuid::new_v4();
+        Self::try_insert_with_retry(pool, name, stale_slug, sentry_key).await
+    }
+
+    async fn try_insert_with_retry(
+        pool: &DbPool,
+        name: &str,
+        slug: &str,
+        sentry_key: uuid::Uuid,
+    ) -> AppResult<Project> {
+        const INSERT_SQL: &str = r#"
+            INSERT INTO projects (name, slug, sentry_key)
+            VALUES ($1, $2, $3)
+            RETURNING id, name, slug, sentry_key, stored_event_count,
+                      digested_event_count, created_at, updated_at,
+                      quota_exceeded_until, quota_exceeded_reason, next_quota_check
+        "#;
+
+        let result = sqlx::query_as::<_, Project>(INSERT_SQL)
+            .bind(name)
+            .bind(slug)
+            .bind(sentry_key)
+            .fetch_one(pool)
+            .await;
+
+        match result {
+            Ok(p) => Ok(p),
+            Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
+                // The slug may have been taken by a concurrent request (TOCTOU).
+                // Re-query to get the next available slug and retry once.
+                let new_slug = Self::generate_unique_slug(pool, name, None).await?;
+                if new_slug == slug {
+                    // Slug is still available → the collision was on name, not slug.
+                    return Err(AppError::Conflict(format!(
+                        "Project with name '{}' already exists",
+                        name
+                    )));
+                }
+                sqlx::query_as::<_, Project>(INSERT_SQL)
+                    .bind(name)
+                    .bind(&new_slug)
+                    .bind(sentry_key)
+                    .fetch_one(pool)
+                    .await
+                    .map_err(|e| {
+                        if let sqlx::Error::Database(ref db_err) = e {
+                            if db_err.is_unique_violation() {
+                                return AppError::Conflict(format!(
+                                    "Project with name '{}' already exists",
+                                    name
+                                ));
+                            }
+                        }
+                        AppError::Database(e)
+                    })
+            }
+            Err(e) => Err(AppError::Database(e)),
         }
     }
 }

--- a/apps/server/tests/integration/projects_api_test.rs
+++ b/apps/server/tests/integration/projects_api_test.rs
@@ -7,7 +7,9 @@ use crate::common::TestDb;
 use actix_session::{storage::CookieSessionStore, SessionMiddleware};
 use actix_web::{cookie::Key, test, web, App};
 use rustrak::config::{Config, DatabaseConfig, RateLimitConfig};
+use rustrak::models::CreateProject;
 use rustrak::routes;
+use rustrak::services::ProjectService;
 use std::time::Duration;
 
 /// Creates a test config
@@ -150,4 +152,38 @@ async fn test_delete_project_not_found() {
 #[ignore = "Session cookies not preserved in actix test framework - use E2E tests"]
 async fn test_list_projects_with_data() {
     // This test requires proper session cookie handling
+}
+
+// =============================================================================
+// Slug Collision Tests
+// =============================================================================
+
+/// Simulates the TOCTOU race: "My Project" already owns "my-project".
+/// A second request for "My-Project" reads a stale view (no slug taken yet)
+/// and tries to INSERT with slug "my-project" — the same slug.
+/// The expected behavior is a transparent retry yielding "my-project-1",
+/// NOT a 409 Conflict visible to the caller.
+#[actix_web::test]
+async fn test_slug_toctou_retries_with_next_candidate() {
+    let db = TestDb::new().await;
+
+    // Establish "my-project" as taken
+    ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "My Project".to_string(),
+            slug: None,
+        },
+    )
+    .await
+    .expect("first create must succeed");
+
+    // Simulate what happens when generate_unique_slug returned "my-project"
+    // from a stale read (TOCTOU race): the INSERT should retry, not 409.
+    let project = ProjectService::create_with_stale_slug(&db.pool, "My-Project", "my-project")
+        .await
+        .expect("stale-slug create must succeed via retry, not 409");
+
+    assert_eq!(project.slug, "my-project-1");
+    assert_eq!(project.name, "My-Project");
 }


### PR DESCRIPTION
## Summary

- Detects UNIQUE constraint violations on the `slug` column during project creation
- Re-queries for the next available slug candidate and retries the INSERT transparently
- Distinguishes slug collisions from name collisions: name violations still return 409
- Exposes `create_with_stale_slug` test helper to deterministically simulate the TOCTOU race

## Root cause

`generate_unique_slug` reads existing slugs and returns the next free candidate. Between that read and the INSERT, a concurrent request can claim the same slug. The previous code surfaced this as a 409 Conflict to the caller, which is wrong — the slug conflict is an internal race condition, not a user error.

## Fix

`try_insert_with_retry` wraps the INSERT: on a unique violation it re-queries for a fresh candidate. If the new candidate equals the original slug, the violation must be on the `name` column (genuine conflict → 409). Otherwise it retries once with the new slug.

## Test plan

- [x] `test_slug_toctou_retries_with_next_candidate` — creates "my-project", then simulates a stale-slug INSERT for "my-project", asserts result slug is "my-project-1" (not a 409)
- [x] Full integration test suite passes

Closes #50