### PR TITLE
feat(slack): add bot token method alongside incoming webhooks

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-slack-multi-config.md
+++ b/_bmad-output/implementation-artifacts/spec-slack-multi-config.md
@@ -1,0 +1,118 @@
+---
+title: 'Slack multi-method config (webhook + bot token)'
+type: 'feature'
+created: '2026-05-16'
+status: 'in-review'
+baseline_commit: '617e45f62f55a45d480a99de7721bd43dd000930'
+context:
+  - 'apps/server/CLAUDE.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** The current `SlackConfig` only supports Incoming Webhooks, and its `channel`/`username`/`icon_emoji` fields are silently ignored by Slack — modern app-based webhooks cannot override channel or identity at runtime. Users who fill in these fields believe they work but they don't.
+
+**Approach:** Replace `SlackConfig` with a tagged enum (`method: "webhook" | "bot_token"`). Webhook variant keeps only `webhook_url` (drop the broken fields). Bot token variant adds `token` (`xoxb-…`) + `channel` + optional `username`/`icon_emoji`, and sends via `POST https://slack.com/api/chat.postMessage`. Add a DB migration to tag existing records as `webhook`. Update the UI dialog to show the right fields per method.
+
+## Boundaries & Constraints
+
+**Always:**
+- Webhook variant validates: HTTPS scheme + host exactly `hooks.slack.com` (existing logic, keep it)
+- Bot token variant validates: token starts with `xoxb-`, channel non-empty
+- For bot token: POST to `https://slack.com/api/chat.postMessage` with `Authorization: Bearer {token}` header; check `ok: true` in response JSON; map `error` field to `NotificationResult::failure`
+- Migration must be backward-compatible: update existing Slack channel configs that lack a `method` field to `{"method": "webhook", ...}`
+- `username` and `icon_emoji` are optional for both methods; for bot token they are silently accepted (Slack ignores them if `chat:write.customize` scope is absent — this is fine, no error)
+- DB `config` column stays `jsonb` — no schema change to `notification_channels` table
+
+**Ask First:**
+- If existing live Slack channels exist in prod and the migration UPDATE would be destructive, halt and confirm
+- If any existing struct field or migration numbering conflicts are found during implementation, halt and ask
+
+**Never:**
+- Do not support `xoxp-` user tokens or `xapp-` app-level tokens — only `xoxb-` bot tokens
+- Do not add OAuth flow — users paste the token manually (same as API tokens in Rustrak)
+- Do not change the `ChannelType` enum or `NotificationChannel` DB model
+- Do not add a `channels:read` Slack API call to resolve channel names — accept channel ID or `#name` as-is
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|---|---|---|---|
+| Webhook — valid | `method: webhook`, valid URL | POST to webhook URL, `NotificationResult::success` | N/A |
+| Webhook — broken channel field (legacy) | existing record `{webhook_url, channel}` after migration | `method` added, `channel` field preserved but ignored at send time | N/A |
+| Bot token — valid | `method: bot_token`, `xoxb-…`, `#alerts` | POST to `chat.postMessage`, `ok: true` → success | N/A |
+| Bot token — invalid token | `xoxb-wrong` | Slack returns `{"ok": false, "error": "invalid_auth"}` → `NotificationResult::failure("Slack API error: invalid_auth", 200)` | Log + store in `last_failure_message` |
+| Bot token — bot not in channel | valid token, channel bot not invited | Slack returns `{"ok": false, "error": "not_in_channel"}` | `NotificationResult::failure("Bot is not a member of the channel", 200)` |
+| Validation — bot token missing `xoxb-` | token `xoxa-abc` | `AppError::Validation("Slack bot token must start with xoxb-")` | Rejected at save time |
+| Validation — empty channel (bot) | `channel: ""` | `AppError::Validation("Channel is required for bot token method")` | Rejected at save time |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `apps/server/migrations/` — new migration to backfill `method: "webhook"` on existing Slack configs
+- `apps/server/src/models/alert.rs:157-166` — `SlackConfig` struct to replace with tagged enum
+- `apps/server/src/services/notification/slack.rs` — entire file; add bot token send path, fix validate_config
+- `apps/webview-ui/src/app/(main)/settings/alerts/alert-channels-list.tsx:83-100` — `slackFormSchema` + `SlackConfigDialog` component (~line 573)
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `apps/server/migrations/<timestamp>_slack_config_method_field.up.sql` -- ADD migration that UPDATEs all `notification_channels` rows where `channel_type = 'slack'` AND `config` does not contain key `method`, setting `config = config || '{"method":"webhook"}'` -- backward compat for existing records; SQLx runs all pending migrations at server startup before accepting requests, so no record without `method` will exist when the new code runs
+- [x] `apps/server/src/models/alert.rs` -- REPLACE `SlackConfig` struct with `#[serde(tag = "method", rename_all = "snake_case")] pub enum SlackConfig { Webhook(SlackWebhookConfig), BotToken(SlackBotTokenConfig) }` where `SlackWebhookConfig { webhook_url: String }` and `SlackBotTokenConfig { token: String, channel: String, username: Option<String>, icon_emoji: Option<String> }` -- enables serde round-trip through `serde_json::Value` config column
+- [x] `apps/server/src/services/notification/slack.rs` -- UPDATE `send()` to match on `SlackConfig` variant: webhook path keeps existing `POST webhook_url` logic (remove channel/username/icon from payload); bot token path calls `POST https://slack.com/api/chat.postMessage` with `Authorization: Bearer {token}` and parses `{ok, error}` JSON response -- fixes the broken webhook channel override and adds bot token support
+- [x] `apps/server/src/services/notification/slack.rs` -- UPDATE `validate_config()` to handle both variants: webhook keeps existing URL validation; bot token checks `token.starts_with("xoxb-")` and `!channel.is_empty()` -- proper validation for both methods
+- [x] `apps/webview-ui/src/app/(main)/settings/alerts/alert-channels-list.tsx` -- UPDATE `slackFormSchema` to include `method: z.enum(["webhook", "bot_token"])`, `webhook_url` (required when method=webhook), `token` (required when method=bot_token), `channel` (required when method=bot_token), `username`/`icon_emoji` (optional for bot_token only) using `.superRefine` -- aligns client validation with new server model
+- [x] `apps/webview-ui/src/app/(main)/settings/alerts/alert-channels-list.tsx` -- UPDATE `SlackConfigDialog` to render method selector (radio or select: "Incoming Webhook" / "Bot Token"), show webhook URL field only for webhook method, show token + channel fields only for bot token method, remove the "Channel (optional) — Override the default channel" field from webhook form -- fixes misleading UI
+- [x] `apps/server/src/routes/alerts.rs` -- UPDATE the notification channel serialization to redact the bot token before returning: if `channel_type == "slack"` and `config["method"] == "bot_token"`, replace `config["token"]` with `"xoxb-****"` in the response JSON -- prevents exposing live `xoxb-…` tokens via `GET /api/notification-channels`
+
+**Acceptance Criteria:**
+- Given an existing Slack channel with only `webhook_url` in config, when the migration runs, then the config gains `"method": "webhook"` and the channel continues to deliver alerts unchanged
+- Given a new Slack channel configured with method=webhook, when the user omits the channel field (it no longer exists), then the alert is sent to the channel hardcoded in the Slack app webhook
+- Given a new Slack channel configured with method=bot_token, when a valid `xoxb-…` token and channel ID are provided, then `POST chat.postMessage` is called and the alert appears in the target channel
+- Given validate_config is called with `method=bot_token` and token `"xoxa-123"`, when the API endpoint is called, then the server returns 400 with `"Slack bot token must start with xoxb-"`
+- Given the UI dialog for Slack, when the user selects "Bot Token" method, then the webhook URL field disappears and token + channel fields appear; when they select "Incoming Webhook", only webhook URL is shown
+
+## Spec Change Log
+
+## Design Notes
+
+**Serde tagged enum for config:**
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "method", rename_all = "snake_case")]
+pub enum SlackConfig {
+    Webhook(SlackWebhookConfig),
+    BotToken(SlackBotTokenConfig),
+}
+```
+Serializes as `{"method":"webhook","webhook_url":"..."}` or `{"method":"bot_token","token":"xoxb-...","channel":"C123"}`. This round-trips cleanly through the `serde_json::Value` config column.
+
+**Bot token send — response parsing:**
+```rust
+// Slack always returns HTTP 200 for the Web API; success/failure is in JSON
+let body: serde_json::Value = response.json().await?;
+if body["ok"].as_bool() == Some(true) {
+    NotificationResult::success(Some(200))
+} else {
+    let err = body["error"].as_str().unwrap_or("unknown_error");
+    let msg = match err {
+        "not_in_channel" => "Bot is not a member of the channel".to_string(),
+        "channel_not_found" => "Slack channel not found".to_string(),
+        "invalid_auth" => "Invalid Slack bot token".to_string(),
+        _ => format!("Slack API error: {}", err),
+    };
+    NotificationResult::failure(msg, Some(200))
+}
+```
+
+## Verification
+
+**Commands:**
+- `cd apps/server && cargo build --features postgres` -- expected: compiles without warnings
+- `cd apps/server && cargo test` -- expected: all tests pass including updated slack unit tests
+- `cd apps/webview-ui && pnpm tsc --noEmit` -- expected: no type errors
+- `cd apps/webview-ui && pnpm lint` -- expected: no Biome errors
+- `cd packages/client && pnpm test` -- expected: all 133+ tests pass (client package unchanged)

--- a/apps/server/migrations/postgres/20260516000000_slack_config_method_field.down.sql
+++ b/apps/server/migrations/postgres/20260516000000_slack_config_method_field.down.sql
@@ -1,0 +1,6 @@
+-- Remove the backfilled `method` key from Slack channel configs.
+-- Only removes the key if value is "webhook" to avoid touching bot_token configs.
+UPDATE notification_channels
+SET config = config - 'method'
+WHERE channel_type = 'slack'
+  AND config->>'method' = 'webhook';

--- a/apps/server/migrations/postgres/20260516000000_slack_config_method_field.up.sql
+++ b/apps/server/migrations/postgres/20260516000000_slack_config_method_field.up.sql
@@ -1,0 +1,7 @@
+-- Backfill `method: "webhook"` on all existing Slack notification channels
+-- that do not yet have the `method` key in their config JSON.
+-- This is safe to run multiple times (the WHERE clause is idempotent).
+UPDATE notification_channels
+SET config = config || '{"method":"webhook"}'::jsonb
+WHERE channel_type = 'slack'
+  AND NOT (config ? 'method');

--- a/apps/server/migrations/sqlite/20260516000000_slack_config_method_field.down.sql
+++ b/apps/server/migrations/sqlite/20260516000000_slack_config_method_field.down.sql
@@ -1,0 +1,6 @@
+-- Remove the backfilled `method` key from Slack channel configs.
+-- Only removes the key if value is "webhook" to avoid touching bot_token configs.
+UPDATE notification_channels
+SET config = json_remove(config, '$.method')
+WHERE channel_type = 'slack'
+  AND json_extract(config, '$.method') = 'webhook';

--- a/apps/server/migrations/sqlite/20260516000000_slack_config_method_field.up.sql
+++ b/apps/server/migrations/sqlite/20260516000000_slack_config_method_field.up.sql
@@ -1,0 +1,7 @@
+-- Backfill `method: "webhook"` on all existing Slack notification channels
+-- that do not yet have the `method` key in their config JSON.
+-- SQLite uses json_patch() to merge objects and json_extract() to check for the key.
+UPDATE notification_channels
+SET config = json_patch(config, '{"method":"webhook"}')
+WHERE channel_type = 'slack'
+  AND json_extract(config, '$.method') IS NULL;

--- a/apps/server/src/models/alert.rs
+++ b/apps/server/src/models/alert.rs
@@ -153,12 +153,29 @@ pub struct EmailConfig {
     pub from_address: Option<String>,
 }
 
-/// Slack channel configuration
+/// Slack channel configuration — tagged enum over delivery method.
+///
+/// Serialises as `{"method":"webhook",...}` or `{"method":"bot_token",...}`.
+/// The DB migration backfills `method:"webhook"` on all existing rows so serde
+/// always sees the tag field.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SlackConfig {
+#[serde(tag = "method", rename_all = "snake_case")]
+pub enum SlackConfig {
+    Webhook(SlackWebhookConfig),
+    BotToken(SlackBotTokenConfig),
+}
+
+/// Config for the Incoming Webhook delivery method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlackWebhookConfig {
     pub webhook_url: String,
-    #[serde(default)]
-    pub channel: Option<String>,
+}
+
+/// Config for the Bot Token (chat.postMessage) delivery method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlackBotTokenConfig {
+    pub token: String,
+    pub channel: String,
     #[serde(default)]
     pub username: Option<String>,
     #[serde(default)]

--- a/apps/server/src/models/mod.rs
+++ b/apps/server/src/models/mod.rs
@@ -10,7 +10,8 @@ pub mod user;
 pub use alert::{
     AlertHistory, AlertPayload, AlertRule, AlertRuleResponse, AlertStatus, AlertType, ChannelType,
     CreateAlertRule, CreateNotificationChannel, EmailConfig, IssueInfo, NotificationChannel,
-    ProjectInfo, SlackConfig, UpdateAlertRule, UpdateNotificationChannel, WebhookConfig,
+    ProjectInfo, SlackBotTokenConfig, SlackConfig, SlackWebhookConfig, UpdateAlertRule,
+    UpdateNotificationChannel, WebhookConfig,
 };
 pub use auth_token::{AuthToken, AuthTokenCreatedResponse, AuthTokenResponse, CreateAuthToken};
 pub use event::{Event, EventDetailResponse, EventResponse};

--- a/apps/server/src/routes/alerts.rs
+++ b/apps/server/src/routes/alerts.rs
@@ -25,6 +25,7 @@ use serde::Deserialize;
 use crate::auth::AuthenticatedUser;
 use crate::db::DbPool;
 use crate::error::AppResult;
+use crate::models::ChannelType;
 use crate::models::{
     AlertPayload, CreateAlertRule, CreateNotificationChannel, IssueInfo, ProjectInfo,
     UpdateAlertRule, UpdateNotificationChannel,
@@ -35,6 +36,28 @@ use crate::services::{create_dispatcher, AlertService, ProjectService};
 
 #[cfg(feature = "openapi")]
 use utoipa::OpenApi;
+
+// =============================================================================
+// Token redaction
+// =============================================================================
+
+/// Redacts the bot token in a Slack channel's config before sending the
+/// channel over the API. Replaces `config.token` with `"xoxb-****"` when
+/// `channel_type == slack` and `config.method == "bot_token"`.
+///
+/// This prevents live `xoxb-…` tokens from being exposed via GET responses.
+pub fn redact_slack_bot_token(channel_type: ChannelType, config: &mut serde_json::Value) {
+    if channel_type == ChannelType::Slack {
+        if config.get("method").and_then(|v| v.as_str()) == Some("bot_token") {
+            if let Some(obj) = config.as_object_mut() {
+                obj.insert(
+                    "token".to_string(),
+                    serde_json::Value::String("xoxb-****".to_string()),
+                );
+            }
+        }
+    }
+}
 
 // =============================================================================
 // Notification Channel Endpoints
@@ -50,13 +73,23 @@ use utoipa::OpenApi;
     ),
     security(("bearer_auth" = [])),
 ))]
+/// Returns a `serde_json::Value` for `channel` with the bot token redacted.
+fn channel_to_safe_json(channel: &crate::models::NotificationChannel) -> serde_json::Value {
+    let mut value = serde_json::to_value(channel).unwrap_or_default();
+    if let Some(config) = value.get_mut("config") {
+        redact_slack_bot_token(channel.channel_type, config);
+    }
+    value
+}
+
 /// GET /api/alert-channels
 pub async fn list_channels(
     pool: web::Data<DbPool>,
     _user: AuthenticatedUser,
 ) -> AppResult<HttpResponse> {
     let channels = AlertService::list_channels(pool.get_ref()).await?;
-    Ok(HttpResponse::Ok().json(channels))
+    let safe: Vec<serde_json::Value> = channels.iter().map(channel_to_safe_json).collect();
+    Ok(HttpResponse::Ok().json(safe))
 }
 
 #[cfg_attr(feature = "openapi", utoipa::path(
@@ -77,7 +110,7 @@ pub async fn create_channel(
     body: web::Json<CreateNotificationChannel>,
 ) -> AppResult<HttpResponse> {
     let channel = AlertService::create_channel(pool.get_ref(), body.into_inner()).await?;
-    Ok(HttpResponse::Created().json(channel))
+    Ok(HttpResponse::Created().json(channel_to_safe_json(&channel)))
 }
 
 #[cfg_attr(feature = "openapi", utoipa::path(
@@ -99,7 +132,7 @@ pub async fn get_channel(
     path: web::Path<i32>,
 ) -> AppResult<HttpResponse> {
     let channel = AlertService::get_channel(pool.get_ref(), path.into_inner()).await?;
-    Ok(HttpResponse::Ok().json(channel))
+    Ok(HttpResponse::Ok().json(channel_to_safe_json(&channel)))
 }
 
 #[cfg_attr(feature = "openapi", utoipa::path(
@@ -124,7 +157,7 @@ pub async fn update_channel(
 ) -> AppResult<HttpResponse> {
     let channel =
         AlertService::update_channel(pool.get_ref(), path.into_inner(), body.into_inner()).await?;
-    Ok(HttpResponse::Ok().json(channel))
+    Ok(HttpResponse::Ok().json(channel_to_safe_json(&channel)))
 }
 
 #[cfg_attr(feature = "openapi", utoipa::path(
@@ -527,4 +560,50 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
     configure_channels(cfg);
     configure_rules(cfg);
     configure_history(cfg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Cycle 5 RED: redact_slack_bot_token replaces token value for bot_token method
+    #[test]
+    fn test_redact_slack_bot_token_replaces_token() {
+        let mut config = serde_json::json!({
+            "method": "bot_token",
+            "token": "xoxb-real-secret-token",
+            "channel": "#alerts"
+        });
+        redact_slack_bot_token(ChannelType::Slack, &mut config);
+        assert_eq!(config["token"], "xoxb-****");
+        // Other fields untouched
+        assert_eq!(config["channel"], "#alerts");
+        assert_eq!(config["method"], "bot_token");
+    }
+
+    #[test]
+    fn test_redact_slack_bot_token_noop_for_webhook_method() {
+        let mut config = serde_json::json!({
+            "method": "webhook",
+            "webhook_url": "https://hooks.slack.com/services/T/B/X"
+        });
+        redact_slack_bot_token(ChannelType::Slack, &mut config);
+        // Must not touch webhook config at all
+        assert!(config.get("token").is_none());
+        assert_eq!(
+            config["webhook_url"],
+            "https://hooks.slack.com/services/T/B/X"
+        );
+    }
+
+    #[test]
+    fn test_redact_slack_bot_token_noop_for_non_slack_channel() {
+        let mut config = serde_json::json!({
+            "method": "bot_token",
+            "token": "xoxb-real-secret"
+        });
+        // Using ChannelType::Webhook — should not redact
+        redact_slack_bot_token(ChannelType::Webhook, &mut config);
+        assert_eq!(config["token"], "xoxb-real-secret");
+    }
 }

--- a/apps/server/src/routes/alerts.rs
+++ b/apps/server/src/routes/alerts.rs
@@ -47,14 +47,14 @@ use utoipa::OpenApi;
 ///
 /// This prevents live `xoxb-…` tokens from being exposed via GET responses.
 pub fn redact_slack_bot_token(channel_type: ChannelType, config: &mut serde_json::Value) {
-    if channel_type == ChannelType::Slack {
-        if config.get("method").and_then(|v| v.as_str()) == Some("bot_token") {
-            if let Some(obj) = config.as_object_mut() {
-                obj.insert(
-                    "token".to_string(),
-                    serde_json::Value::String("xoxb-****".to_string()),
-                );
-            }
+    if channel_type == ChannelType::Slack
+        && config.get("method").and_then(|v| v.as_str()) == Some("bot_token")
+    {
+        if let Some(obj) = config.as_object_mut() {
+            obj.insert(
+                "token".to_string(),
+                serde_json::Value::String("xoxb-****".to_string()),
+            );
         }
     }
 }
@@ -62,6 +62,14 @@ pub fn redact_slack_bot_token(channel_type: ChannelType, config: &mut serde_json
 // =============================================================================
 // Notification Channel Endpoints
 // =============================================================================
+
+fn channel_to_safe_json(channel: &crate::models::NotificationChannel) -> serde_json::Value {
+    let mut value = serde_json::to_value(channel).unwrap_or_default();
+    if let Some(config) = value.get_mut("config") {
+        redact_slack_bot_token(channel.channel_type, config);
+    }
+    value
+}
 
 #[cfg_attr(feature = "openapi", utoipa::path(
     get,
@@ -73,15 +81,6 @@ pub fn redact_slack_bot_token(channel_type: ChannelType, config: &mut serde_json
     ),
     security(("bearer_auth" = [])),
 ))]
-/// Returns a `serde_json::Value` for `channel` with the bot token redacted.
-fn channel_to_safe_json(channel: &crate::models::NotificationChannel) -> serde_json::Value {
-    let mut value = serde_json::to_value(channel).unwrap_or_default();
-    if let Some(config) = value.get_mut("config") {
-        redact_slack_bot_token(channel.channel_type, config);
-    }
-    value
-}
-
 /// GET /api/alert-channels
 pub async fn list_channels(
     pool: web::Data<DbPool>,

--- a/apps/server/src/services/notification/slack.rs
+++ b/apps/server/src/services/notification/slack.rs
@@ -1,14 +1,17 @@
 //! Slack notification dispatcher.
 //!
-//! Sends alerts to Slack channels using incoming webhooks.
-//! Uses Slack Block Kit for rich message formatting.
+//! Supports two delivery methods:
+//! - `webhook` — POST to an Incoming Webhook URL (no channel/identity override)
+//! - `bot_token` — POST to `chat.postMessage` with `Authorization: Bearer xoxb-…`
 
 use async_trait::async_trait;
 use serde_json::json;
 
 use super::{NotificationDispatcher, NotificationResult};
 use crate::error::{AppError, AppResult};
-use crate::models::{AlertPayload, NotificationChannel, SlackConfig};
+use crate::models::{
+    AlertPayload, NotificationChannel, SlackBotTokenConfig, SlackConfig, SlackWebhookConfig,
+};
 
 /// Slack notification dispatcher
 pub struct SlackNotifier {
@@ -26,8 +29,17 @@ impl SlackNotifier {
         Self { client }
     }
 
-    /// Formats an alert as a Slack Block Kit message
-    fn format_message(config: &SlackConfig, payload: &AlertPayload) -> serde_json::Value {
+    /// Escapes special Slack markdown characters
+    fn escape_markdown(text: &str) -> String {
+        text.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+    }
+
+    /// Builds the Slack Block Kit message body for the webhook variant.
+    /// Channel/username/icon are NOT included — Slack ignores overrides on
+    /// modern app-based webhooks and including them is misleading.
+    fn format_webhook_message(payload: &AlertPayload) -> serde_json::Value {
         let level_emoji = match payload.issue.level.as_deref() {
             Some("fatal") => ":rotating_light:",
             Some("error") => ":x:",
@@ -58,9 +70,7 @@ impl SlackNotifier {
             .collect::<Vec<String>>()
             .join(" ");
 
-        let mut message = json!({
-            "username": config.username.as_deref().unwrap_or("Rustrak"),
-            "icon_emoji": config.icon_emoji.as_deref().unwrap_or(":bug:"),
+        json!({
             "blocks": [
                 {
                     "type": "header",
@@ -115,51 +125,33 @@ impl SlackNotifier {
                     ]
                 }
             ]
-        });
+        })
+    }
 
-        // Add channel override if specified
-        if let Some(ref channel) = config.channel {
-            message["channel"] = json!(channel);
+    /// Builds the chat.postMessage body for the bot token variant.
+    fn format_bot_message(cfg: &SlackBotTokenConfig, payload: &AlertPayload) -> serde_json::Value {
+        let mut body = Self::format_webhook_message(payload);
+        body["channel"] = json!(cfg.channel);
+        if let Some(ref username) = cfg.username {
+            body["username"] = json!(username);
         }
-
-        message
+        if let Some(ref icon_emoji) = cfg.icon_emoji {
+            body["icon_emoji"] = json!(icon_emoji);
+        }
+        body
     }
 
-    /// Escapes special Slack markdown characters
-    fn escape_markdown(text: &str) -> String {
-        text.replace('&', "&amp;")
-            .replace('<', "&lt;")
-            .replace('>', "&gt;")
-    }
-}
-
-impl Default for SlackNotifier {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[async_trait]
-impl NotificationDispatcher for SlackNotifier {
-    async fn send(
+    /// Sends via Incoming Webhook (no auth header needed, URL is the secret).
+    async fn send_webhook(
         &self,
-        channel: &NotificationChannel,
+        cfg: &SlackWebhookConfig,
         payload: &AlertPayload,
     ) -> NotificationResult {
-        // Parse config
-        let config: SlackConfig = match serde_json::from_value(channel.config.clone()) {
-            Ok(c) => c,
-            Err(e) => {
-                return NotificationResult::failure(format!("Invalid Slack config: {}", e), None)
-            }
-        };
+        let message = Self::format_webhook_message(payload);
 
-        let message = Self::format_message(&config, payload);
-
-        // Send to Slack webhook
         match self
             .client
-            .post(&config.webhook_url)
+            .post(&cfg.webhook_url)
             .header("Content-Type", "application/json")
             .json(&message)
             .send()
@@ -197,37 +189,141 @@ impl NotificationDispatcher for SlackNotifier {
         }
     }
 
+    /// Sends via `chat.postMessage` using a bot token.
+    /// Slack's Web API always returns HTTP 200; success/failure is in the JSON body.
+    async fn send_bot_token(
+        &self,
+        cfg: &SlackBotTokenConfig,
+        payload: &AlertPayload,
+    ) -> NotificationResult {
+        let body = Self::format_bot_message(cfg, payload);
+
+        match self
+            .client
+            .post("https://slack.com/api/chat.postMessage")
+            .header("Authorization", format!("Bearer {}", cfg.token))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(response) => {
+                let http_status = response.status().as_u16();
+                match response.json::<serde_json::Value>().await {
+                    Ok(json_body) => {
+                        if json_body["ok"].as_bool() == Some(true) {
+                            NotificationResult::success(Some(http_status))
+                        } else {
+                            let err = json_body["error"].as_str().unwrap_or("unknown_error");
+                            let msg = match err {
+                                "not_in_channel" => {
+                                    "Bot is not a member of the channel".to_string()
+                                }
+                                "channel_not_found" => "Slack channel not found".to_string(),
+                                "invalid_auth" => "Invalid Slack bot token".to_string(),
+                                _ => format!("Slack API error: {}", err),
+                            };
+                            NotificationResult::failure(msg, Some(http_status))
+                        }
+                    }
+                    Err(e) => NotificationResult::failure(
+                        format!("Failed to parse Slack API response: {}", e),
+                        Some(http_status),
+                    ),
+                }
+            }
+            Err(e) => {
+                let error_msg = if e.is_timeout() {
+                    "Request to Slack timed out".to_string()
+                } else if e.is_connect() {
+                    "Connection to Slack failed".to_string()
+                } else {
+                    format!("Slack request failed: {}", e)
+                };
+                NotificationResult::failure(error_msg, None)
+            }
+        }
+    }
+}
+
+impl Default for SlackNotifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl NotificationDispatcher for SlackNotifier {
+    async fn send(
+        &self,
+        channel: &NotificationChannel,
+        payload: &AlertPayload,
+    ) -> NotificationResult {
+        let config: SlackConfig = match serde_json::from_value(channel.config.clone()) {
+            Ok(c) => c,
+            Err(e) => {
+                return NotificationResult::failure(format!("Invalid Slack config: {}", e), None)
+            }
+        };
+
+        match config {
+            SlackConfig::Webhook(cfg) => self.send_webhook(&cfg, payload).await,
+            SlackConfig::BotToken(cfg) => self.send_bot_token(&cfg, payload).await,
+        }
+    }
+
     fn validate_config(&self, config: &serde_json::Value) -> AppResult<()> {
         let slack_config: SlackConfig = serde_json::from_value(config.clone())
             .map_err(|e| AppError::Validation(format!("Invalid Slack config: {}", e)))?;
 
-        if slack_config.webhook_url.is_empty() {
-            return Err(AppError::Validation(
-                "Slack webhook URL is required".to_string(),
-            ));
+        match slack_config {
+            SlackConfig::Webhook(cfg) => validate_webhook_config(&cfg),
+            SlackConfig::BotToken(cfg) => validate_bot_token_config(&cfg),
         }
-
-        // Validate URL format and extract components
-        let parsed_url = url::Url::parse(&slack_config.webhook_url)
-            .map_err(|_| AppError::Validation("Invalid Slack webhook URL format".to_string()))?;
-
-        // Slack webhooks must use HTTPS
-        if parsed_url.scheme() != "https" {
-            return Err(AppError::Validation(
-                "Slack webhook URL must use HTTPS".to_string(),
-            ));
-        }
-
-        // Validate exact host match to prevent bypass via subdomains
-        // e.g., hooks.slack.com.evil.com would fail this check
-        if parsed_url.host_str() != Some("hooks.slack.com") {
-            return Err(AppError::Validation(
-                "Invalid Slack webhook URL: host must be hooks.slack.com".to_string(),
-            ));
-        }
-
-        Ok(())
     }
+}
+
+/// Validates webhook config: HTTPS + host must be exactly hooks.slack.com.
+fn validate_webhook_config(cfg: &SlackWebhookConfig) -> AppResult<()> {
+    if cfg.webhook_url.is_empty() {
+        return Err(AppError::Validation(
+            "Slack webhook URL is required".to_string(),
+        ));
+    }
+
+    let parsed_url = url::Url::parse(&cfg.webhook_url)
+        .map_err(|_| AppError::Validation("Invalid Slack webhook URL format".to_string()))?;
+
+    if parsed_url.scheme() != "https" {
+        return Err(AppError::Validation(
+            "Slack webhook URL must use HTTPS".to_string(),
+        ));
+    }
+
+    if parsed_url.host_str() != Some("hooks.slack.com") {
+        return Err(AppError::Validation(
+            "Invalid Slack webhook URL: host must be hooks.slack.com".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validates bot token config: token must start with `xoxb-`, channel must be non-empty.
+fn validate_bot_token_config(cfg: &SlackBotTokenConfig) -> AppResult<()> {
+    if !cfg.token.starts_with("xoxb-") {
+        return Err(AppError::Validation(
+            "Slack bot token must start with xoxb-".to_string(),
+        ));
+    }
+
+    if cfg.channel.is_empty() {
+        return Err(AppError::Validation(
+            "Channel is required for bot token method".to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -259,22 +355,20 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_format_message_structure() {
-        let config = SlackConfig {
-            webhook_url: "https://hooks.slack.com/test".to_string(),
-            channel: Some("#alerts".to_string()),
-            username: Some("TestBot".to_string()),
-            icon_emoji: Some(":robot:".to_string()),
-        };
-        let payload = create_test_payload();
+    // -------------------------------------------------------------------------
+    // Existing tests — updated for new enum shape
+    // -------------------------------------------------------------------------
 
-        let message = SlackNotifier::format_message(&config, &payload);
+    #[test]
+    fn test_format_webhook_message_structure() {
+        let payload = create_test_payload();
+        let message = SlackNotifier::format_webhook_message(&payload);
 
         assert!(message["blocks"].is_array());
-        assert_eq!(message["username"], "TestBot");
-        assert_eq!(message["icon_emoji"], ":robot:");
-        assert_eq!(message["channel"], "#alerts");
+        // Webhook messages must NOT include username/icon/channel — Slack ignores them
+        assert!(message.get("username").is_none());
+        assert!(message.get("icon_emoji").is_none());
+        assert!(message.get("channel").is_none());
     }
 
     #[test]
@@ -285,5 +379,132 @@ mod tests {
             SlackNotifier::escape_markdown("foo & <bar>"),
             "foo &amp; &lt;bar&gt;"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Cycle 1: SlackConfig tagged enum — webhook variant serde round-trip
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_slack_config_webhook_deserializes_with_method_field() {
+        // After the migration, existing records gain {"method":"webhook",...}
+        // The enum must deserialize this shape correctly.
+        let json = serde_json::json!({
+            "method": "webhook",
+            "webhook_url": "https://hooks.slack.com/services/T/B/X"
+        });
+        let config: SlackConfig = serde_json::from_value(json).expect("must deserialize");
+        match config {
+            SlackConfig::Webhook(w) => {
+                assert_eq!(w.webhook_url, "https://hooks.slack.com/services/T/B/X");
+            }
+            _ => panic!("expected Webhook variant"),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cycle 2: BotToken variant serde round-trip
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_slack_config_bot_token_deserializes() {
+        let json = serde_json::json!({
+            "method": "bot_token",
+            "token": "xoxb-12345-67890",
+            "channel": "#alerts"
+        });
+        let config: SlackConfig = serde_json::from_value(json).expect("must deserialize");
+        match config {
+            SlackConfig::BotToken(b) => {
+                assert_eq!(b.token, "xoxb-12345-67890");
+                assert_eq!(b.channel, "#alerts");
+                assert!(b.username.is_none());
+                assert!(b.icon_emoji.is_none());
+            }
+            _ => panic!("expected BotToken variant"),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cycle 3: validate_config for bot token
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_bot_token_rejects_non_xoxb_prefix() {
+        let notifier = SlackNotifier::new();
+        let config = serde_json::json!({
+            "method": "bot_token",
+            "token": "xoxa-wrong",
+            "channel": "#alerts"
+        });
+        let result = notifier.validate_config(&config);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("xoxb-"),
+            "error should mention xoxb- prefix, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_validate_bot_token_rejects_empty_channel() {
+        let notifier = SlackNotifier::new();
+        let config = serde_json::json!({
+            "method": "bot_token",
+            "token": "xoxb-valid-token",
+            "channel": ""
+        });
+        let result = notifier.validate_config(&config);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Channel"),
+            "error should mention Channel, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_validate_bot_token_valid() {
+        let notifier = SlackNotifier::new();
+        let config = serde_json::json!({
+            "method": "bot_token",
+            "token": "xoxb-123-456-abc",
+            "channel": "C1234567890"
+        });
+        assert!(notifier.validate_config(&config).is_ok());
+    }
+
+    // -------------------------------------------------------------------------
+    // Cycle 4: validate_config still works for webhook variant
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_webhook_valid_url() {
+        let notifier = SlackNotifier::new();
+        let config = serde_json::json!({
+            "method": "webhook",
+            "webhook_url": "https://hooks.slack.com/services/T/B/X"
+        });
+        assert!(notifier.validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_webhook_rejects_http() {
+        let notifier = SlackNotifier::new();
+        let config = serde_json::json!({
+            "method": "webhook",
+            "webhook_url": "http://hooks.slack.com/services/T/B/X"
+        });
+        assert!(notifier.validate_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_webhook_rejects_wrong_host() {
+        let notifier = SlackNotifier::new();
+        let config = serde_json::json!({
+            "method": "webhook",
+            "webhook_url": "https://hooks.slack.com.evil.com/services/T/B/X"
+        });
+        assert!(notifier.validate_config(&config).is_err());
     }
 }

--- a/apps/server/src/services/notification/slack.rs
+++ b/apps/server/src/services/notification/slack.rs
@@ -317,7 +317,7 @@ fn validate_bot_token_config(cfg: &SlackBotTokenConfig) -> AppResult<()> {
         ));
     }
 
-    if cfg.channel.is_empty() {
+    if cfg.channel.trim().is_empty() {
         return Err(AppError::Validation(
             "Channel is required for bot token method".to_string(),
         ));

--- a/apps/server/tests/integration/alerts_api_test.rs
+++ b/apps/server/tests/integration/alerts_api_test.rs
@@ -175,11 +175,12 @@ async fn test_channel_invalid_config_fails() {
 async fn test_slack_channel_config_validation() {
     let db = TestDb::new().await;
 
-    // Invalid Slack webhook URL
+    // Invalid Slack webhook URL (wrong host, but method field present)
     let create_input = CreateNotificationChannel {
         name: "Invalid Slack".to_string(),
         channel_type: ChannelType::Slack,
         config: json!({
+            "method": "webhook",
             "webhook_url": "https://example.com/not-slack"
         }),
         is_enabled: true,
@@ -193,6 +194,7 @@ async fn test_slack_channel_config_validation() {
         name: "Valid Slack".to_string(),
         channel_type: ChannelType::Slack,
         config: json!({
+            "method": "webhook",
             "webhook_url": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXX"
         }),
         is_enabled: true,

--- a/apps/server/tests/unit/notification_test.rs
+++ b/apps/server/tests/unit/notification_test.rs
@@ -83,10 +83,15 @@ fn test_webhook_validate_config_invalid_scheme() {
 // Slack Config Validation Tests
 // =============================================================================
 
+// =============================================================================
+// Slack Config Validation Tests — webhook method
+// =============================================================================
+
 #[test]
 fn test_slack_validate_config_valid() {
     let dispatcher = create_dispatcher(ChannelType::Slack);
     let config = json!({
+        "method": "webhook",
         "webhook_url": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXX"
     });
 
@@ -96,7 +101,20 @@ fn test_slack_validate_config_valid() {
 #[test]
 fn test_slack_validate_config_missing_url() {
     let dispatcher = create_dispatcher(ChannelType::Slack);
-    let config = json!({});
+    // method field present but webhook_url missing — serde should fail
+    let config = json!({ "method": "webhook" });
+
+    assert!(dispatcher.validate_config(&config).is_err());
+}
+
+#[test]
+fn test_slack_validate_config_missing_method_field_is_err() {
+    // Legacy shape without method field — should fail after migration
+    // (migration adds the field; configs missing it are invalid at validate time)
+    let dispatcher = create_dispatcher(ChannelType::Slack);
+    let config = json!({
+        "webhook_url": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXX"
+    });
 
     assert!(dispatcher.validate_config(&config).is_err());
 }
@@ -105,6 +123,7 @@ fn test_slack_validate_config_missing_url() {
 fn test_slack_validate_config_invalid_domain() {
     let dispatcher = create_dispatcher(ChannelType::Slack);
     let config = json!({
+        "method": "webhook",
         "webhook_url": "https://example.com/webhook"
     });
 
@@ -114,8 +133,8 @@ fn test_slack_validate_config_invalid_domain() {
 #[test]
 fn test_slack_validate_config_rejects_subdomain_bypass() {
     let dispatcher = create_dispatcher(ChannelType::Slack);
-    // This should be rejected - it's a subdomain bypass attempt
     let config = json!({
+        "method": "webhook",
         "webhook_url": "https://hooks.slack.com.evil.com/services/T00000000/B00000000/XXXXXXXX"
     });
 
@@ -125,12 +144,56 @@ fn test_slack_validate_config_rejects_subdomain_bypass() {
 #[test]
 fn test_slack_validate_config_rejects_http() {
     let dispatcher = create_dispatcher(ChannelType::Slack);
-    // HTTP should be rejected
     let config = json!({
+        "method": "webhook",
         "webhook_url": "http://hooks.slack.com/services/T00000000/B00000000/XXXXXXXX"
     });
 
     assert!(dispatcher.validate_config(&config).is_err());
+}
+
+// =============================================================================
+// Slack Config Validation Tests — bot_token method
+// =============================================================================
+
+#[test]
+fn test_slack_bot_token_validate_config_valid() {
+    let dispatcher = create_dispatcher(ChannelType::Slack);
+    let config = json!({
+        "method": "bot_token",
+        "token": "xoxb-123456789-abcdefghij",
+        "channel": "C1234567890"
+    });
+
+    assert!(dispatcher.validate_config(&config).is_ok());
+}
+
+#[test]
+fn test_slack_bot_token_validate_rejects_non_xoxb_prefix() {
+    let dispatcher = create_dispatcher(ChannelType::Slack);
+    let config = json!({
+        "method": "bot_token",
+        "token": "xoxa-should-fail",
+        "channel": "#alerts"
+    });
+
+    let result = dispatcher.validate_config(&config);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("xoxb-"));
+}
+
+#[test]
+fn test_slack_bot_token_validate_rejects_empty_channel() {
+    let dispatcher = create_dispatcher(ChannelType::Slack);
+    let config = json!({
+        "method": "bot_token",
+        "token": "xoxb-valid",
+        "channel": ""
+    });
+
+    let result = dispatcher.validate_config(&config);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("Channel"));
 }
 
 // =============================================================================

--- a/apps/webview-ui/src/app/(main)/settings/alerts/alert-channels-list.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/alerts/alert-channels-list.tsx
@@ -80,24 +80,69 @@ const webhookFormSchema = z.object({
   is_enabled: z.boolean(),
 });
 
-const slackFormSchema = z.object({
-  name: z.string().min(1, 'Name is required').max(255),
-  webhook_url: z
-    .string()
-    .url('Please enter a valid URL')
-    .refine((value) => {
-      try {
-        const url = new URL(value);
-        // Validate exact hostname to prevent bypass via subdomains
-        // e.g., hooks.slack.com.evil.com would fail
-        return url.protocol === 'https:' && url.hostname === 'hooks.slack.com';
-      } catch {
-        return false;
+const slackFormSchema = z
+  .object({
+    name: z.string().min(1, 'Name is required').max(255),
+    method: z.enum(['webhook', 'bot_token']),
+    // Webhook fields
+    webhook_url: z.string().optional(),
+    // Bot token fields
+    token: z.string().optional(),
+    channel: z.string().optional(),
+    username: z.string().optional(),
+    icon_emoji: z.string().optional(),
+    is_enabled: z.boolean(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.method === 'webhook') {
+      if (!data.webhook_url || data.webhook_url.trim() === '') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Webhook URL is required',
+          path: ['webhook_url'],
+        });
+      } else {
+        try {
+          const url = new URL(data.webhook_url);
+          if (url.protocol !== 'https:' || url.hostname !== 'hooks.slack.com') {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message:
+                'Must be a valid Slack webhook URL (https://hooks.slack.com/...)',
+              path: ['webhook_url'],
+            });
+          }
+        } catch {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Please enter a valid URL',
+            path: ['webhook_url'],
+          });
+        }
       }
-    }, 'Must be a valid Slack webhook URL (https://hooks.slack.com/...)'),
-  channel: z.string().optional(),
-  is_enabled: z.boolean(),
-});
+    } else if (data.method === 'bot_token') {
+      if (!data.token || data.token.trim() === '') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Bot token is required',
+          path: ['token'],
+        });
+      } else if (!data.token.startsWith('xoxb-')) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Bot token must start with xoxb-',
+          path: ['token'],
+        });
+      }
+      if (!data.channel || data.channel.trim() === '') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Channel is required for bot token method',
+          path: ['channel'],
+        });
+      }
+    }
+  });
 
 // Helper schema for email validation
 const emailAddressRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -128,6 +173,8 @@ const emailFormSchema = z.object({
 type WebhookFormData = z.infer<typeof webhookFormSchema>;
 type SlackFormData = z.infer<typeof slackFormSchema>;
 type EmailFormData = z.infer<typeof emailFormSchema>;
+
+type SlackMethod = 'webhook' | 'bot_token';
 
 interface AlertChannelsListProps {
   initialChannels: NotificationChannel[];
@@ -586,30 +633,50 @@ function SlackConfigDialog({
     resolver: zodResolver(slackFormSchema),
     defaultValues: {
       name: '',
+      method: 'webhook',
       webhook_url: '',
+      token: '',
       channel: '',
+      username: '',
+      icon_emoji: '',
       is_enabled: true,
     },
   });
+
+  const method = form.watch('method') as SlackMethod;
 
   // Reset form when dialog opens
   useEffect(() => {
     if (open && existingChannel) {
       const config = existingChannel.config as {
+        method?: SlackMethod;
         webhook_url?: string;
+        token?: string;
         channel?: string;
+        username?: string;
+        icon_emoji?: string;
       };
+      const existingMethod: SlackMethod = config.method ?? 'webhook';
       form.reset({
         name: existingChannel.name,
+        method: existingMethod,
         webhook_url: config.webhook_url ?? '',
+        // Never pre-fill the token (it is redacted on the server as "xoxb-****")
+        token: '',
         channel: config.channel ?? '',
+        username: config.username ?? '',
+        icon_emoji: config.icon_emoji ?? '',
         is_enabled: existingChannel.is_enabled,
       });
     } else if (open) {
       form.reset({
         name: '',
+        method: 'webhook',
         webhook_url: '',
+        token: '',
         channel: '',
+        username: '',
+        icon_emoji: '',
         is_enabled: true,
       });
     }
@@ -618,11 +685,21 @@ function SlackConfigDialog({
   const onSubmit = (data: SlackFormData) => {
     startTransition(async () => {
       try {
-        const config: Record<string, unknown> = {
-          webhook_url: data.webhook_url,
-        };
-        if (data.channel) {
-          config.channel = data.channel;
+        let config: Record<string, unknown>;
+
+        if (data.method === 'webhook') {
+          config = {
+            method: 'webhook',
+            webhook_url: data.webhook_url,
+          };
+        } else {
+          config = {
+            method: 'bot_token',
+            token: data.token,
+            channel: data.channel,
+          };
+          if (data.username) config.username = data.username;
+          if (data.icon_emoji) config.icon_emoji = data.icon_emoji;
         }
 
         if (existingChannel) {
@@ -659,12 +736,13 @@ function SlackConfigDialog({
             {existingChannel ? 'Edit Slack Integration' : 'Configure Slack'}
           </DialogTitle>
           <DialogDescription>
-            Send alerts to your Slack workspace using incoming webhooks.
+            Send alerts to your Slack workspace.
           </DialogDescription>
         </DialogHeader>
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            {/* Channel name */}
             <FormField
               control={form.control}
               name="name"
@@ -685,53 +763,134 @@ function SlackConfigDialog({
               )}
             />
 
+            {/* Method selector */}
             <FormField
               control={form.control}
-              name="webhook_url"
+              name="method"
               render={({ field }) => (
                 <FormItem>
                   <FormLabel className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
-                    Webhook URL
+                    Delivery Method
                   </FormLabel>
-                  <FormControl>
-                    <Input
-                      type="url"
-                      placeholder="https://hooks.slack.com/services/..."
+                  <div className="grid grid-cols-2 gap-2">
+                    <button
+                      type="button"
                       disabled={isLoading}
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Create an incoming webhook in your Slack app settings
-                  </FormDescription>
+                      onClick={() => field.onChange('webhook')}
+                      className={cn(
+                        'rounded-md border px-3 py-2 text-sm text-left transition-colors',
+                        field.value === 'webhook'
+                          ? 'border-primary bg-primary/10 text-primary font-semibold'
+                          : 'border-muted-foreground/30 hover:border-primary/50',
+                      )}
+                    >
+                      <div className="font-medium">Incoming Webhook</div>
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        Paste a webhook URL
+                      </div>
+                    </button>
+                    <button
+                      type="button"
+                      disabled={isLoading}
+                      onClick={() => field.onChange('bot_token')}
+                      className={cn(
+                        'rounded-md border px-3 py-2 text-sm text-left transition-colors',
+                        field.value === 'bot_token'
+                          ? 'border-primary bg-primary/10 text-primary font-semibold'
+                          : 'border-muted-foreground/30 hover:border-primary/50',
+                      )}
+                    >
+                      <div className="font-medium">Bot Token</div>
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        Use an xoxb- bot token
+                      </div>
+                    </button>
+                  </div>
                   <FormMessage />
                 </FormItem>
               )}
             />
 
-            <FormField
-              control={form.control}
-              name="channel"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
-                    Channel (optional)
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder="#alerts"
-                      disabled={isLoading}
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Override the default channel configured in Slack
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            {/* Webhook-specific fields */}
+            {method === 'webhook' && (
+              <FormField
+                control={form.control}
+                name="webhook_url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+                      Webhook URL
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="url"
+                        placeholder="https://hooks.slack.com/services/..."
+                        disabled={isLoading}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Create an incoming webhook in your Slack app settings
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
 
+            {/* Bot token-specific fields */}
+            {method === 'bot_token' && (
+              <>
+                <FormField
+                  control={form.control}
+                  name="token"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+                        Bot Token
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          type="password"
+                          placeholder="xoxb-..."
+                          disabled={isLoading}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        OAuth bot token starting with xoxb- from your Slack app
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="channel"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+                        Channel
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="#alerts or C1234567890"
+                          disabled={isLoading}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Channel name or ID where alerts will be posted
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
+
+            {/* Enabled toggle */}
             <FormField
               control={form.control}
               name="is_enabled"


### PR DESCRIPTION
## Summary

- **Bug fix:** The existing `channel`, `username`, and `icon_emoji` fields in the Slack webhook config were silently ignored by Slack — modern app-based webhooks cannot override channel or identity at runtime. These fields have been removed from the webhook form to stop misleading users.
- **New method:** Bot Token (`xoxb-…`) via `chat.postMessage` — supports dynamic channel targeting with a single token, optional `username`/`icon_emoji` customization, and friendly error mapping for common Slack API errors.
- **Security:** Bot tokens are redacted as `xoxb-****` in all API list/get responses to prevent credential exposure.

## Changes

| Layer | Change |
|---|---|
| DB migration | Backfills `"method":"webhook"` on existing Slack channel configs (postgres + sqlite) |
| `models/alert.rs` | `SlackConfig` struct → `#[serde(tag = "method")]` enum with `Webhook` and `BotToken` variants |
| `services/notification/slack.rs` | Handles both send paths; removes broken channel override from webhook; maps Slack API errors |
| `routes/alerts.rs` | Redacts `xoxb-…` token in channel responses |
| `alert-channels-list.tsx` | Method selector UI with conditional fields per method; `superRefine` validation |

## Test plan

- [ ] `cargo test` — 266 passed, 0 failed
- [ ] `cargo build --features postgres` — clean
- [ ] `pnpm tsc --noEmit` (webview-ui) — 0 errors
- [ ] `pnpm test` (packages/client) — 268 passed, 0 failed
- [ ] Existing Slack channels continue working after migration (method field backfilled)
- [ ] New webhook channel: channel field no longer shown in UI
- [ ] New bot token channel: token + channel fields shown, `xoxb-` prefix enforced
- [ ] `GET /api/notification-channels` returns `"token": "xoxb-****"` for bot token channels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Slack "method" with webhook or bot-token delivery; UI lets you choose and shows method-specific fields
  * Bot-token delivery supports channel plus optional username and emoji formatting
  * API responses redact bot tokens for security

* **Bug Fixes / Validation**
  * Enforce webhook URL and bot-token format (e.g., token prefix) with clearer validation errors

* **Chores**
  * Existing Slack configs backfilled to default to webhook when missing method

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbianS/rustrak/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->