### PR TITLE
feat(mcp): add @rustrak/mcp — MCP server for AI-assisted error management

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["@rustrak/test-sentry"]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,7 @@ permissions:
   packages: write
   pages: write
   id-token: write
+  # id-token: write is also required for npm provenance attestation
 
 jobs:
   detect-package:
@@ -17,6 +18,8 @@ jobs:
       is_server: ${{ steps.check.outputs.is_server }}
       is_ui: ${{ steps.check.outputs.is_ui }}
       is_docs: ${{ steps.check.outputs.is_docs }}
+      is_npm_client: ${{ steps.check.outputs.is_npm_client }}
+      is_npm_mcp: ${{ steps.check.outputs.is_npm_mcp }}
       version: ${{ steps.check.outputs.version }}
     steps:
       - name: Detect package from release tag
@@ -48,6 +51,18 @@ jobs:
             echo "is_docs=true" >> $GITHUB_OUTPUT
           else
             echo "is_docs=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$TAG" == "@rustrak/client@"* ]]; then
+            echo "is_npm_client=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_npm_client=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$TAG" == "@rustrak/mcp@"* ]]; then
+            echo "is_npm_mcp=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_npm_mcp=false" >> $GITHUB_OUTPUT
           fi
 
   # ── SQLite image (default: latest) ───────────────────────────────────────────
@@ -343,3 +358,41 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
+  # ── npm publish ───────────────────────────────────────────────────────────────
+
+  publish-npm:
+    needs: detect-package
+    if: needs.detect-package.outputs.is_npm_client == 'true' || needs.detect-package.outputs.is_npm_mcp == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "latest"
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build @rustrak/client
+        if: needs.detect-package.outputs.is_npm_client == 'true'
+        run: pnpm --filter @rustrak/client build
+
+      - name: Build @rustrak/mcp
+        if: needs.detect-package.outputs.is_npm_mcp == 'true'
+        run: pnpm --filter @rustrak/client build && pnpm --filter @rustrak/mcp build
+
+      - name: Publish @rustrak/client
+        if: needs.detect-package.outputs.is_npm_client == 'true'
+        run: pnpm --filter @rustrak/client publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @rustrak/mcp
+        if: needs.detect-package.outputs.is_npm_mcp == 'true'
+        run: pnpm --filter @rustrak/mcp publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,5 +122,20 @@ jobs:
           else
             echo "Tag $CLIENT_TAG already exists, skipping"
           fi
+
+          # MCP
+          MCP_VERSION=$(node -p "require('./packages/mcp/package.json').version")
+          MCP_TAG="@rustrak/mcp@$MCP_VERSION"
+          if ! git tag -l | grep -q "^$MCP_TAG$"; then
+            echo "Creating release for $MCP_TAG"
+            git tag "$MCP_TAG"
+            git push origin "$MCP_TAG"
+            gh release create "$MCP_TAG" \
+              --title "🤖 @rustrak/mcp v$MCP_VERSION" \
+              --notes "Release of @rustrak/mcp version $MCP_VERSION" \
+              --latest=false
+          else
+            echo "Tag $MCP_TAG already exists, skipping"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/_bmad-output/implementation-artifacts/spec-mcp-package.md
+++ b/_bmad-output/implementation-artifacts/spec-mcp-package.md
@@ -1,0 +1,129 @@
+---
+title: 'Rustrak MCP Server Package'
+type: 'feature'
+created: '2026-05-17'
+status: 'in-review'
+baseline_commit: '7fd41b8669b24e57582673c4502c52662482b085'
+context:
+  - '_bmad-output/project-context.md'
+  - '.claude/skills/tdd/SKILL.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** There is no way for an AI (Claude Desktop, Cursor, etc.) to manage Rustrak errors directly — the dashboard must be opened manually to view issues, resolve them, or create projects.
+
+**Approach:** Create the `packages/mcp` package (`@rustrak/mcp`) — a TypeScript MCP server that wraps `@rustrak/client` and exposes ~18 tools so AI can list projects, inspect issues, view events, resolve errors, and manage tokens, all via stdio transport.
+
+## Boundaries & Constraints
+
+**Always:**
+- Implement with strict TDD using the `.claude/skills/tdd` skill: write the test first (red), then the minimum code to pass (green), then refactor. Never write implementation code without a failing test first.
+- Vitest must be fully configured in `packages/mcp/vitest.config.ts` with ESM support (`pool: 'forks'` or equivalent for Node ESM), and tests must run with `pnpm test` from the package before writing any implementation.
+- Transport: stdio only (this phase). `console.log` FORBIDDEN — corrupts JSON-RPC. Use only `console.error`.
+- Auth: `RUSTRAK_API_URL` + `RUSTRAK_API_TOKEN` from env vars. Never as tool arguments. Fail at startup if missing.
+- Errors: return `{ isError: true, content }` — do NOT throw. The LLM must be able to see and handle the error.
+- Zod: the SDK accepts Standard Schema (v1.10+). Use `zod` v4 from the workspace (same version as the rest of the project). Do NOT install Zod v3.
+- Build: tsup with ESM output. `"type": "module"` in package.json. Entry `bin: { "rustrak-mcp": "./dist/index.js" }`.
+- Follow project conventions: kebab-case for files, Biome for lint/format.
+
+**Ask First:**
+- If during implementation `@modelcontextprotocol/sdk` does NOT support Zod v4 via Standard Schema, HALT — need to decide whether to use Zod v3 as an isolated dep or find an alternative.
+
+**Never:**
+- Changes to the webview-ui or Rust server.
+- HTTP transport (out of scope this phase).
+- MCP Resources (tools only this phase).
+- Adding business logic that does not already exist in `@rustrak/client`.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| list_issues happy path | `project_id: 1` | JSON with `{ items: [...], total: N }` in `content[0].text` | N/A |
+| resolve_issue success | `project_id: 1, issue_id: "<uuid>"` | JSON with updated issue, `is_resolved: true` | N/A |
+| Tool call → API 404 | non-existent issue_id | `isError: true`, message "Not found: ..." | No throw |
+| Tool call → API 429 | Rate limit exceeded | `isError: true`, message with retry-after | No throw |
+| Startup without token | `RUSTRAK_API_TOKEN` not in env | `console.error` + `process.exit(1)` | Fail fast |
+| delete_issue called | `project_id, issue_id` | Void — returns message "Issue deleted successfully" | isError on failure |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `packages/client/src/client.ts` -- `RustrakClient` + `ClientConfig` — inject into server factory
+- `packages/client/src/errors/index.ts` -- error classes for `toMcpError()`: `NotFoundError`, `RateLimitError`, `AuthenticationError`, `RustrakError`, etc.
+- `packages/client/src/resources/issues.ts` -- `list(projectId, opts?)`, `get(projectId, issueId)`, `updateState(projectId, issueId, state)`, `delete(projectId, issueId)`
+- `packages/client/src/resources/projects.ts` -- `list(opts?)`, `get(id)`, `create(input)`, `update(id, input)`
+- `packages/client/src/resources/events.ts` -- `list(projectId, issueId, opts?)`, `get(projectId, issueId, eventId)`
+- `packages/client/src/resources/tokens.ts` -- `list()`, `create(input)`, `delete(id)`
+- `packages/client/src/resources/alert-channels.ts` -- `list()`, `test(id)`
+- `packages/client/src/resources/alert-rules.ts` -- `list(projectId)`
+- `turbo.json` -- `packages/mcp` covered by existing `packages/*` glob, no changes needed
+- `pnpm-workspace.yaml` -- already includes `packages/*`, no changes needed
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `packages/mcp/package.json` -- created with deps `@modelcontextprotocol/sdk ^1.29.0`, `@rustrak/client workspace:*`, `zod ^4.3.6`; devdeps `tsup`, `typescript`, `vitest`; scripts `build`, `test`, `typecheck`; `bin: { rustrak-mcp: ./dist/index.js }`; `"type": "module"`
+- [x] `packages/mcp/tsconfig.json` -- `target: ES2022`, `module: NodeNext`, `moduleResolution: NodeNext`, `strict: true`, `outDir: ./dist`
+- [x] `packages/mcp/tsup.config.ts` -- entry `src/index.ts`, format `esm`, `dts: false`, `shims: true`
+- [x] `packages/mcp/vitest.config.ts` -- vitest config with ESM support: `pool: 'forks'`, `environment: 'node'`, glob `tests/**/*.test.ts`
+- [x] `packages/mcp/src/config.ts` -- `loadConfig()`: validates `RUSTRAK_API_URL` and `RUSTRAK_API_TOKEN`; throws on missing → `process.exit(1)` in entry point
+- [x] `packages/mcp/src/errors.ts` -- `toMcpError(err: unknown)`: maps `@rustrak/client` error classes to `{ content: [{ type: 'text', text }], isError: true }`. Sanitized — never exposes stack traces.
+- [x] `packages/mcp/src/tools/projects.ts` -- registers: `list_projects`, `get_project`, `create_project`
+- [x] `packages/mcp/src/tools/issues.ts` -- registers: `list_issues`, `get_issue`, `resolve_issue`, `unresolve_issue`, `mute_issue`, `delete_issue` (with `destructiveHint: true`)
+- [x] `packages/mcp/src/tools/events.ts` -- registers: `list_events`, `get_event`
+- [x] `packages/mcp/src/tools/tokens.ts` -- registers: `list_tokens`, `create_token`, `revoke_token` (with `destructiveHint: true`)
+- [x] `packages/mcp/src/tools/alerts.ts` -- registers: `list_alert_channels`, `test_alert_channel`, `list_alert_rules`
+- [x] `packages/mcp/src/server.ts` -- `createServer(client: RustrakClient): McpServer` — calls all `register*Tools()`; exported for testing
+- [x] `packages/mcp/src/index.ts` -- entry: `loadConfig()` → create `RustrakClient` → `createServer()` → `StdioServerTransport` → `server.connect(transport)`. Only `console.error` for logs.
+- [x] `packages/mcp/tests/setup.ts` -- `createTestEnv(mockClient)`: creates server + `InMemoryTransport.createLinkedPair()` + `Client`; connects both; returns `{ mcpClient, callTool }` with typed wrapper
+- [x] `packages/mcp/tests/tools/issues.test.ts` -- covers: list_issues happy path, resolve_issue happy path, 404 → isError, 429 → isError with retry-after
+- [x] `packages/mcp/tests/tools/projects.test.ts` -- covers: list_projects happy path, create_project happy path
+- [x] `packages/mcp/tests/integration/server.test.ts` -- `mcpClient.listTools()` returns all 18 expected tools; destructiveHint verified on delete_issue / revoke_token
+
+**Acceptance Criteria:**
+- Given `RUSTRAK_API_TOKEN` missing from env, when server starts, then `process.exit(1)` is called with error message on stderr
+- Given `list_issues` called with valid `project_id`, when client returns data, then `result.isError` is falsy and `result.content[0].text` is parseable JSON with `items` field
+- Given any tool when API returns `NotFoundError`, then `result.isError === true` and text contains no stack trace or internal paths
+- Given `delete_issue` registered, when client lists tools via `mcpClient.listTools()`, then the tool appears with `destructiveHint: true` annotation
+- Given `pnpm build --filter @rustrak/mcp`, when tsup compiles, then `dist/index.js` exists and is executable
+- Given `pnpm test --filter @rustrak/mcp`, when vitest runs, then all 33 tests pass with no type errors
+
+## Design Notes
+
+**Server factory pattern:** `createServer(client)` receives the injected `RustrakClient` — does not create it internally. Decouples config from server and makes testing trivial with a mock.
+
+**Tool registration:** each `src/tools/*.ts` file exports a `register*Tools(server, client)` function. `server.ts` calls all of them. Avoids a monolithic `server.ts`.
+
+**`server.tool()` vs `server.registerTool()`:** all `server.tool()` overloads are deprecated in SDK v1.29.0. Use `server.registerTool(name, { description, inputSchema, annotations? }, handler)` exclusively.
+
+**Test typed wrapper:** `callTool` in `tests/setup.ts` wraps `mcpClient.callTool()` with `as Promise<McpToolResult>` to bypass the `[x: string]: unknown` index signature on the SDK return type, giving test files clean access to `result.content` and `result.isError`.
+
+**Error translation:**
+```typescript
+export function toMcpError(err: unknown) {
+  if (err instanceof NotFoundError)
+    return { content: [{ type: 'text' as const, text: `Not found: ${err.message}` }], isError: true };
+  if (err instanceof RateLimitError)
+    return { content: [{ type: 'text' as const, text: `Rate limited. Retry after: ${err.retryAfter ?? '?'}s` }], isError: true };
+  return { content: [{ type: 'text' as const, text: `Unexpected error: ${String(err)}` }], isError: true };
+}
+```
+
+## Verification
+
+**Commands:**
+- `pnpm --filter @rustrak/mcp build` -- expected: exits 0, `packages/mcp/dist/index.js` exists (11.84 KB ESM)
+- `pnpm --filter @rustrak/mcp test` -- expected: 33 tests pass, 8 test files, 0 failures
+- `pnpm --filter @rustrak/mcp typecheck` -- expected: 0 TypeScript errors
+- `pnpm --filter @rustrak/mcp lint` -- expected: Biome 0 errors or warnings
+
+## Spec Change Log
+
+- **2026-05-17**: Discovered `server.tool()` is fully deprecated in SDK v1.29.0. Migrated all tool registrations to `server.registerTool()`. Config object form `{ description, inputSchema, annotations }` is the correct non-deprecated API.
+- **2026-05-17**: Added `callTool` typed wrapper to `tests/setup.ts` to resolve `result.content is unknown` TS errors caused by the SDK's `[x: string]: unknown` index signature on `callTool` return type.
+- **2026-05-17**: Spec translated to English and status set to `in-review`.

--- a/apps/server/src/routes/alerts.rs
+++ b/apps/server/src/routes/alerts.rs
@@ -22,7 +22,7 @@ use actix_web::{web, HttpResponse};
 use chrono::Utc;
 use serde::Deserialize;
 
-use crate::auth::AuthenticatedUser;
+use crate::auth::ApiAuth;
 use crate::db::DbPool;
 use crate::error::AppResult;
 use crate::models::ChannelType;
@@ -86,7 +86,7 @@ fn channel_to_safe_json(channel: &crate::models::NotificationChannel) -> serde_j
 /// GET /api/alert-channels
 pub async fn list_channels(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
 ) -> AppResult<HttpResponse> {
     let channels = AlertService::list_channels(pool.get_ref()).await?;
     let safe: Vec<serde_json::Value> = channels.iter().map(channel_to_safe_json).collect();
@@ -107,7 +107,7 @@ pub async fn list_channels(
 /// POST /api/alert-channels
 pub async fn create_channel(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     body: web::Json<CreateNotificationChannel>,
 ) -> AppResult<HttpResponse> {
     let channel = AlertService::create_channel(pool.get_ref(), body.into_inner()).await?;
@@ -129,7 +129,7 @@ pub async fn create_channel(
 /// GET /api/alert-channels/{id}
 pub async fn get_channel(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     path: web::Path<i32>,
 ) -> AppResult<HttpResponse> {
     let channel = AlertService::get_channel(pool.get_ref(), path.into_inner()).await?;
@@ -152,7 +152,7 @@ pub async fn get_channel(
 /// PATCH /api/alert-channels/{id}
 pub async fn update_channel(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     path: web::Path<i32>,
     body: web::Json<UpdateNotificationChannel>,
 ) -> AppResult<HttpResponse> {
@@ -176,7 +176,7 @@ pub async fn update_channel(
 /// DELETE /api/alert-channels/{id}
 pub async fn delete_channel(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     path: web::Path<i32>,
 ) -> AppResult<HttpResponse> {
     AlertService::delete_channel(pool.get_ref(), path.into_inner()).await?;
@@ -198,7 +198,7 @@ pub async fn delete_channel(
 /// POST /api/alert-channels/{id}/test
 pub async fn test_channel(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     path: web::Path<i32>,
 ) -> AppResult<HttpResponse> {
     let channel = AlertService::get_channel(pool.get_ref(), path.into_inner()).await?;
@@ -262,7 +262,7 @@ pub async fn test_channel(
 /// GET /api/projects/{project_id}/alert-rules
 pub async fn list_rules(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     path: web::Path<i32>,
 ) -> AppResult<HttpResponse> {
     let project_id = path.into_inner();
@@ -298,7 +298,7 @@ pub async fn list_rules(
 /// POST /api/projects/{project_id}/alert-rules
 pub async fn create_rule(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     path: web::Path<i32>,
     body: web::Json<CreateAlertRule>,
 ) -> AppResult<HttpResponse> {
@@ -337,7 +337,7 @@ pub struct RulePath {
 /// GET /api/projects/{project_id}/alert-rules/{rule_id}
 pub async fn get_rule(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     path: web::Path<RulePath>,
 ) -> AppResult<HttpResponse> {
     let params = path.into_inner();
@@ -378,7 +378,7 @@ pub async fn get_rule(
 /// PATCH /api/projects/{project_id}/alert-rules/{rule_id}
 pub async fn update_rule(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     path: web::Path<RulePath>,
     body: web::Json<UpdateAlertRule>,
 ) -> AppResult<HttpResponse> {
@@ -419,7 +419,7 @@ pub async fn update_rule(
 /// DELETE /api/projects/{project_id}/alert-rules/{rule_id}
 pub async fn delete_rule(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     path: web::Path<RulePath>,
 ) -> AppResult<HttpResponse> {
     let params = path.into_inner();
@@ -472,7 +472,7 @@ fn default_limit() -> i64 {
 /// GET /api/projects/{project_id}/alert-history
 pub async fn list_history(
     pool: web::Data<DbPool>,
-    _user: AuthenticatedUser,
+    _auth: ApiAuth,
     path: web::Path<i32>,
     query: web::Query<HistoryQuery>,
 ) -> AppResult<HttpResponse> {

--- a/apps/server/src/routes/alerts.rs
+++ b/apps/server/src/routes/alerts.rs
@@ -84,10 +84,7 @@ fn channel_to_safe_json(channel: &crate::models::NotificationChannel) -> serde_j
     security(("bearer_auth" = [])),
 ))]
 /// GET /api/alert-channels
-pub async fn list_channels(
-    pool: web::Data<DbPool>,
-    _auth: ApiAuth,
-) -> AppResult<HttpResponse> {
+pub async fn list_channels(pool: web::Data<DbPool>, _auth: ApiAuth) -> AppResult<HttpResponse> {
     let channels = AlertService::list_channels(pool.get_ref()).await?;
     let safe: Vec<serde_json::Value> = channels.iter().map(channel_to_safe_json).collect();
     Ok(HttpResponse::Ok().json(safe))

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,8 +1,10 @@
 {
   "name": "@rustrak/client",
   "version": "0.1.1",
-  "private": true,
   "description": "TypeScript client for Rustrak API",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -1,0 +1,350 @@
+# Rustrak MCP - Model Context Protocol Server
+
+> **Context Note**: This is the **MCP package context** for Rustrak.
+> - Root context: `/CLAUDE.md`
+> - Server API: `apps/server/CLAUDE.md`
+> - WebView UI: `apps/webview-ui/CLAUDE.md`
+> - Client Package: `packages/client/CLAUDE.md`
+
+## Overview
+
+`@rustrak/mcp` is an MCP (Model Context Protocol) server that wraps `@rustrak/client` and exposes 18 tools so AI assistants (Claude Desktop, Cursor, etc.) can manage Rustrak error tracking directly — list projects, inspect issues, view stack traces, resolve errors, and manage tokens without leaving the AI tool.
+
+**Key Features:**
+- 18 tools covering projects, issues, events, tokens, and alert channels
+- stdio transport — runs as a local process, no network port needed
+- Secure — API token loaded from env vars, never passed as a tool argument
+- Safe destructive actions — `delete_issue` and `revoke_token` annotated with `destructiveHint`
+- Graceful errors — all API errors returned as `isError: true` content, never thrown
+
+## Architecture
+
+```
+AI Client (Claude Desktop / Cursor / Claude Code)
+        │  stdio (JSON-RPC)
+        ▼
+┌─────────────────────┐
+│   @rustrak/mcp      │
+│   McpServer         │
+│   ├── projects      │  ← registerProjectTools()
+│   ├── issues        │  ← registerIssueTools()
+│   ├── events        │  ← registerEventTools()
+│   ├── tokens        │  ← registerTokenTools()
+│   └── alerts        │  ← registerAlertTools()
+└──────────┬──────────┘
+           │  HTTP (Bearer token)
+           ▼
+┌─────────────────────┐
+│   @rustrak/client   │  ← RustrakClient (injected)
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│   Rustrak Server    │
+│   (Rust/Actix-web)  │
+└─────────────────────┘
+```
+
+## Tech Stack
+
+- **MCP SDK**: [@modelcontextprotocol/sdk](https://github.com/modelcontextprotocol/typescript-sdk) v1.29.0
+- **Validation**: [Zod](https://zod.dev) v4+ (Standard Schema — compatible with SDK v1.10+)
+- **Client**: `@rustrak/client` workspace package
+- **Build Tool**: [tsup](https://tsup.egoist.dev) (ESM output, `"type": "module"`)
+- **Testing**: [Vitest](https://vitest.dev) + `InMemoryTransport` (in-process, no subprocess)
+- **TypeScript**: v5.9+ (strict mode, NodeNext module resolution)
+
+## Project Structure
+
+```
+packages/mcp/
+├── CLAUDE.md              # This file
+├── README.md              # Usage and quick-start documentation
+├── package.json           # @rustrak/mcp (type: module, bin: rustrak-mcp)
+├── tsconfig.json          # Strict TypeScript, NodeNext module resolution
+├── tsup.config.ts         # ESM-only build, entry: src/index.ts
+├── vitest.config.ts       # pool: forks (ESM support), tests/**/*.test.ts
+│
+├── src/
+│   ├── index.ts           # Entry: loadConfig → RustrakClient → server → stdio
+│   ├── server.ts          # createServer(client): McpServer — factory, exported for testing
+│   ├── config.ts          # loadConfig(): validates RUSTRAK_API_URL + RUSTRAK_API_TOKEN
+│   ├── errors.ts          # toMcpError(err): maps client errors → { isError, content }
+│   │
+│   └── tools/
+│       ├── projects.ts    # list_projects, get_project, create_project
+│       ├── issues.ts      # list_issues, get_issue, resolve_issue, unresolve_issue, mute_issue, delete_issue
+│       ├── events.ts      # list_events, get_event
+│       ├── tokens.ts      # list_tokens, create_token, revoke_token
+│       └── alerts.ts      # list_alert_channels, test_alert_channel, list_alert_rules
+│
+├── tests/
+│   ├── setup.ts           # createTestEnv(mockClient): typed callTool wrapper
+│   ├── config.test.ts     # loadConfig env var validation
+│   │
+│   ├── tools/
+│   │   ├── projects.test.ts
+│   │   ├── issues.test.ts
+│   │   ├── events.test.ts
+│   │   ├── tokens.test.ts
+│   │   └── alerts.test.ts
+│   │
+│   └── integration/
+│       └── server.test.ts # listTools() → 18 tools, destructiveHint verified
+│
+└── dist/                  # Build output (ESM only)
+    └── index.js           # Executable MCP server (~12KB)
+```
+
+## Design Patterns
+
+### 1. Server Factory Pattern
+
+`createServer(client)` receives the injected `RustrakClient` — does not create it internally. This decouples configuration from the server and makes testing trivial.
+
+```typescript
+// src/server.ts
+export function createServer(client: RustrakClient): McpServer {
+  const server = new McpServer({ name: 'rustrak-mcp-server', version: '0.1.0' });
+  registerProjectTools(server, client);
+  registerIssueTools(server, client);
+  registerEventTools(server, client);
+  registerTokenTools(server, client);
+  registerAlertTools(server, client);
+  return server;
+}
+```
+
+**Why factory pattern?**
+- Decouples env config from server construction
+- `createServer(mockClient)` in tests — no real HTTP calls
+- Each tool file is independently testable
+
+### 2. Tool Registration Per File
+
+Each `src/tools/*.ts` file exports one `register*Tools(server, client)` function. No monolithic `server.ts`.
+
+```typescript
+// src/tools/issues.ts
+export function registerIssueTools(server: McpServer, client: RustrakClient) {
+  server.registerTool(
+    'list_issues',
+    {
+      description: 'List issues for a project.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        status: z.enum(['open', 'resolved', 'muted', 'all']).optional(),
+      },
+    },
+    async ({ project_id, status }) => {
+      try {
+        const result = await client.issues.list(project_id, { status });
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+}
+```
+
+**CRITICAL**: Always use `server.registerTool()`. All `server.tool()` overloads are deprecated in SDK v1.29.0.
+
+### 3. Error Translation (`toMcpError`)
+
+Tool handlers never throw. API errors are caught and returned as `isError: true` content so the LLM can see and handle the error.
+
+```typescript
+// src/errors.ts
+export function toMcpError(err: unknown) {
+  if (err instanceof NotFoundError)
+    return { content: [{ type: 'text' as const, text: `Not found: ${err.message}` }], isError: true };
+  if (err instanceof RateLimitError)
+    return { content: [{ type: 'text' as const, text: `Rate limited. Retry after: ${err.retryAfter ?? '?'}s` }], isError: true };
+  if (err instanceof AuthenticationError)
+    return { content: [{ type: 'text' as const, text: 'Authentication failed. Check RUSTRAK_API_TOKEN.' }], isError: true };
+  return { content: [{ type: 'text' as const, text: `Unexpected error: ${String(err)}` }], isError: true };
+}
+```
+
+**Rules:**
+- Never expose stack traces or internal paths in error text
+- Map every known `@rustrak/client` error class explicitly
+- Fall through to `String(err)` for unknown errors
+
+### 4. Destructive Tool Annotations
+
+Tools that permanently delete data are annotated with `destructiveHint: true`. Supported MCP clients will prompt for confirmation before executing.
+
+```typescript
+server.registerTool(
+  'delete_issue',
+  {
+    description: 'Permanently delete an issue and all its events.',
+    inputSchema: {
+      project_id: z.number().int().describe('Project ID'),
+      issue_id: z.string().describe('Issue ID'),
+    },
+    annotations: { destructiveHint: true },
+  },
+  async ({ project_id, issue_id }) => { ... },
+);
+```
+
+Destructive tools: `delete_issue`, `revoke_token`.
+
+### 5. Typed Test Wrapper (`callTool`)
+
+`mcpClient.callTool()` returns `{ [x: string]: unknown }` — the index signature makes `content` and `isError` unknown. The test setup uses a typed cast to fix this cleanly across all tests.
+
+```typescript
+// tests/setup.ts
+export type McpTextContent = { type: 'text'; text: string };
+export type McpToolResult = { isError?: boolean; content: McpTextContent[] };
+
+export async function createTestEnv(mockClient: unknown) {
+  const server = createServer(mockClient as never);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const mcpClient = new Client({ name: 'test', version: '1.0.0' });
+  await server.connect(serverTransport);
+  await mcpClient.connect(clientTransport);
+  const callTool = (params: Parameters<typeof mcpClient.callTool>[0]): Promise<McpToolResult> =>
+    mcpClient.callTool(params) as Promise<McpToolResult>;
+  return { mcpClient, server, callTool };
+}
+```
+
+**Usage in tests:**
+```typescript
+let callTool: Awaited<ReturnType<typeof createTestEnv>>['callTool'];
+
+beforeEach(async () => {
+  testEnv = await createTestEnv(mockClient);
+  callTool = testEnv.callTool;
+});
+
+it('returns issues', async () => {
+  const result = await callTool({ name: 'list_issues', arguments: { project_id: 1 } });
+  expect(result.isError).toBeFalsy();
+  const parsed = JSON.parse(result.content[0].text);
+  expect(parsed.items).toBeDefined();
+});
+```
+
+## Key Rules for Agents
+
+**stdio transport:**
+- `console.log` is **FORBIDDEN** — corrupts the JSON-RPC stream
+- Only `console.error` for diagnostic output (goes to stderr, not stdout)
+
+**Auth:**
+- Credentials come from `RUSTRAK_API_URL` and `RUSTRAK_API_TOKEN` env vars only
+- Never accept tokens as tool arguments
+- `loadConfig()` exits with `process.exit(1)` if env vars are missing
+
+**Tool registration:**
+- Always `server.registerTool()` — never `server.tool()`
+- Input schema uses Zod v4 objects (Standard Schema)
+- Annotations go in the second argument: `{ description, inputSchema, annotations? }`
+
+**Error handling:**
+- Every tool handler must have a `try/catch` that calls `toMcpError(err)`
+- Never `throw` from a tool handler
+
+**Adding a new tool:**
+1. Add handler to the appropriate `src/tools/*.ts` file
+2. Write a failing test first (TDD — see `.claude/skills/tdd`)
+3. Implement the minimum code to pass
+4. Verify `mcpClient.listTools()` includes the new tool in `tests/integration/server.test.ts`
+
+## Testing
+
+### Running Tests
+
+```bash
+# Run all tests (33 tests)
+pnpm test
+
+# Watch mode
+pnpm dev
+
+# Type check
+pnpm typecheck
+```
+
+### Test Coverage
+
+- **Config tests** (3 tests): missing URL, missing token, both present
+- **Tool tests** (25 tests): happy path + error cases for all 5 tool groups
+- **Integration tests** (5 tests): `listTools()` returns all 18 tools, `destructiveHint` on delete/revoke
+
+### InMemoryTransport
+
+Tests use `InMemoryTransport.createLinkedPair()` — in-process, no subprocess, no real network. Fast and deterministic.
+
+```typescript
+const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+await server.connect(serverTransport);
+await mcpClient.connect(clientTransport);
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `RUSTRAK_API_TOKEN` | Yes | — | 40-char hex API token. Server exits if missing. |
+| `RUSTRAK_API_URL` | No | `http://localhost:8080` | Base URL of your Rustrak server. |
+
+### Local Development (.mcp.json)
+
+The repo root `.mcp.json` is picked up by Claude Code automatically:
+
+```json
+{
+  "mcpServers": {
+    "rustrak": {
+      "command": "node",
+      "args": ["packages/mcp/dist/index.js"],
+      "env": {
+        "RUSTRAK_API_URL": "http://localhost:8080",
+        "RUSTRAK_API_TOKEN": "<your-token>"
+      }
+    }
+  }
+}
+```
+
+Build before connecting: `pnpm --filter @rustrak/mcp build`
+
+## Development
+
+### Building
+
+```bash
+pnpm build
+# Outputs: dist/index.js (ESM, ~12KB)
+```
+
+### Adding a New Tool Group
+
+1. Create `src/tools/new-group.ts` with `registerNewGroupTools(server, client)`
+2. Import and call it in `src/server.ts`
+3. Create `tests/tools/new-group.test.ts` (TDD — test first)
+4. Update the tool count in `tests/integration/server.test.ts`
+
+## Skills to Use
+
+When working on this package:
+- **tdd** — Write failing test first, then minimum implementation, then refactor
+- **typescript-strict** — Type-safe patterns, Zod usage
+- **rust-coder** — When understanding the server API to add new tools
+
+## References
+
+- **MCP TypeScript SDK**: https://github.com/modelcontextprotocol/typescript-sdk
+- **MCP Specification**: https://modelcontextprotocol.io
+- **Client Package**: `packages/client/CLAUDE.md`
+- **TDD Skill**: `.claude/skills/tdd/SKILL.md`
+- **Spec**: `_bmad-output/implementation-artifacts/spec-mcp-package.md`

--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -295,7 +295,7 @@ await mcpClient.connect(clientTransport);
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `RUSTRAK_API_TOKEN` | Yes | — | 40-char hex API token. Server exits if missing. |
-| `RUSTRAK_API_URL` | No | `http://localhost:8080` | Base URL of your Rustrak server. |
+| `RUSTRAK_API_URL` | Yes | — | Base URL of your Rustrak server. Server exits if missing. |
 
 ### Local Development (.mcp.json)
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,158 @@
+# @rustrak/mcp
+
+MCP (Model Context Protocol) server for Rustrak. Lets AI assistants (Claude Desktop, Cursor, etc.) manage your error tracking directly — list projects, inspect issues, view stack traces, resolve errors, and manage tokens without leaving your AI tool.
+
+## Features
+
+- **18 tools** covering projects, issues, events, tokens, and alert channels
+- **stdio transport** — runs as a local process, no network port needed
+- **Secure** — API token loaded from env vars, never passed as tool argument
+- **Safe destructive actions** — `delete_issue` and `revoke_token` annotated with `destructiveHint`
+- **Graceful errors** — all API errors returned as `isError: true` content, never thrown
+
+## Quick Start
+
+### 1. Generate an API token
+
+In the Rustrak web UI: **Settings → Tokens → Create token**. Save the full token value — it is shown only once.
+
+### 2. Configure in Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "rustrak": {
+      "command": "npx",
+      "args": ["-y", "@rustrak/mcp"],
+      "env": {
+        "RUSTRAK_API_URL": "https://your-rustrak-instance.example.com",
+        "RUSTRAK_API_TOKEN": "your-40-char-hex-token"
+      }
+    }
+  }
+}
+```
+
+### 3. Local monorepo (development)
+
+Build first, then configure with a `node` command pointing to the dist:
+
+```json
+{
+  "mcpServers": {
+    "rustrak": {
+      "command": "node",
+      "args": ["packages/mcp/dist/index.js"],
+      "env": {
+        "RUSTRAK_API_URL": "http://localhost:8080",
+        "RUSTRAK_API_TOKEN": "your-40-char-hex-token"
+      }
+    }
+  }
+}
+```
+
+Or use the project-level `.mcp.json` at the repo root (Claude Code picks this up automatically).
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `RUSTRAK_API_TOKEN` | ✅ | — | 40-char hex API token. Server exits if missing. |
+| `RUSTRAK_API_URL` | — | `http://localhost:8080` | Base URL of your Rustrak server. |
+
+## Available Tools
+
+### Projects
+| Tool | Description |
+|------|-------------|
+| `list_projects` | List all projects |
+| `get_project` | Get project details including DSN |
+| `create_project` | Create a new project |
+
+### Issues
+| Tool | Description |
+|------|-------------|
+| `list_issues` | List issues with filters (open / resolved / muted / all) |
+| `get_issue` | Get a single issue with full details |
+| `resolve_issue` | Mark an issue as resolved |
+| `unresolve_issue` | Re-open a resolved issue |
+| `mute_issue` | Mute an issue (silences alerts) |
+| `delete_issue` | ⚠️ Permanently delete an issue and all its events |
+
+### Events
+| Tool | Description |
+|------|-------------|
+| `list_events` | List raw events for an issue (cursor pagination) |
+| `get_event` | Get a single event with full Sentry envelope data |
+
+### Tokens
+| Tool | Description |
+|------|-------------|
+| `list_tokens` | List API tokens (masked) |
+| `create_token` | Create a new API token (full value shown once) |
+| `revoke_token` | ⚠️ Permanently revoke an API token |
+
+### Alerts
+| Tool | Description |
+|------|-------------|
+| `list_alert_channels` | List notification channels (Slack, email, webhook) |
+| `test_alert_channel` | Send a test notification to a channel |
+| `list_alert_rules` | List alert rules for a project |
+
+> ⚠️ Tools marked as destructive will prompt for confirmation in supported clients.
+
+## Example prompts
+
+Once connected, you can ask your AI assistant things like:
+
+- _"List all unresolved issues in project 1"_
+- _"Show me the stack trace for issue abc-123"_
+- _"Resolve all TypeError issues from the last deployment"_
+- _"Create a token called 'CI pipeline' and give me the value"_
+- _"How many events does issue xyz have?"_
+
+## Development
+
+```bash
+# Build
+pnpm --filter @rustrak/mcp build
+
+# Run tests (33 tests)
+pnpm --filter @rustrak/mcp test
+
+# Type check
+pnpm --filter @rustrak/mcp typecheck
+
+# Watch mode
+pnpm --filter @rustrak/mcp dev
+```
+
+## Architecture
+
+```
+AI Client (Claude Desktop / Cursor)
+        │  stdio (JSON-RPC)
+        ▼
+┌─────────────────────┐
+│   @rustrak/mcp      │
+│   McpServer         │
+│   ├── projects      │
+│   ├── issues        │
+│   ├── events        │
+│   ├── tokens        │
+│   └── alerts        │
+└──────────┬──────────┘
+           │  HTTP (Bearer token)
+           ▼
+┌─────────────────────┐
+│   Rustrak Server    │
+│   (Rust/Actix-web)  │
+└─────────────────────┘
+```
+
+## License
+
+GPL-3.0

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -61,7 +61,7 @@ Or use the project-level `.mcp.json` at the repo root (Claude Code picks this up
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `RUSTRAK_API_TOKEN` | ✅ | — | 40-char hex API token. Server exits if missing. |
-| `RUSTRAK_API_URL` | — | `http://localhost:8080` | Base URL of your Rustrak server. |
+| `RUSTRAK_API_URL` | ✅ | — | Base URL of your Rustrak server. Server exits if missing. |
 
 ## Available Tools
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@rustrak/mcp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server for Rustrak error tracking — wraps @rustrak/client",
+  "type": "module",
+  "bin": {
+    "rustrak-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "@rustrak/client": "workspace:*",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "25.8.0",
+    "tsup": "8.5.1",
+    "typescript": "6.0.3",
+    "vitest": "4.1.6"
+  }
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,18 +1,40 @@
 {
   "name": "@rustrak/mcp",
   "version": "0.1.0",
-  "private": true,
   "description": "MCP server for Rustrak error tracking — wraps @rustrak/client",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "bin": {
     "rustrak-mcp": "./dist/index.js"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
+  "keywords": [
+    "rustrak",
+    "mcp",
+    "model-context-protocol",
+    "error-tracking",
+    "claude"
+  ],
+  "license": "GPL-3.0",
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
     "@rustrak/client": "workspace:*",

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -1,0 +1,24 @@
+export interface Config {
+  RUSTRAK_API_URL: string;
+  RUSTRAK_API_TOKEN: string;
+}
+
+export function loadConfig(): Config {
+  const url = process.env['RUSTRAK_API_URL'];
+  if (!url) {
+    throw new Error(
+      'Missing required environment variable: RUSTRAK_API_URL. ' +
+        'Set RUSTRAK_API_URL to the base URL of your Rustrak server.',
+    );
+  }
+
+  const token = process.env['RUSTRAK_API_TOKEN'];
+  if (!token) {
+    throw new Error(
+      'Missing required environment variable: RUSTRAK_API_TOKEN. ' +
+        'Set RUSTRAK_API_TOKEN to a valid Rustrak API token.',
+    );
+  }
+
+  return { RUSTRAK_API_URL: url, RUSTRAK_API_TOKEN: token };
+}

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -6,18 +6,20 @@ export interface Config {
 export function loadConfig(): Config {
   const url = process.env['RUSTRAK_API_URL'];
   if (!url) {
-    throw new Error(
-      'Missing required environment variable: RUSTRAK_API_URL. ' +
+    console.error(
+      '[rustrak-mcp] Missing required environment variable: RUSTRAK_API_URL. ' +
         'Set RUSTRAK_API_URL to the base URL of your Rustrak server.',
     );
+    process.exit(1);
   }
 
   const token = process.env['RUSTRAK_API_TOKEN'];
   if (!token) {
-    throw new Error(
-      'Missing required environment variable: RUSTRAK_API_TOKEN. ' +
+    console.error(
+      '[rustrak-mcp] Missing required environment variable: RUSTRAK_API_TOKEN. ' +
         'Set RUSTRAK_API_TOKEN to a valid Rustrak API token.',
     );
+    process.exit(1);
   }
 
   return { RUSTRAK_API_URL: url, RUSTRAK_API_TOKEN: token };

--- a/packages/mcp/src/errors.ts
+++ b/packages/mcp/src/errors.ts
@@ -1,0 +1,32 @@
+import {
+  AuthenticationError,
+  NotFoundError,
+  RateLimitError,
+  RustrakError,
+} from '@rustrak/client';
+
+type McpErrorResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+};
+
+function mcpError(text: string): McpErrorResult {
+  return { content: [{ type: 'text' as const, text }], isError: true };
+}
+
+export function toMcpError(err: unknown): McpErrorResult {
+  if (err instanceof NotFoundError) {
+    return mcpError(`Not found: ${err.message}`);
+  }
+  if (err instanceof RateLimitError) {
+    const after = err.retryAfter !== undefined ? err.retryAfter : '?';
+    return mcpError(`Rate limited. Retry after: ${after}s`);
+  }
+  if (err instanceof AuthenticationError) {
+    return mcpError('Authentication failed. Check RUSTRAK_API_TOKEN.');
+  }
+  if (err instanceof RustrakError) {
+    return mcpError(`API error: ${err.message}`);
+  }
+  return mcpError(`Unexpected error: ${String(err)}`);
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,14 @@
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { RustrakClient } from '@rustrak/client';
+import { loadConfig } from './config.js';
+import { createServer } from './server.js';
+
+const config = loadConfig();
+const client = new RustrakClient({
+  baseUrl: config.RUSTRAK_API_URL,
+  token: config.RUSTRAK_API_TOKEN,
+});
+const server = createServer(client);
+const transport = new StdioServerTransport();
+await server.connect(transport);
+console.error('[rustrak-mcp] Server started');

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,22 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RustrakClient } from '@rustrak/client';
+import { registerAlertTools } from './tools/alerts.js';
+import { registerEventTools } from './tools/events.js';
+import { registerIssueTools } from './tools/issues.js';
+import { registerProjectTools } from './tools/projects.js';
+import { registerTokenTools } from './tools/tokens.js';
+
+export function createServer(client: RustrakClient): McpServer {
+  const server = new McpServer({
+    name: 'rustrak-mcp',
+    version: '0.1.0',
+  });
+
+  registerProjectTools(server, client);
+  registerIssueTools(server, client);
+  registerEventTools(server, client);
+  registerTokenTools(server, client);
+  registerAlertTools(server, client);
+
+  return server;
+}

--- a/packages/mcp/src/tools/alerts.ts
+++ b/packages/mcp/src/tools/alerts.ts
@@ -1,0 +1,69 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RustrakClient } from '@rustrak/client';
+import { z } from 'zod';
+import { toMcpError } from '../errors.js';
+
+export function registerAlertTools(
+  server: McpServer,
+  client: RustrakClient,
+): void {
+  server.registerTool(
+    'list_alert_channels',
+    {
+      description:
+        'List all configured alert notification channels (Slack, email, webhook, etc.).',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const result = await client.alertChannels.list();
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'test_alert_channel',
+    {
+      description:
+        'Send a test notification to an alert channel to verify it is configured correctly.',
+      inputSchema: {
+        channel_id: z.number().int().describe('Alert channel ID to test'),
+      },
+    },
+    async ({ channel_id }) => {
+      try {
+        const result = await client.alertChannels.test(channel_id);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'list_alert_rules',
+    {
+      description: 'List all alert rules configured for a project.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+      },
+    },
+    async ({ project_id }) => {
+      try {
+        const result = await client.alertRules.list(project_id);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/events.ts
+++ b/packages/mcp/src/tools/events.ts
@@ -1,0 +1,62 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RustrakClient } from '@rustrak/client';
+import { z } from 'zod';
+import { toMcpError } from '../errors.js';
+
+export function registerEventTools(
+  server: McpServer,
+  client: RustrakClient,
+): void {
+  server.registerTool(
+    'list_events',
+    {
+      description:
+        'List raw events for a specific issue. Events are individual error occurrences within a grouped issue.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        issue_id: z.string().describe('Issue ID'),
+        cursor: z.string().optional().describe('Pagination cursor'),
+        order: z
+          .enum(['asc', 'desc'])
+          .optional()
+          .describe('Sort order (default: desc)'),
+      },
+    },
+    async ({ project_id, issue_id, cursor, order }) => {
+      try {
+        const result = await client.events.list(project_id, issue_id, {
+          cursor,
+          order,
+        });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_event',
+    {
+      description:
+        'Get full detail for a single event, including the complete Sentry envelope data.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        issue_id: z.string().describe('Issue ID'),
+        event_id: z.string().describe('Event ID'),
+      },
+    },
+    async ({ project_id, issue_id, event_id }) => {
+      try {
+        const result = await client.events.get(project_id, issue_id, event_id);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/issues.ts
+++ b/packages/mcp/src/tools/issues.ts
@@ -1,0 +1,154 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RustrakClient } from '@rustrak/client';
+import { z } from 'zod';
+import { toMcpError } from '../errors.js';
+
+export function registerIssueTools(
+  server: McpServer,
+  client: RustrakClient,
+): void {
+  server.registerTool(
+    'list_issues',
+    {
+      description:
+        'List issues for a Rustrak project. Returns paginated grouped error occurrences.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        page: z.number().int().min(1).optional(),
+        per_page: z.number().int().min(1).max(100).optional(),
+        filter: z
+          .enum(['open', 'resolved', 'muted', 'all'])
+          .optional()
+          .describe('Filter issues by state (default: open)'),
+      },
+    },
+    async ({ project_id, page, per_page, filter }) => {
+      try {
+        const result = await client.issues.list(project_id, {
+          page,
+          per_page,
+          filter,
+        });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_issue',
+    {
+      description: 'Get a single issue by ID.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        issue_id: z.string().describe('Issue ID'),
+      },
+    },
+    async ({ project_id, issue_id }) => {
+      try {
+        const result = await client.issues.get(project_id, issue_id);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'resolve_issue',
+    {
+      description: 'Mark an issue as resolved.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        issue_id: z.string().describe('Issue ID'),
+      },
+    },
+    async ({ project_id, issue_id }) => {
+      try {
+        const result = await client.issues.updateState(project_id, issue_id, {
+          is_resolved: true,
+        });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'unresolve_issue',
+    {
+      description: 'Mark a resolved issue as unresolved (re-open it).',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        issue_id: z.string().describe('Issue ID'),
+      },
+    },
+    async ({ project_id, issue_id }) => {
+      try {
+        const result = await client.issues.updateState(project_id, issue_id, {
+          is_resolved: false,
+        });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'mute_issue',
+    {
+      description: 'Mute an issue so it no longer triggers alerts.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        issue_id: z.string().describe('Issue ID'),
+      },
+    },
+    async ({ project_id, issue_id }) => {
+      try {
+        const result = await client.issues.updateState(project_id, issue_id, {
+          is_muted: true,
+        });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'delete_issue',
+    {
+      description: 'Permanently delete an issue and all its events.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        issue_id: z.string().describe('Issue ID'),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ project_id, issue_id }) => {
+      try {
+        await client.issues.delete(project_id, issue_id);
+        return {
+          content: [
+            { type: 'text', text: `Issue ${issue_id} deleted successfully.` },
+          ],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/projects.ts
+++ b/packages/mcp/src/tools/projects.ts
@@ -1,0 +1,80 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RustrakClient } from '@rustrak/client';
+import { z } from 'zod';
+import { toMcpError } from '../errors.js';
+
+export function registerProjectTools(
+  server: McpServer,
+  client: RustrakClient,
+): void {
+  server.registerTool(
+    'list_projects',
+    {
+      description: 'List all Rustrak projects you have access to.',
+      inputSchema: {
+        page: z.number().int().min(1).optional().describe('Page number'),
+        per_page: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe('Items per page'),
+      },
+    },
+    async ({ page, per_page }) => {
+      try {
+        const result = await client.projects.list({ page, per_page });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_project',
+    {
+      description: 'Get details for a single Rustrak project.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+      },
+    },
+    async ({ project_id }) => {
+      try {
+        const result = await client.projects.get(project_id);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'create_project',
+    {
+      description: 'Create a new Rustrak project.',
+      inputSchema: {
+        name: z.string().min(1).describe('Project name'),
+        slug: z
+          .string()
+          .optional()
+          .describe('URL-safe slug (auto-generated if omitted)'),
+      },
+    },
+    async ({ name, slug }) => {
+      try {
+        const result = await client.projects.create({ name, slug });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/tokens.ts
+++ b/packages/mcp/src/tools/tokens.ts
@@ -1,0 +1,76 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RustrakClient } from '@rustrak/client';
+import { z } from 'zod';
+import { toMcpError } from '../errors.js';
+
+export function registerTokenTools(
+  server: McpServer,
+  client: RustrakClient,
+): void {
+  server.registerTool(
+    'list_tokens',
+    {
+      description:
+        'List all API tokens. Token values are masked — only the prefix is shown.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const result = await client.tokens.list();
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'create_token',
+    {
+      description:
+        'Create a new API token. The full token value is returned ONCE — save it immediately.',
+      inputSchema: {
+        description: z
+          .string()
+          .min(1)
+          .describe('Human-readable label for this token'),
+      },
+    },
+    async ({ description }) => {
+      try {
+        const result = await client.tokens.create({ description });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'revoke_token',
+    {
+      description:
+        'Permanently revoke an API token. This action cannot be undone.',
+      inputSchema: {
+        token_id: z.number().int().describe('Token ID to revoke'),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ token_id }) => {
+      try {
+        await client.tokens.delete(token_id);
+        return {
+          content: [
+            { type: 'text', text: `Token ${token_id} revoked successfully.` },
+          ],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+}

--- a/packages/mcp/tests/config.test.ts
+++ b/packages/mcp/tests/config.test.ts
@@ -7,23 +7,39 @@ describe('loadConfig', () => {
   const originalEnv = { ...process.env };
 
   afterEach(() => {
-    // Restore env
-    process.env = { ...originalEnv };
+    Object.keys(process.env).forEach((key) => {
+      if (!(key in originalEnv)) delete process.env[key];
+    });
+    Object.assign(process.env, originalEnv);
     vi.resetModules();
   });
 
-  it('throws when RUSTRAK_API_URL is missing', async () => {
+  it('exits with code 1 when RUSTRAK_API_URL is missing', async () => {
     delete process.env['RUSTRAK_API_URL'];
     delete process.env['RUSTRAK_API_TOKEN'];
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementationOnce((_code?: string | number | null) => {
+        throw new Error('process.exit');
+      });
     const { loadConfig } = await import('../src/config.js');
-    expect(() => loadConfig()).toThrow(/RUSTRAK_API_URL/);
+    expect(() => loadConfig()).toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
   });
 
-  it('throws when RUSTRAK_API_TOKEN is missing', async () => {
+  it('exits with code 1 when RUSTRAK_API_TOKEN is missing', async () => {
     process.env['RUSTRAK_API_URL'] = 'http://localhost:8080';
     delete process.env['RUSTRAK_API_TOKEN'];
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementationOnce((_code?: string | number | null) => {
+        throw new Error('process.exit');
+      });
     const { loadConfig } = await import('../src/config.js');
-    expect(() => loadConfig()).toThrow(/RUSTRAK_API_TOKEN/);
+    expect(() => loadConfig()).toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
   });
 
   it('returns config when both env vars are present', async () => {

--- a/packages/mcp/tests/config.test.ts
+++ b/packages/mcp/tests/config.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// We need to import loadConfig after setting env vars.
+// Using dynamic import to re-evaluate per test.
+
+describe('loadConfig', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore env
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  it('throws when RUSTRAK_API_URL is missing', async () => {
+    delete process.env['RUSTRAK_API_URL'];
+    delete process.env['RUSTRAK_API_TOKEN'];
+    const { loadConfig } = await import('../src/config.js');
+    expect(() => loadConfig()).toThrow(/RUSTRAK_API_URL/);
+  });
+
+  it('throws when RUSTRAK_API_TOKEN is missing', async () => {
+    process.env['RUSTRAK_API_URL'] = 'http://localhost:8080';
+    delete process.env['RUSTRAK_API_TOKEN'];
+    const { loadConfig } = await import('../src/config.js');
+    expect(() => loadConfig()).toThrow(/RUSTRAK_API_TOKEN/);
+  });
+
+  it('returns config when both env vars are present', async () => {
+    process.env['RUSTRAK_API_URL'] = 'http://localhost:8080';
+    process.env['RUSTRAK_API_TOKEN'] = 'test-token-abc';
+    const { loadConfig } = await import('../src/config.js');
+    const config = loadConfig();
+    expect(config.RUSTRAK_API_URL).toBe('http://localhost:8080');
+    expect(config.RUSTRAK_API_TOKEN).toBe('test-token-abc');
+  });
+});

--- a/packages/mcp/tests/errors.test.ts
+++ b/packages/mcp/tests/errors.test.ts
@@ -1,0 +1,89 @@
+import {
+  AuthenticationError,
+  BadRequestError,
+  NetworkError,
+  NotFoundError,
+  RateLimitError,
+  ServerError,
+} from '@rustrak/client';
+import { describe, expect, it } from 'vitest';
+import { toMcpError } from '../src/errors.js';
+
+describe('toMcpError', () => {
+  it('returns isError: true for NotFoundError', () => {
+    const err = new NotFoundError('issue-123');
+    const result = toMcpError(err);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.type).toBe('text');
+    expect(result.content[0]?.text).toMatch(/not found/i);
+  });
+
+  it('does not include stack traces in error output', () => {
+    const err = new NotFoundError('issue-123');
+    const result = toMcpError(err);
+    const text = result.content[0]?.text ?? '';
+    expect(text).not.toMatch(/at Object\./);
+    expect(text).not.toMatch(/\.ts:\d+/);
+  });
+
+  it('returns isError: true for RateLimitError with retryAfter', () => {
+    const err = new RateLimitError('Rate limit exceeded', 30);
+    const result = toMcpError(err);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/30/);
+  });
+
+  it('returns isError: true for RateLimitError without retryAfter', () => {
+    const err = new RateLimitError('Rate limit exceeded');
+    const result = toMcpError(err);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/rate limit/i);
+  });
+
+  it('returns isError: true for AuthenticationError', () => {
+    const err = new AuthenticationError();
+    const result = toMcpError(err);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/RUSTRAK_API_TOKEN/);
+  });
+
+  it('returns isError: true for generic RustrakError', () => {
+    const err = new BadRequestError('Invalid input');
+    const result = toMcpError(err);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/Invalid input/);
+  });
+
+  it('returns isError: true for ServerError', () => {
+    const err = new ServerError('Internal server error', 500);
+    const result = toMcpError(err);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/Internal server error/);
+  });
+
+  it('returns isError: true for NetworkError', () => {
+    const err = new NetworkError('Connection refused');
+    const result = toMcpError(err);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/Connection refused/);
+  });
+
+  it('returns isError: true for unknown errors', () => {
+    const err = new Error('Something unexpected');
+    const result = toMcpError(err);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/Unexpected error/i);
+  });
+
+  it('returns isError: true for non-Error unknowns', () => {
+    const result = toMcpError('string error');
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toMatch(/Unexpected error/i);
+  });
+
+  it('content items have correct type literal', () => {
+    const result = toMcpError(new NotFoundError('x'));
+    // type must be exactly 'text' for MCP content
+    expect(result.content[0]?.type).toBe('text');
+  });
+});

--- a/packages/mcp/tests/integration/server.test.ts
+++ b/packages/mcp/tests/integration/server.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestEnv } from '../setup.js';
+
+const EXPECTED_TOOLS = [
+  // Projects (3)
+  'list_projects',
+  'get_project',
+  'create_project',
+  // Issues (6)
+  'list_issues',
+  'get_issue',
+  'resolve_issue',
+  'unresolve_issue',
+  'mute_issue',
+  'delete_issue',
+  // Events (2)
+  'list_events',
+  'get_event',
+  // Tokens (3)
+  'list_tokens',
+  'create_token',
+  'revoke_token',
+  // Alerts (3)
+  'list_alert_channels',
+  'test_alert_channel',
+  'list_alert_rules',
+] as const;
+
+describe('MCP server integration', () => {
+  let mockClient: any;
+  let testEnv: Awaited<ReturnType<typeof createTestEnv>>;
+
+  beforeEach(async () => {
+    mockClient = {
+      projects: { list: vi.fn(), get: vi.fn(), create: vi.fn() },
+      issues: {
+        list: vi.fn(),
+        get: vi.fn(),
+        updateState: vi.fn(),
+        delete: vi.fn(),
+      },
+      events: { list: vi.fn(), get: vi.fn() },
+      tokens: { list: vi.fn(), create: vi.fn(), delete: vi.fn() },
+      alertChannels: { list: vi.fn(), test: vi.fn() },
+      alertRules: { list: vi.fn() },
+    };
+    testEnv = await createTestEnv(mockClient);
+  });
+
+  afterEach(async () => {
+    await testEnv.mcpClient.close();
+  });
+
+  it(`registers all ${EXPECTED_TOOLS.length} tools`, async () => {
+    const { tools } = await testEnv.mcpClient.listTools();
+    const toolNames = tools.map((t: { name: string }) => t.name);
+
+    for (const expected of EXPECTED_TOOLS) {
+      expect(
+        toolNames,
+        `Expected tool "${expected}" to be registered`,
+      ).toContain(expected);
+    }
+
+    expect(tools).toHaveLength(EXPECTED_TOOLS.length);
+  });
+
+  it('delete_issue has destructiveHint: true', async () => {
+    const { tools } = await testEnv.mcpClient.listTools();
+    const deleteIssue = tools.find(
+      (t: { name: string }) => t.name === 'delete_issue',
+    );
+    expect(deleteIssue).toBeDefined();
+    expect(deleteIssue?.annotations?.destructiveHint).toBe(true);
+  });
+
+  it('revoke_token has destructiveHint: true', async () => {
+    const { tools } = await testEnv.mcpClient.listTools();
+    const revokeToken = tools.find(
+      (t: { name: string }) => t.name === 'revoke_token',
+    );
+    expect(revokeToken).toBeDefined();
+    expect(revokeToken?.annotations?.destructiveHint).toBe(true);
+  });
+});

--- a/packages/mcp/tests/setup.ts
+++ b/packages/mcp/tests/setup.ts
@@ -1,0 +1,22 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../src/server.js';
+
+export type McpTextContent = { type: 'text'; text: string };
+export type McpToolResult = { isError?: boolean; content: McpTextContent[] };
+
+export async function createTestEnv(mockClient: unknown) {
+  const server = createServer(mockClient as never);
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const mcpClient = new Client({ name: 'test', version: '1.0.0' });
+  await server.connect(serverTransport);
+  await mcpClient.connect(clientTransport);
+
+  const callTool = (
+    params: Parameters<typeof mcpClient.callTool>[0],
+  ): Promise<McpToolResult> =>
+    mcpClient.callTool(params) as Promise<McpToolResult>;
+
+  return { mcpClient, server, callTool };
+}

--- a/packages/mcp/tests/tools/alerts.test.ts
+++ b/packages/mcp/tests/tools/alerts.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestEnv } from '../setup.js';
+
+describe('alert tools', () => {
+  let mockClient: any;
+  let testEnv: Awaited<ReturnType<typeof createTestEnv>>;
+  let callTool: Awaited<ReturnType<typeof createTestEnv>>['callTool'];
+
+  beforeEach(async () => {
+    mockClient = {
+      alertChannels: {
+        list: vi.fn(),
+        test: vi.fn(),
+      },
+      alertRules: {
+        list: vi.fn(),
+      },
+    };
+    testEnv = await createTestEnv(mockClient);
+    callTool = testEnv.callTool;
+  });
+
+  afterEach(async () => {
+    await testEnv.mcpClient.close();
+  });
+
+  describe('list_alert_channels', () => {
+    it('returns all alert notification channels', async () => {
+      const mockChannels = [
+        {
+          id: 1,
+          name: 'Slack #errors',
+          channel_type: 'slack',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+      mockClient.alertChannels.list.mockResolvedValue(mockChannels);
+
+      const result = await callTool({ name: 'list_alert_channels', arguments: {} });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].channel_type).toBe('slack');
+    });
+  });
+
+  describe('test_alert_channel', () => {
+    it('sends a test notification to the channel', async () => {
+      const mockResponse = { success: true, message: 'Test notification sent' };
+      mockClient.alertChannels.test.mockResolvedValue(mockResponse);
+
+      const result = await callTool({
+        name: 'test_alert_channel',
+        arguments: { channel_id: 1 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+      expect(mockClient.alertChannels.test).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('list_alert_rules', () => {
+    it('returns alert rules for a project', async () => {
+      const mockRules = [
+        {
+          id: 1,
+          project_id: 42,
+          channel_id: 1,
+          alert_type: 'new_issue',
+          is_active: true,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+      mockClient.alertRules.list.mockResolvedValue(mockRules);
+
+      const result = await callTool({
+        name: 'list_alert_rules',
+        arguments: { project_id: 42 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].alert_type).toBe('new_issue');
+      expect(mockClient.alertRules.list).toHaveBeenCalledWith(42);
+    });
+  });
+});

--- a/packages/mcp/tests/tools/events.test.ts
+++ b/packages/mcp/tests/tools/events.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestEnv } from '../setup.js';
+
+describe('event tools', () => {
+  let mockClient: any;
+  let testEnv: Awaited<ReturnType<typeof createTestEnv>>;
+  let callTool: Awaited<ReturnType<typeof createTestEnv>>['callTool'];
+
+  beforeEach(async () => {
+    mockClient = {
+      events: {
+        list: vi.fn(),
+        get: vi.fn(),
+      },
+    };
+    testEnv = await createTestEnv(mockClient);
+    callTool = testEnv.callTool;
+  });
+
+  afterEach(async () => {
+    await testEnv.mcpClient.close();
+  });
+
+  describe('list_events', () => {
+    it('returns events for an issue', async () => {
+      const mockData = {
+        items: [
+          {
+            id: 'evt-1',
+            issue_id: 'iss-1',
+            timestamp: '2024-01-01T00:00:00Z',
+            platform: 'javascript',
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      };
+      mockClient.events.list.mockResolvedValue(mockData);
+
+      const result = await callTool({
+        name: 'list_events',
+        arguments: { project_id: 1, issue_id: 'iss-1' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.items).toHaveLength(1);
+      expect(mockClient.events.list).toHaveBeenCalledWith(1, 'iss-1', {
+        cursor: undefined,
+        order: undefined,
+      });
+    });
+  });
+
+  describe('get_event', () => {
+    it('returns a single event with full detail', async () => {
+      const mockEvent = {
+        id: 'evt-42',
+        issue_id: 'iss-1',
+        timestamp: '2024-01-01T00:00:00Z',
+        platform: 'javascript',
+        data: { exception: { values: [{ type: 'TypeError', value: 'oops' }] } },
+      };
+      mockClient.events.get.mockResolvedValue(mockEvent);
+
+      const result = await callTool({
+        name: 'get_event',
+        arguments: { project_id: 1, issue_id: 'iss-1', event_id: 'evt-42' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.id).toBe('evt-42');
+      expect(parsed.data.exception.values[0].type).toBe('TypeError');
+      expect(mockClient.events.get).toHaveBeenCalledWith(1, 'iss-1', 'evt-42');
+    });
+  });
+});

--- a/packages/mcp/tests/tools/issues.test.ts
+++ b/packages/mcp/tests/tools/issues.test.ts
@@ -1,0 +1,127 @@
+import { NotFoundError, RateLimitError } from '@rustrak/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestEnv } from '../setup.js';
+
+describe('issue tools', () => {
+  let mockClient: any;
+  let testEnv: Awaited<ReturnType<typeof createTestEnv>>;
+  let callTool: Awaited<ReturnType<typeof createTestEnv>>['callTool'];
+
+  beforeEach(async () => {
+    mockClient = {
+      issues: {
+        list: vi.fn(),
+        get: vi.fn(),
+        updateState: vi.fn(),
+        delete: vi.fn(),
+      },
+      projects: { list: vi.fn(), get: vi.fn(), create: vi.fn() },
+      events: { list: vi.fn(), get: vi.fn() },
+      tokens: { list: vi.fn(), create: vi.fn(), delete: vi.fn() },
+      alertChannels: { list: vi.fn(), test: vi.fn() },
+      alertRules: { list: vi.fn() },
+    };
+    testEnv = await createTestEnv(mockClient);
+    callTool = testEnv.callTool;
+  });
+
+  afterEach(async () => {
+    await testEnv.mcpClient.close();
+  });
+
+  describe('list_issues', () => {
+    it('returns paginated issues for a project', async () => {
+      const mockData = {
+        items: [
+          {
+            id: 'abc123',
+            title: 'TypeError: Cannot read property',
+            is_resolved: false,
+            is_muted: false,
+            event_count: 5,
+            user_count: 2,
+            first_seen: '2024-01-01T00:00:00Z',
+            last_seen: '2024-01-02T00:00:00Z',
+            project_id: 1,
+          },
+        ],
+        total: 1,
+        page: 1,
+        per_page: 25,
+      };
+      mockClient.issues.list.mockResolvedValue(mockData);
+
+      const result = await callTool({
+        name: 'list_issues',
+        arguments: { project_id: 1 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0]?.type).toBe('text');
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.items).toHaveLength(1);
+      expect(mockClient.issues.list).toHaveBeenCalledWith(1, {
+        page: undefined,
+        per_page: undefined,
+        filter: undefined,
+      });
+    });
+  });
+
+  describe('resolve_issue', () => {
+    it('resolves an issue successfully', async () => {
+      const mockIssue = {
+        id: 'abc123',
+        title: 'TypeError',
+        is_resolved: true,
+        is_muted: false,
+        event_count: 1,
+        user_count: 1,
+        first_seen: '2024-01-01T00:00:00Z',
+        last_seen: '2024-01-01T00:00:00Z',
+        project_id: 1,
+      };
+      mockClient.issues.updateState.mockResolvedValue(mockIssue);
+
+      const result = await callTool({
+        name: 'resolve_issue',
+        arguments: { project_id: 1, issue_id: 'abc123' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.is_resolved).toBe(true);
+      expect(mockClient.issues.updateState).toHaveBeenCalledWith(1, 'abc123', {
+        is_resolved: true,
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns isError: true on 404', async () => {
+      mockClient.issues.get.mockRejectedValue(new NotFoundError('issue-xyz'));
+
+      const result = await callTool({
+        name: 'get_issue',
+        arguments: { project_id: 1, issue_id: 'xyz' },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toMatch(/not found/i);
+    });
+
+    it('returns isError: true on 429 rate limit', async () => {
+      mockClient.issues.list.mockRejectedValue(
+        new RateLimitError('Rate limit exceeded', 60),
+      );
+
+      const result = await callTool({
+        name: 'list_issues',
+        arguments: { project_id: 1 },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toMatch(/60/);
+    });
+  });
+});

--- a/packages/mcp/tests/tools/projects.test.ts
+++ b/packages/mcp/tests/tools/projects.test.ts
@@ -1,0 +1,113 @@
+import { NotFoundError } from '@rustrak/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestEnv } from '../setup.js';
+
+describe('project tools', () => {
+  let mockClient: any;
+  let testEnv: Awaited<ReturnType<typeof createTestEnv>>;
+  let callTool: Awaited<ReturnType<typeof createTestEnv>>['callTool'];
+
+  beforeEach(async () => {
+    mockClient = {
+      projects: {
+        list: vi.fn(),
+        get: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+    };
+    testEnv = await createTestEnv(mockClient);
+    callTool = testEnv.callTool;
+  });
+
+  afterEach(async () => {
+    await testEnv.mcpClient.close();
+  });
+
+  describe('list_projects', () => {
+    it('returns all projects', async () => {
+      const mockData = {
+        items: [
+          {
+            id: 1,
+            name: 'My App',
+            slug: 'my-app',
+            sentry_key: 'abc-123',
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        ],
+        total: 1,
+        page: 1,
+        per_page: 25,
+      };
+      mockClient.projects.list.mockResolvedValue(mockData);
+
+      const result = await callTool({ name: 'list_projects', arguments: {} });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.items).toHaveLength(1);
+      expect(parsed.items[0].name).toBe('My App');
+    });
+
+    it('returns isError on not found', async () => {
+      mockClient.projects.list.mockRejectedValue(new NotFoundError('projects'));
+
+      const result = await callTool({ name: 'list_projects', arguments: {} });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('get_project', () => {
+    it('returns a single project by ID', async () => {
+      const mockProject = {
+        id: 42,
+        name: 'Backend',
+        slug: 'backend',
+        sentry_key: 'xyz',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      };
+      mockClient.projects.get.mockResolvedValue(mockProject);
+
+      const result = await callTool({
+        name: 'get_project',
+        arguments: { project_id: 42 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.id).toBe(42);
+      expect(mockClient.projects.get).toHaveBeenCalledWith(42);
+    });
+  });
+
+  describe('create_project', () => {
+    it('creates a project with name', async () => {
+      const mockProject = {
+        id: 99,
+        name: 'New Project',
+        slug: 'new-project',
+        sentry_key: 'new-key',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      };
+      mockClient.projects.create.mockResolvedValue(mockProject);
+
+      const result = await callTool({
+        name: 'create_project',
+        arguments: { name: 'New Project' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.id).toBe(99);
+      expect(mockClient.projects.create).toHaveBeenCalledWith({
+        name: 'New Project',
+        slug: undefined,
+      });
+    });
+  });
+});

--- a/packages/mcp/tests/tools/tokens.test.ts
+++ b/packages/mcp/tests/tools/tokens.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestEnv } from '../setup.js';
+
+describe('token tools', () => {
+  let mockClient: any;
+  let testEnv: Awaited<ReturnType<typeof createTestEnv>>;
+  let callTool: Awaited<ReturnType<typeof createTestEnv>>['callTool'];
+
+  beforeEach(async () => {
+    mockClient = {
+      tokens: {
+        list: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+      },
+    };
+    testEnv = await createTestEnv(mockClient);
+    callTool = testEnv.callTool;
+  });
+
+  afterEach(async () => {
+    await testEnv.mcpClient.close();
+  });
+
+  describe('list_tokens', () => {
+    it('returns all tokens (masked)', async () => {
+      const mockTokens = [
+        {
+          id: 1,
+          description: 'CI token',
+          token_prefix: 'abc',
+          created_at: '2024-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          description: 'Dev token',
+          token_prefix: 'xyz',
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+      mockClient.tokens.list.mockResolvedValue(mockTokens);
+
+      const result = await callTool({ name: 'list_tokens', arguments: {} });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].description).toBe('CI token');
+    });
+  });
+
+  describe('create_token', () => {
+    it('creates a new API token', async () => {
+      const mockCreated = {
+        id: 10,
+        description: 'New Token',
+        token: 'full-secret-token-abc123',
+        token_prefix: 'full',
+        created_at: '2024-01-01T00:00:00Z',
+      };
+      mockClient.tokens.create.mockResolvedValue(mockCreated);
+
+      const result = await callTool({
+        name: 'create_token',
+        arguments: { description: 'New Token' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.token).toBe('full-secret-token-abc123');
+      expect(mockClient.tokens.create).toHaveBeenCalledWith({
+        description: 'New Token',
+      });
+    });
+  });
+
+  describe('revoke_token', () => {
+    it('revokes (deletes) a token by ID', async () => {
+      mockClient.tokens.delete.mockResolvedValue(undefined);
+
+      const result = await callTool({
+        name: 'revoke_token',
+        arguments: { token_id: 5 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0]?.text).toMatch(/revoked/i);
+      expect(mockClient.tokens.delete).toHaveBeenCalledWith(5);
+    });
+  });
+});

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "ignoreDeprecations": "6.0",
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node18',
+  shims: true,
+  dts: false,
+  clean: true,
+  splitting: false,
+  sourcemap: false,
+  minify: false,
+  outDir: 'dist',
+  banner: {
+    js: '#!/usr/bin/env node',
+  },
+});

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    pool: 'forks',
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,31 @@ importers:
         specifier: 4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(msw@2.14.6(@types/node@25.8.0)(typescript@6.0.3))(vite@7.3.1(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0))
 
+  packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
+      '@rustrak/client':
+        specifier: workspace:*
+        version: link:../client
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 25.8.0
+        version: 25.8.0
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.0)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(msw@2.14.6(@types/node@25.8.0)(typescript@6.0.3))(vite@7.3.1(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.9.0))
+
   packages/test-sentry:
     dependencies:
       '@sentry/node':
@@ -891,6 +916,12 @@ packages:
     peerDependencies:
       vue: ^3.2.0
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
@@ -1179,6 +1210,16 @@ packages:
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
@@ -3370,6 +3411,10 @@ packages:
     engines: {node: '>=14.6'}
     deprecated: this version has critical issues, please update to the latest version
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -3390,6 +3435,17 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -3463,6 +3519,10 @@ packages:
     engines: {node: '>=20.0.0'}
     hasBin: true
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -3480,9 +3540,21 @@ packages:
     peerDependencies:
       esbuild: '>=0.18'
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001765:
     resolution: {integrity: sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==}
@@ -3606,6 +3678,18 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-hrtime@5.0.0:
     resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
     engines: {node: '>=12'}
@@ -3613,9 +3697,21 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -3833,6 +3929,10 @@ packages:
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -3862,6 +3962,13 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   embla-carousel-react@8.6.0:
     resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
     peerDependencies:
@@ -3877,6 +3984,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.21.3:
     resolution: {integrity: sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==}
@@ -3894,8 +4005,20 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
@@ -3919,6 +4042,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -3963,11 +4089,19 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
   execa@8.0.1:
@@ -3977,6 +4111,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -3996,6 +4140,9 @@ packages:
 
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -4024,6 +4171,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -4054,6 +4205,14 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -4067,6 +4226,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   function-timeout@1.0.2:
     resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
     engines: {node: '>=18'}
@@ -4079,6 +4241,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -4086,6 +4252,10 @@ packages:
   get-own-enumerable-keys@1.0.0:
     resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
     engines: {node: '>=14.16'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
@@ -4111,6 +4281,10 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -4128,6 +4302,14 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
 
   hast-util-embedded@3.0.0:
     resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
@@ -4208,6 +4390,10 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  hono@4.12.19:
+    resolution: {integrity: sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==}
+    engines: {node: '>=16.9.0'}
+
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
@@ -4219,6 +4405,10 @@ packages:
 
   html-whitespace-sensitive-tag-names@3.0.1:
     resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -4261,6 +4451,9 @@ packages:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
     engines: {node: '>=18'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -4276,6 +4469,14 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-absolute-url@4.0.1:
     resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
@@ -4334,6 +4535,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regexp@3.1.0:
     resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
     engines: {node: '>=12'}
@@ -4385,6 +4589,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -4402,6 +4609,12 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -4583,6 +4796,10 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mathjax-full@3.2.2:
     resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
     deprecated: Version 4 replaces this package with the scoped package @mathjax/src
@@ -4640,6 +4857,14 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -4771,6 +4996,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -4913,8 +5146,19 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -4992,6 +5236,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -5016,6 +5264,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -5057,6 +5308,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -5125,6 +5380,14 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -5148,6 +5411,14 @@ packages:
     resolution: {integrity: sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ==}
     peerDependencies:
       vue: '>= 3.2.0'
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-compiler-runtime@19.1.0-rc.3:
     resolution: {integrity: sha512-Cssogys2XZu6SqxRdX2xd8cQAf57BBvFbLEBlIa77161lninbKUn/EqbecCe7W3eqDQfg3rIoOwzExzgCh7h/g==}
@@ -5357,6 +5628,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
@@ -5408,6 +5683,10 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5432,11 +5711,22 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -5452,6 +5742,22 @@ packages:
 
   shiki@3.21.0:
     resolution: {integrity: sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -5672,6 +5978,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -5753,6 +6063,10 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -5832,6 +6146,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
@@ -5863,6 +6181,10 @@ packages:
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
@@ -6044,6 +6366,9 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
@@ -6077,6 +6402,11 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
@@ -6763,6 +7093,10 @@ snapshots:
       '@tanstack/vue-virtual': 3.13.24(vue@3.5.33(typescript@6.0.3))
       vue: 3.5.33(typescript@6.0.3)
 
+  '@hono/node-server@1.19.14(hono@4.12.19)':
+    dependencies:
+      hono: 4.12.19
+
   '@hookform/resolvers@5.2.2(react-hook-form@7.75.0(react@19.2.6))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -7050,6 +7384,28 @@ snapshots:
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.19)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.19
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mswjs/interceptors@0.41.3':
     dependencies:
@@ -9399,6 +9755,11 @@ snapshots:
 
   '@xmldom/xmldom@0.9.8': {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-import-attributes@1.9.5(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -9416,6 +9777,17 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
       zod: 4.4.3
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -9486,6 +9858,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   brace-expansion@5.0.5:
@@ -9501,7 +9887,19 @@ snapshots:
       esbuild: 0.27.2
       load-tsconfig: 0.2.5
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001765: {}
 
@@ -9608,11 +10006,26 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -9848,6 +10261,8 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.2
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
@@ -9870,6 +10285,14 @@ snapshots:
 
   dotenv@8.6.0: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
   embla-carousel-react@8.6.0(react@19.2.6):
     dependencies:
       embla-carousel: 8.6.0
@@ -9883,6 +10306,8 @@ snapshots:
   embla-carousel@8.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   enhanced-resolve@5.21.3:
     dependencies:
@@ -9898,7 +10323,15 @@ snapshots:
 
   entities@7.0.1: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   es-toolkit@1.46.1: {}
 
@@ -9976,6 +10409,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@5.0.0: {}
 
   esm@3.2.25: {}
@@ -10023,9 +10458,15 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
 
   eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
 
   execa@8.0.1:
     dependencies:
@@ -10040,6 +10481,44 @@ snapshots:
       strip-final-newline: 3.0.0
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -10060,6 +10539,8 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
+
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -10093,6 +10574,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -10123,6 +10615,10 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -10138,15 +10634,35 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   function-timeout@1.0.2: {}
 
   fuse.js@7.3.0: {}
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
 
   get-own-enumerable-keys@1.0.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@8.0.1: {}
 
@@ -10178,6 +10694,8 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
@@ -10187,6 +10705,12 @@ snapshots:
   hachure-fill@0.5.2: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-embedded@3.0.0:
     dependencies:
@@ -10389,6 +10913,8 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
+  hono@4.12.19: {}
+
   hookable@6.1.1: {}
 
   html-escaper@2.0.2: {}
@@ -10396,6 +10922,14 @@ snapshots:
   html-void-elements@3.0.0: {}
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   human-id@4.1.3: {}
 
@@ -10435,6 +10969,8 @@ snapshots:
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
+  inherits@2.0.4: {}
+
   inline-style-parser@0.2.7: {}
 
   input-otp@1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
@@ -10445,6 +10981,10 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-absolute-url@4.0.1: {}
 
@@ -10485,6 +11025,8 @@ snapshots:
   is-obj@3.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   is-regexp@3.1.0: {}
 
@@ -10527,6 +11069,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   joycon@3.1.1: {}
 
   js-base64@3.7.8: {}
@@ -10541,6 +11085,10 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -10701,6 +11249,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
+
+  math-intrinsics@1.1.0: {}
 
   mathjax-full@3.2.2:
     dependencies:
@@ -10894,6 +11444,10 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -11212,6 +11766,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-fn@4.0.0: {}
 
   minimatch@10.1.1:
@@ -11400,7 +11960,17 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@6.0.0:
     dependencies:
@@ -11526,6 +12096,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-browserify@1.0.1: {}
 
   path-data-parser@0.1.0: {}
@@ -11542,6 +12114,8 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -11570,6 +12144,8 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -11624,6 +12200,15 @@ snapshots:
   prismjs@1.30.0: {}
 
   property-information@7.1.0: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
 
   quansync@0.2.11: {}
 
@@ -11708,6 +12293,15 @@ snapshots:
       vue: 3.5.33(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-compiler-runtime@19.1.0-rc.3(react@19.2.6):
     dependencies:
@@ -12013,6 +12607,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3
@@ -12099,6 +12695,16 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -12117,9 +12723,36 @@ snapshots:
 
   semver@7.7.3: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   server-only@0.0.1: {}
 
   set-cookie-parser@3.1.0: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -12169,6 +12802,34 @@ snapshots:
       '@shikijs/types': 3.21.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -12270,7 +12931,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
 
   super-regex@1.1.0:
@@ -12351,6 +13012,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.19
@@ -12397,7 +13060,7 @@ snapshots:
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.12
@@ -12440,6 +13103,12 @@ snapshots:
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript@6.0.3: {}
 
@@ -12554,6 +13223,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unpipe@1.0.0: {}
+
   until-async@3.0.2: {}
 
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.6):
@@ -12576,6 +13247,8 @@ snapshots:
       react: 19.2.6
 
   uuid@11.1.0: {}
+
+  vary@1.1.2: {}
 
   vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -12730,6 +13403,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrappy@1.0.2: {}
+
   xml2js@0.6.2:
     dependencies:
       sax: 1.5.0
@@ -12756,6 +13431,10 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.3.5: {}
 


### PR DESCRIPTION
## Summary

- Introduces `packages/mcp` (`@rustrak/mcp`): a TypeScript MCP server wrapping `@rustrak/client` that exposes **18 tools** so AI assistants (Claude Desktop, Cursor, Claude Code) can manage Rustrak error tracking directly via stdio transport
- All tools use `server.registerTool()` (non-deprecated SDK v1.29.0 API); errors always returned as `{ isError: true }`, never thrown
- `delete_issue` and `revoke_token` annotated with `destructiveHint: true` for confirmation in supported clients
- 33 Vitest tests using `InMemoryTransport` (in-process, no subprocess)
- `.mcp.json` at repo root for instant local Claude Code use after `pnpm build`
- Auth via `RUSTRAK_API_URL` + `RUSTRAK_API_TOKEN` env vars only — never as tool arguments
- **Server fix**: alert routes switched from `AuthenticatedUser` to `ApiAuth` so token-based clients (MCP) can call alert endpoints

## Tools added (18 total)

| Group | Tools |
|-------|-------|
| Projects | `list_projects`, `get_project`, `create_project` |
| Issues | `list_issues`, `get_issue`, `resolve_issue`, `unresolve_issue`, `mute_issue`, `delete_issue` ⚠️ |
| Events | `list_events`, `get_event` |
| Tokens | `list_tokens`, `create_token`, `revoke_token` ⚠️ |
| Alerts | `list_alert_channels`, `test_alert_channel`, `list_alert_rules` |

## Test plan

- [ ] `pnpm --filter @rustrak/mcp build` → exits 0, `dist/index.js` exists
- [ ] `pnpm --filter @rustrak/mcp test` → 33 tests pass, 0 failures
- [ ] `pnpm --filter @rustrak/mcp typecheck` → 0 TypeScript errors
- [ ] Start server locally, build MCP package, connect via `.mcp.json` in Claude Code → verify tools appear and `list_projects` returns real data
- [ ] Missing `RUSTRAK_API_TOKEN` → server logs error and exits on startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an MCP server (cli) exposing 18 tools for projects, issues, events, tokens, and alerts — enabling AI agents to interact with Rustrak with secure token handling and clear error responses.
* **Documentation**
  * Added full spec and README with setup, quick-start, tool catalog, examples, and testing guidance.
* **Bug Fixes**
  * Alert endpoints updated to use a unified API auth approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbianS/rustrak/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->