### PR TITLE
feat(auth): accept Bearer tokens on management API endpoints

### DIFF
--- a/apps/server/src/auth/extractors.rs
+++ b/apps/server/src/auth/extractors.rs
@@ -186,13 +186,21 @@ impl FromRequest for ApiAuth {
         let session_future = AuthenticatedUser::from_request(req, payload);
 
         Box::pin(async move {
-            if bearer_future.await.is_ok() {
-                return Ok(ApiAuth);
+            match bearer_future.await {
+                Ok(_) => return Ok(ApiAuth),
+                Err(AppError::Unauthorized(_)) => {} // auth rejected — fall through to session
+                Err(e) => return Err(e),             // Internal/Database — propagate
             }
             session_future
                 .await
                 .map(|_| ApiAuth)
-                .map_err(|_| AppError::Unauthorized("Not authenticated".to_string()))
+                .map_err(|e| {
+                    if e.as_response_error().status_code().is_server_error() {
+                        AppError::Internal(format!("Session error: {e}"))
+                    } else {
+                        AppError::Unauthorized("Not authenticated".to_string())
+                    }
+                })
         })
     }
 }

--- a/apps/server/src/auth/extractors.rs
+++ b/apps/server/src/auth/extractors.rs
@@ -191,16 +191,13 @@ impl FromRequest for ApiAuth {
                 Err(AppError::Unauthorized(_)) => {} // auth rejected — fall through to session
                 Err(e) => return Err(e),             // Internal/Database — propagate
             }
-            session_future
-                .await
-                .map(|_| ApiAuth)
-                .map_err(|e| {
-                    if e.as_response_error().status_code().is_server_error() {
-                        AppError::Internal(format!("Session error: {e}"))
-                    } else {
-                        AppError::Unauthorized("Not authenticated".to_string())
-                    }
-                })
+            session_future.await.map(|_| ApiAuth).map_err(|e| {
+                if e.as_response_error().status_code().is_server_error() {
+                    AppError::Internal(format!("Session error: {e}"))
+                } else {
+                    AppError::Unauthorized("Not authenticated".to_string())
+                }
+            })
         })
     }
 }

--- a/apps/server/src/auth/extractors.rs
+++ b/apps/server/src/auth/extractors.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::auth::sentry_auth::parse_sentry_auth_header;
+use crate::auth::session::AuthenticatedUser;
 use crate::db::DbPool;
 use crate::error::AppError;
 use crate::models::{AuthToken, Project};
@@ -166,6 +167,32 @@ impl FromRequest for SentryAuth {
             }
 
             Ok(SentryAuth { project })
+        })
+    }
+}
+
+/// Composite extractor for management API endpoints.
+///
+/// Accepts either a Bearer token (`Authorization: Bearer <token>`) or a valid
+/// session cookie, in that order. Returns 401 only if both are absent/invalid.
+pub struct ApiAuth;
+
+impl FromRequest for ApiAuth {
+    type Error = AppError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>>>>;
+
+    fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+        let bearer_future = BearerAuth::from_request(req, payload);
+        let session_future = AuthenticatedUser::from_request(req, payload);
+
+        Box::pin(async move {
+            if bearer_future.await.is_ok() {
+                return Ok(ApiAuth);
+            }
+            session_future
+                .await
+                .map(|_| ApiAuth)
+                .map_err(|_| AppError::Unauthorized("Not authenticated".to_string()))
         })
     }
 }

--- a/apps/server/src/auth/mod.rs
+++ b/apps/server/src/auth/mod.rs
@@ -3,6 +3,6 @@ pub mod sentry_auth;
 pub mod session;
 pub mod token;
 
-pub use extractors::{BearerAuth, SentryAuth};
+pub use extractors::{ApiAuth, BearerAuth, SentryAuth};
 pub use session::{clear_session, get_user_id_from_session, set_user_session, AuthenticatedUser};
 pub use token::generate_token;

--- a/apps/server/src/routes/events.rs
+++ b/apps/server/src/routes/events.rs
@@ -1,7 +1,7 @@
 use actix_web::{web, HttpResponse};
 use uuid::Uuid;
 
-use crate::auth::AuthenticatedUser;
+use crate::auth::ApiAuth;
 use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
 #[cfg(feature = "openapi")]
@@ -34,7 +34,7 @@ pub async fn list_events(
     pool: web::Data<DbPool>,
     path: web::Path<(i32, Uuid)>,
     query: web::Query<ListEventsQuery>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let (project_id, issue_id) = path.into_inner();
 
@@ -98,7 +98,7 @@ pub async fn list_events(
 pub async fn get_event(
     pool: web::Data<DbPool>,
     path: web::Path<(i32, Uuid, Uuid)>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let (project_id, issue_id, event_id) = path.into_inner();
 

--- a/apps/server/src/routes/issues.rs
+++ b/apps/server/src/routes/issues.rs
@@ -1,7 +1,7 @@
 use actix_web::{web, HttpResponse};
 use uuid::Uuid;
 
-use crate::auth::AuthenticatedUser;
+use crate::auth::ApiAuth;
 use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
 #[cfg(feature = "openapi")]
@@ -34,7 +34,7 @@ pub async fn list_issues(
     pool: web::Data<DbPool>,
     path: web::Path<i32>,
     query: web::Query<ListIssuesQuery>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let project_id = path.into_inner();
 
@@ -87,7 +87,7 @@ pub async fn list_issues(
 pub async fn get_issue(
     pool: web::Data<DbPool>,
     path: web::Path<(i32, Uuid)>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let (project_id, issue_id) = path.into_inner();
 
@@ -126,7 +126,7 @@ pub async fn update_issue(
     pool: web::Data<DbPool>,
     path: web::Path<(i32, Uuid)>,
     body: web::Json<UpdateIssueState>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let (project_id, issue_id) = path.into_inner();
 
@@ -172,7 +172,7 @@ pub async fn update_issue(
 pub async fn delete_issue(
     pool: web::Data<DbPool>,
     path: web::Path<(i32, Uuid)>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let (project_id, issue_id) = path.into_inner();
 

--- a/apps/server/src/routes/projects.rs
+++ b/apps/server/src/routes/projects.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpResponse};
 
-use crate::auth::AuthenticatedUser;
+use crate::auth::ApiAuth;
 use crate::config::Config;
 use crate::db::DbPool;
 use crate::error::AppResult;
@@ -29,7 +29,7 @@ pub async fn list_projects(
     pool: web::Data<DbPool>,
     config: web::Data<Config>,
     query: web::Query<ListProjectsQuery>,
-    _user: AuthenticatedUser, // Requires authentication
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let (projects, total_count) =
         ProjectService::list_offset(pool.get_ref(), query.order, query.page, query.per_page)
@@ -63,7 +63,7 @@ pub async fn get_project(
     pool: web::Data<DbPool>,
     config: web::Data<Config>,
     path: web::Path<i32>,
-    _user: AuthenticatedUser, // Requires authentication
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let id = path.into_inner();
     let project = ProjectService::get_by_id(pool.get_ref(), id).await?;
@@ -89,7 +89,7 @@ pub async fn create_project(
     pool: web::Data<DbPool>,
     config: web::Data<Config>,
     body: web::Json<CreateProject>,
-    _user: AuthenticatedUser, // Requires authentication
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let project = ProjectService::create(pool.get_ref(), body.into_inner()).await?;
     let base_url = build_base_url(&config);
@@ -117,7 +117,7 @@ pub async fn update_project(
     config: web::Data<Config>,
     path: web::Path<i32>,
     body: web::Json<UpdateProject>,
-    _user: AuthenticatedUser, // Requires authentication
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let id = path.into_inner();
     let project = ProjectService::update(pool.get_ref(), id, body.into_inner()).await?;
@@ -142,7 +142,7 @@ pub async fn update_project(
 pub async fn delete_project(
     pool: web::Data<DbPool>,
     path: web::Path<i32>,
-    _user: AuthenticatedUser, // Requires authentication
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let id = path.into_inner();
     ProjectService::delete(pool.get_ref(), id).await?;

--- a/apps/server/src/routes/tokens.rs
+++ b/apps/server/src/routes/tokens.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpResponse};
 
-use crate::auth::AuthenticatedUser;
+use crate::auth::ApiAuth;
 use crate::db::DbPool;
 use crate::error::AppResult;
 use crate::models::CreateAuthToken;
@@ -22,10 +22,7 @@ use utoipa::OpenApi;
     security(("bearer_auth" = [])),
 ))]
 /// GET /api/tokens - List all tokens (masked)
-pub async fn list_tokens(
-    pool: web::Data<DbPool>,
-    _user: AuthenticatedUser, // Requires authentication
-) -> AppResult<HttpResponse> {
+pub async fn list_tokens(pool: web::Data<DbPool>, _auth: ApiAuth) -> AppResult<HttpResponse> {
     let tokens = AuthTokenService::list(pool.get_ref()).await?;
     let responses: Vec<_> = tokens.iter().map(|t| t.to_response()).collect();
 
@@ -46,7 +43,7 @@ pub async fn list_tokens(
 /// POST /api/tokens - Create a new token
 pub async fn create_token(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser, // Requires authentication
+    _auth: ApiAuth,
     body: web::Json<CreateAuthToken>,
 ) -> AppResult<HttpResponse> {
     let token = AuthTokenService::create(pool.get_ref(), body.into_inner()).await?;
@@ -70,7 +67,7 @@ pub async fn create_token(
 /// DELETE /api/tokens/{id} - Revoke a token
 pub async fn delete_token(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser, // Requires authentication
+    _auth: ApiAuth,
     path: web::Path<i32>,
 ) -> AppResult<HttpResponse> {
     let id = path.into_inner();

--- a/apps/server/tests/integration/projects_api_test.rs
+++ b/apps/server/tests/integration/projects_api_test.rs
@@ -7,9 +7,9 @@ use crate::common::TestDb;
 use actix_session::{storage::CookieSessionStore, SessionMiddleware};
 use actix_web::{cookie::Key, test, web, App};
 use rustrak::config::{Config, DatabaseConfig, RateLimitConfig};
-use rustrak::models::CreateProject;
+use rustrak::models::{CreateAuthToken, CreateProject};
 use rustrak::routes;
-use rustrak::services::ProjectService;
+use rustrak::services::{AuthTokenService, ProjectService};
 use std::time::Duration;
 
 /// Creates a test config
@@ -152,6 +152,41 @@ async fn test_delete_project_not_found() {
 #[ignore = "Session cookies not preserved in actix test framework - use E2E tests"]
 async fn test_list_projects_with_data() {
     // This test requires proper session cookie handling
+}
+
+// =============================================================================
+// Bearer Token Auth Tests
+// =============================================================================
+
+/// A valid Bearer token must be accepted by management endpoints.
+/// Currently FAILS because handlers use AuthenticatedUser (session-only).
+/// After the fix (ApiAuth composite extractor), this must return 200.
+#[actix_web::test]
+async fn test_list_projects_with_valid_bearer_token_returns_200() {
+    let db = TestDb::new().await;
+    let config = create_test_config();
+
+    // Create a real token in the DB
+    let token = AuthTokenService::create(&db.pool, CreateAuthToken { description: None })
+        .await
+        .expect("token creation must succeed");
+
+    // No SessionMiddleware — Bearer auth must work standalone
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(web::Data::new(config))
+            .configure(routes::projects::configure),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/api/projects")
+        .insert_header(("Authorization", format!("Bearer {}", token.token)))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
 }
 
 // =============================================================================

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,8 @@ services:
     build:
       context: ./apps/server
       dockerfile: Dockerfile
+      args:
+        FEATURES: postgres
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## Summary

- Adds `ApiAuth` composite extractor that tries `BearerAuth` first, falls back to session auth
- Replaces `AuthenticatedUser` with `ApiAuth` on all management routes: projects, issues, events, tokens
- Bearer tokens created via `/settings/tokens` can now authenticate programmatic API requests

## Motivation

The `BearerAuth` extractor and `auth_tokens` table were fully implemented but never wired into management routes. Any programmatic access (CI pipelines, external dashboards, monitoring scripts) required a browser session — effectively making the API token feature useless for its intended purpose.

## Security

- No unauthenticated access possible: both Bearer and session must fail independently for a 401 to be returned
- Invalid/revoked tokens fall through to session auth (not to open access)
- Existing `test_list_projects_unauthorized` (no credentials → 401) still passes
- No new attack surface introduced; limitations (no token TTL, no scopes) preexist

## Test plan

- [x] `test_list_projects_with_valid_bearer_token_returns_200` — valid Bearer token gets 200 on `GET /api/projects`
- [x] `test_list_projects_unauthorized` — no credentials still returns 401
- [x] Full test suite (166 integration + 129 unit) passes

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Management API endpoints now support bearer token authentication in addition to session-based authentication for greater flexibility in API client integration.

* **Tests**
  * Added integration test coverage for bearer token authentication on API endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbianS/rustrak/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->