### PR TITLE
feat(skills): add analyze-pr-feedback skill

### DIFF
--- a/.claude/skills/analyze-pr-feedback/SKILL.md
+++ b/.claude/skills/analyze-pr-feedback/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: analyze-pr-feedback
+description: 'Analyze Rustrak PR review threads, verdict each as real error vs false positive, fix approved items, commit, push, resolve threads. Use when on a PR branch or given a PR number and wanting to address review feedback.'
+---
+
+# analyze-pr-feedback
+
+Analyzes all review comments on a Rustrak PR — bots and humans alike — against the actual codebase. Produces evidence-based verdicts, applies user-approved fixes, commits and pushes, then resolves all threads on GitHub.
+
+**Your role:** Senior Rustrak developer. Deep knowledge of the stack (Rust/Actix-web, TypeScript/Zod, Next.js). Analytical, skeptical, evidence-driven. Bots are frequently wrong — never accept a bot comment at face value without verifying it against real code. Your verdict comes from reading the code, not the diff.
+
+**Invocation:** `/analyze-pr-feedback [pr_number]`
+
+If no `pr_number` is given, auto-detect it from the current branch.
+
+---
+
+## GLOBAL RULES
+
+- Read the full step file before taking any action
+- Execute sections in order — no skipping
+- Halt at every pause point and wait for user confirmation
+- Load the next step only when directed — never preload
+- **NEVER** commit, push, or call the GitHub API without explicit user approval
+- **FALLBACK:** If an instruction references a subprocess or subagent not available, achieve the outcome in the main thread
+- **Silent success:** Only display output at decision points and on errors
+
+---
+
+## STEP MAP
+
+```
+INPUT: pr_number (explicit arg or auto-detected from current branch)
+│
+step-01-init-fetch        [auto]
+├── Resolve PR number
+├── Fetch PR metadata
+├── GraphQL: all review threads
+├── REST: general reviews
+├── Filter resolved, classify bot/human
+└── → step-02-analyze
+
+step-02-analyze           [auto]
+├── Load project context (CLAUDE.md files + relevant docs)
+├── Per thread: read real code, understand claim, investigate thoroughly
+│   └── Verdict: REAL | FALSE_POSITIVE + evidence + fix_approach / fp_explanation
+└── → step-03-decision
+
+step-03-decision          ← PAUSE: user decides
+├── Compact table (all threads, all verdicts)
+├── [A] Fix all real errors        → step-04-fix-commit
+├── [S] Select by index            → step-04-fix-commit
+├── [N] None                       → step-05-resolve
+└── [C] Cancel → stop
+
+step-04-fix-commit        ← PAUSE: confirm commit
+├── Apply approved fixes (Edit tool only)
+├── Adaptive lint/test pipeline by file type
+├── Show git diff --stat + proposed commit message
+├── [Confirmed] git commit + push to pr_head_branch
+└── → step-05-resolve
+
+step-05-resolve           ← PAUSE: confirm GitHub API calls
+├── Show resolution plan
+├── [Confirmed] GraphQL: resolve fixed threads
+├── REST: reply + resolve FP threads
+├── Reply + resolve skipped threads
+└── Inline final summary
+```
+
+---
+
+## INITIALIZATION
+
+Extract `pr_number` from the argument if provided. Then load and execute `references/step-01-init-fetch.md`.

--- a/.claude/skills/analyze-pr-feedback/references/step-01-init-fetch.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-01-init-fetch.md
@@ -51,6 +51,7 @@ gh api graphql -f query='
             comments(first: 20) {
               nodes {
                 id
+                databaseId
                 body
                 path
                 line
@@ -68,7 +69,7 @@ gh api graphql -f query='
 ' -F owner="AbianS" -F repo="rustrak" -F pr={pr_number}
 ```
 
-Per thread store: `thread_id`, `is_resolved`, `is_outdated`, and per comment: `comment_id`, `author_login`, `body`, `path`, `line`, `diff_hunk`.
+Per thread store: `thread_id`, `is_resolved`, `is_outdated`, and per comment: `comment_id` (GraphQL node ID), `comment_db_id` (integer `databaseId`, used for REST `in_reply_to`), `author_login`, `body`, `path`, `line`, `diff_hunk`.
 
 ### 4. Fetch General Reviews (REST)
 
@@ -84,7 +85,7 @@ Store reviews with non-empty `body` and state CHANGES_REQUESTED or COMMENTED as 
 
 Mark `is_bot = true` if `author_login` ends in `[bot]` or is: `github-actions`, `coderabbitai`, `sonarqube`, `codeclimate`, `renovate`, `dependabot`.
 
-Store remaining as `active_threads`. Store filtered general reviews as `active_reviews`.
+Store remaining as `active_threads`. Set `total_active_threads = active_threads.length`. Store filtered general reviews as `active_reviews`.
 
 **If both empty:** display `✅ PR #{pr_number} has no active review comments.` → stop.
 

--- a/.claude/skills/analyze-pr-feedback/references/step-01-init-fetch.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-01-init-fetch.md
@@ -1,0 +1,99 @@
+---
+name: step-01-init-fetch
+description: Resolve PR number, fetch metadata, all review threads and general reviews, filter and classify
+nextStep: references/step-02-analyze.md
+---
+
+# Step 1: Init + Fetch
+
+## GOAL
+
+Resolve the PR, fetch all active review threads and general reviews. No analysis, no verdicts.
+
+## CONSTANTS
+
+- `repo` = `AbianS/rustrak`
+- `repo_owner` = `AbianS`
+- `repo_name` = `rustrak`
+
+## SEQUENCE
+
+### 1. Resolve PR Number
+
+**If `pr_number` was provided as arg:** use it directly.
+
+**If not:** run `gh pr view --json number` and extract `number` as `pr_number`.
+
+**If it fails:** display `❌ No PR found on current branch. Use: /analyze-pr-feedback 1234` → stop.
+
+### 2. Fetch PR Metadata
+
+```bash
+gh pr view {pr_number} --repo AbianS/rustrak --json number,title,headRefName,baseRefName,state,url,reviewDecision,author
+```
+
+Store: `pr_title`, `pr_head_branch`, `pr_base_branch`, `pr_state`, `pr_url`, `pr_review_decision`, `pr_author`.
+
+**If `pr_state` = MERGED or CLOSED:** display `⚠️ PR #{pr_number} is {pr_state}. Continue anyway? [Y/N]` → halt. N → stop.
+
+### 3. Fetch Review Threads (GraphQL)
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            comments(first: 20) {
+              nodes {
+                id
+                body
+                path
+                line
+                startLine
+                diffHunk
+                createdAt
+                author { login }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -F owner="AbianS" -F repo="rustrak" -F pr={pr_number}
+```
+
+Per thread store: `thread_id`, `is_resolved`, `is_outdated`, and per comment: `comment_id`, `author_login`, `body`, `path`, `line`, `diff_hunk`.
+
+### 4. Fetch General Reviews (REST)
+
+```bash
+gh api repos/AbianS/rustrak/pulls/{pr_number}/reviews
+```
+
+Store reviews with non-empty `body` and state CHANGES_REQUESTED or COMMENTED as `general_reviews` array (fields: `review_id`, `author_login`, `body`, `state`, `submitted_at`).
+
+### 5. Filter and Classify
+
+**Discard** threads where `is_resolved = true`.
+
+Mark `is_bot = true` if `author_login` ends in `[bot]` or is: `github-actions`, `coderabbitai`, `sonarqube`, `codeclimate`, `renovate`, `dependabot`.
+
+Store remaining as `active_threads`. Store filtered general reviews as `active_reviews`.
+
+**If both empty:** display `✅ PR #{pr_number} has no active review comments.` → stop.
+
+### 6. Display and Proceed
+
+Display one line:
+```
+PR #{pr_number} — {pr_title}
+{active_threads.count} inline threads ({bot_count} bots, {human_count} humans) + {active_reviews.count} general reviews. Analyzing...
+```
+
+Load and execute `{nextStep}`.

--- a/.claude/skills/analyze-pr-feedback/references/step-02-analyze.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-02-analyze.md
@@ -1,0 +1,97 @@
+---
+name: step-02-analyze
+description: Load project context, exhaustive per-thread analysis against real code, verdict REAL or FALSE_POSITIVE with evidence
+nextStep: references/step-03-decision.md
+---
+
+# Step 2: Analyze
+
+## GOAL
+
+Produce an evidence-based verdict for every active thread. Your opinion comes from the code, not from the diff hunk or the comment text.
+
+## ANALYSIS MINDSET
+
+Review bots (CodeRabbit, SonarQube, etc.) make frequent mistakes with:
+- Idiomatic Rust patterns they don't understand (lifetimes, ownership, error propagation with `?`)
+- TypeScript strict mode with Zod — they confuse inferred types with incorrect types
+- Project conventions that aren't in the diff but are present in surrounding code
+- Code that looks wrong in the diff but is protected upstream
+
+Be extremely skeptical. The burden of proof is on the comment — if you cannot confirm the claim with real code, it's a FALSE_POSITIVE.
+
+## SEQUENCE
+
+### 1. Load Project Context
+
+Before analyzing any thread, read:
+- `{project-root}/CLAUDE.md` — vision, stack, conventions, auth architecture
+- `{project-root}/apps/server/CLAUDE.md` — Rust conventions, error patterns, ingestion
+- `{project-root}/packages/client/CLAUDE.md` — TypeScript conventions, testing
+- `{project-root}/apps/webview-ui/CLAUDE.md` — Next.js conventions
+
+If any thread touches ingestion endpoints, grouping logic, or the Sentry protocol, also read:
+- `{project-root}/docs/ingestion-flow.md`
+- `{project-root}/docs/api-design.md`
+- `{project-root}/docs/grouping-algorithm.md`
+
+This context is your authority reference for deciding what is an intentional convention vs a real error.
+
+### 2. Analyze Each Thread
+
+Process `active_threads` one by one. For each:
+
+#### a. Read the Real Code
+
+**If the thread has `path`:** read the full file or at least ±50 lines around `line`. Also read `diff_hunk` as additional context — never as the sole source.
+
+**For Rust files** (`apps/server/`): understand the return type, implemented traits, error handling, and whether `#[allow(...)]` indicates a conscious decision.
+
+**For TypeScript files** (`packages/client/`, `apps/webview-ui/`): understand inferred types, Zod schemas, and whether the code is covered by tests.
+
+#### b. Understand the Claim
+
+Extract:
+- `comment_claim` — what the reviewer asserts (one sentence, max 60 chars)
+- `comment_type` — one of: `style` | `logic` | `security` | `performance` | `typing` | `test` | `docs` | `unsafe` | `api-contract`
+
+#### c. Investigate Thoroughly
+
+Before issuing a verdict, verify:
+
+1. Is the claim technically accurate at the referenced location?
+2. Does the same pattern exist elsewhere in the project? (grep/glob) — if it's a recurring pattern, it's likely an intentional convention.
+3. Is the concern already handled? (upstream validation, error handling in the caller, Actix framework guarantees, Zod type that prevents the case)
+4. Is this a conscious decision documented in CLAUDE.md or in nearby comments?
+5. Is `comment_type` `unsafe` or `security`? If so, investigate deeper — the bar for FALSE_POSITIVE is higher here.
+6. Is the bot flagging something idiomatic in Rust/TypeScript that it simply doesn't know? (e.g., `unwrap()` in initialization code, `expect()` with a clear message, `async_trait`, `impl Trait` in return position)
+
+#### d. Verdict
+
+**`REAL`** — the claim is accurate AND the issue causes or could cause: incorrect behavior, data corruption, security vulnerability, runtime panic, or unhandled error. AND it is NOT mitigated by another mechanism in the codebase.
+
+**`FALSE_POSITIVE`** — the claim is inaccurate, already handled, contradicts an established project convention, is a different style with no functional impact, or the bot does not understand the language/framework idiom.
+
+Store per thread:
+```
+{
+  thread_id, index, author_login, is_bot,
+  path, line, comment_claim, comment_type,
+  verdict: "REAL" | "FALSE_POSITIVE",
+  evidence,       // 1-2 sentences citing specific code with line reference
+  fix_approach,   // REAL only: brief proposed fix (max 60 chars)
+  fp_explanation  // FALSE_POSITIVE only: why no change is needed (max 60 chars)
+}
+```
+
+Add to `analysis_results`.
+
+### 3. Analyze General Reviews
+
+For each entry in `active_reviews`: read the body, extract concrete concerns, apply the same verdict logic. Store in `analysis_results` with `path: null`.
+
+### 4. Compute Stats and Proceed
+
+Compute: `total_analyzed`, `count_real`, `count_fp`.
+
+Load and execute `{nextStep}`.

--- a/.claude/skills/analyze-pr-feedback/references/step-02-analyze.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-02-analyze.md
@@ -75,7 +75,7 @@ Before issuing a verdict, verify:
 Store per thread:
 ```
 {
-  thread_id, index, author_login, is_bot,
+  thread_id, comment_id, index, author_login, is_bot,
   path, line, comment_claim, comment_type,
   verdict: "REAL" | "FALSE_POSITIVE",
   evidence,       // 1-2 sentences citing specific code with line reference

--- a/.claude/skills/analyze-pr-feedback/references/step-03-decision.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-03-decision.md
@@ -1,0 +1,58 @@
+---
+name: step-03-decision
+description: Display analysis as a compact table, await user decision on which errors to fix
+nextStepFix: references/step-04-fix-commit.md
+nextStepResolve: references/step-05-resolve.md
+---
+
+# Step 3: Decision
+
+## GOAL
+
+Show the full analysis in a single compact table. Get user decision. No changes yet.
+
+## SEQUENCE
+
+### 1. Display Analysis Table
+
+```
+PR #{pr_number} — {pr_title}
+{count_real} real errors · {count_fp} false positives · {total_analyzed} total
+
+| #  | Author             | Type         | File:line                       | Verdict       | Summary / Action                             |
+|----|--------------------|--------------|---------------------------------|---------------|----------------------------------------------|
+| 1  | coderabbit 🤖      | logic        | src/routes/ingest.rs:87         | 🔴 REAL       | unwrap() without context on critical path    |
+| 2  | coderabbit 🤖      | style        | src/models/event.rs:34          | 🟡 FP         | Idiomatic Rust pattern — project convention  |
+| 3  | abians 👤          | security     | src/auth/middleware.rs:112      | 🔴 REAL       | Token exposed in error log                   |
+```
+
+Table rules:
+- One row per thread in `analysis_results`
+- `Author`: `{author_login}` + `🤖` if `is_bot`, `👤` if human
+- `File:line`: `{path}:{line}` truncated to 35 chars, or `(general)` if `path` is null
+- `Verdict`: `🔴 REAL` or `🟡 FP`
+- `Summary / Action`: for REAL → `fix_approach` (max 50 chars); for FP → `fp_explanation` (max 50 chars)
+
+### 2. Decision Menu
+
+**If `count_real = 0`:**
+```
+No real errors detected. Proceed to resolve all comments on GitHub? [Y/N]
+```
+Halt. Y → set `approved_fixes = []`, load `{nextStepResolve}`. N → stop.
+
+**If `count_real > 0`:**
+```
+Which fixes to apply?
+  [A] All real errors ({count_real})
+  [S] Manual selection — specify indices (e.g.: 1,3)
+  [N] None — only resolve comments on GitHub
+  [C] Cancel
+```
+Halt and wait.
+
+- **[A]:** `approved_fixes` = all REAL results → load `{nextStepFix}`
+- **[S]:** ask `Which indices? (e.g.: 1,3)` → parse. If a selected index is FP: `⚠️ #{index} is a false positive. Include anyway? [Y/N]`. Set `approved_fixes`. If `approved_fixes` is empty (all rejected): `No fixes selected.` → load `{nextStepResolve}`. Otherwise → load `{nextStepFix}`
+- **[N]:** `approved_fixes = []` → load `{nextStepResolve}`
+- **[C]:** `Cancelled. No changes have been applied.` → stop
+- **Unrecognized input:** re-display menu

--- a/.claude/skills/analyze-pr-feedback/references/step-04-fix-commit.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-04-fix-commit.md
@@ -1,0 +1,130 @@
+---
+name: step-04-fix-commit
+description: Apply approved fixes, adaptive lint/test pipeline by file type, confirm and commit+push to PR branch
+nextStep: references/step-05-resolve.md
+---
+
+# Step 4: Fix + Commit
+
+## GOAL
+
+Apply only `approved_fixes`. Lint and tests adapted to the touched files. Confirm commit message. Commit + push to `pr_head_branch`. No GitHub API calls.
+
+## CONSTRAINTS
+
+- Fix ONLY items in `approved_fixes` — no opportunistic refactoring
+- NEVER use `--no-verify`
+- NEVER push to `main`
+- NEVER open a new PR
+
+## SEQUENCE
+
+### 1. Apply Each Fix
+
+For each item in `approved_fixes`:
+
+**a.** Read `{path}` if not already in memory.
+
+**b.** Apply the change with the `Edit` tool as described in `fix_approach`. Preserve existing code style. Fix ONLY what the comment addresses.
+
+**c.** If the fix is non-trivial (schema change, new module, migration):
+```
+⚠️ Fix #{index} is complex: {description}. Proceed? [Y/N]
+```
+Halt. N → add to `skipped_fixes` with reason, continue with the next.
+
+Mark `fix_applied = true` for applied items.
+
+### 2. Lint and Test Pipeline
+
+Determine which pipelines to run based on the paths of modified files:
+
+#### Rust files (`apps/server/`)
+
+```bash
+cd apps/server && cargo fmt
+```
+```bash
+cd apps/server && cargo clippy -- -D warnings
+```
+**If clippy reports errors:** display them and fix before continuing.
+
+```bash
+cd apps/server && cargo test
+```
+**If tests fail:** display the failure. If pre-existing (not caused by the fixes): ask `Pre-existing failure unrelated to these changes. Continue? [Y/N]`.
+
+#### TypeScript — Client (`packages/client/`)
+
+```bash
+pnpm --filter @rustrak/client test
+```
+**If tests fail:** display the failure. If pre-existing: ask the same question as Rust.
+
+#### Next.js — WebView UI (`apps/webview-ui/`)
+
+```bash
+pnpm --filter webview-ui build
+```
+No unit tests — display `ℹ️ Changes in webview-ui — manual validation recommended.`
+
+#### Changes across multiple zones
+
+Run each affected zone's pipeline in order: server → client → webview-ui.
+
+### 3. Show Diff and Propose Commit
+
+Run `git diff --stat` and `git status --short`. Display:
+
+```
+Modified files:
+{git diff --stat output}
+
+Fixes applied: {count}
+{for each fix_applied: "  [{index}] {path}:{line} — {comment_claim}"}
+{if skipped_fixes: "Skipped: {count} — {reasons}"}
+
+Proposed commit:
+fix({scope}): address PR #{pr_number} review feedback
+
+{2-3 lines describing what was fixed and why}
+
+[Y] Confirm  [E] Edit message  [C] Cancel
+```
+
+`scope` = most affected module in kebab-case. If spanning unrelated zones → `review`.
+
+Halt. C → `Changes are in your working tree. No commit was made.` → stop.
+
+### 4. Stage, Commit, Push
+
+Stage only the files modified by `approved_fixes`:
+```bash
+git add {paths from approved_fixes that were actually modified}
+```
+
+Verify with `git status` — if unrelated files appear, `git restore --staged` them.
+
+```bash
+git commit -m "$(cat <<'EOF'
+{commit_message}
+EOF
+)"
+```
+
+**If commit fails (hook):** display the error, fix it, re-stage, create a new commit — never use `--no-verify`.
+
+Store `commit_sha`. Display: `✅ Commit: {commit_sha}`
+
+```bash
+git push origin {pr_head_branch}
+```
+
+**If push is rejected:** ask `⚠️ Push was rejected. Force push? [Y/N]` — NEVER force without explicit confirmation.
+
+- **[Y]:** `git push --force-with-lease origin {pr_head_branch}` → success: `✅ Force pushed: {pr_head_branch}` → failure: display error → stop.
+- **[N]:** `Changes are committed locally. Push cancelled.` → stop.
+
+Display: `✅ Pushed to {pr_head_branch}.`
+
+Load and execute `{nextStep}`.

--- a/.claude/skills/analyze-pr-feedback/references/step-05-resolve.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-05-resolve.md
@@ -22,7 +22,7 @@ Resolve every active thread on GitHub. Fixed → mark resolved. FP/skipped → r
 ```
 Resolution plan — {total_active_threads} threads:
 
-  🔴 Resolve (fixed):              {count_fixed}
+  🔴 Resolve (fixed):              {count_fix_applied}
   🟡 Reply + resolve (FP):         {count_fp}
   ⏭️  Reply + resolve (skipped):    {count_skipped}
 
@@ -53,12 +53,14 @@ For each thread where `verdict = FALSE_POSITIVE`:
 
 **a. Post reply:**
 ```bash
-gh api repos/AbianS/rustrak/pulls/{pr_number}/comments \
+gh api repos/{repo_owner}/{repo_name}/pulls/{pr_number}/comments \
   --method POST \
-  -f body="> {first 60 chars of comment_claim}...
-
-Reviewed: {fp_explanation}. No changes needed." \
-  -f in_reply_to={comment_id}
+  --input - << 'BODY'
+{
+  "body": "> {first 60 chars of comment_claim}...\n\nReviewed: {fp_explanation}. No changes needed.",
+  "in_reply_to": {comment_id}
+}
+BODY
 ```
 
 **b. Resolve thread** (same GraphQL mutation as step 2).
@@ -78,7 +80,7 @@ Then resolve via GraphQL.
 **If `active_reviews` is non-empty:** post a single consolidated response:
 
 ```bash
-gh api repos/AbianS/rustrak/pulls/{pr_number}/reviews \
+gh api repos/{repo_owner}/{repo_name}/pulls/{pr_number}/reviews \
   --method POST \
   -f body="All comments in this review have been analyzed and processed. See recent commits." \
   -f event="COMMENT"

--- a/.claude/skills/analyze-pr-feedback/references/step-05-resolve.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-05-resolve.md
@@ -1,0 +1,100 @@
+---
+name: step-05-resolve
+description: Confirm, resolve all GitHub threads (fixed → resolve, FP → reply + resolve), print final summary
+---
+
+# Step 5: Resolve + Summary
+
+## GOAL
+
+Resolve every active thread on GitHub. Fixed → mark resolved. FP/skipped → reply with explanation then resolve. Inline final summary.
+
+## CONSTRAINTS
+
+- NEVER call the GitHub API without user confirmation
+- NEVER resolve threads that had `is_resolved = true` at fetch time
+- No git commands in this step
+
+## SEQUENCE
+
+### 1. Show Plan and Confirm
+
+```
+Resolution plan — {total_active_threads} threads:
+
+  🔴 Resolve (fixed):              {count_fixed}
+  🟡 Reply + resolve (FP):         {count_fp}
+  ⏭️  Reply + resolve (skipped):    {count_skipped}
+
+Proceed? [Y/N]
+```
+
+Halt. N → stop.
+
+### 2. Resolve Fixed Threads
+
+For each thread in `approved_fixes` where `fix_applied = true`:
+
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }
+' -F threadId="{thread_id}"
+```
+
+On error: store in `resolve_errors`, continue.
+
+### 3. Reply + Resolve FP Threads
+
+For each thread where `verdict = FALSE_POSITIVE`:
+
+**a. Post reply:**
+```bash
+gh api repos/AbianS/rustrak/pulls/{pr_number}/comments \
+  --method POST \
+  -f body="> {first 60 chars of comment_claim}...
+
+Reviewed: {fp_explanation}. No changes needed." \
+  -f in_reply_to={comment_id}
+```
+
+**b. Resolve thread** (same GraphQL mutation as step 2).
+
+On error: store in `resolve_errors`, continue.
+
+### 4. Reply + Resolve Skipped Threads
+
+For each thread in `skipped_fixes`:
+
+Reply: `Reviewed. The proposed fix requires broader changes ({skip_reason}). Will be addressed in a separate commit.`
+
+Then resolve via GraphQL.
+
+### 5. Reply to General Reviews
+
+**If `active_reviews` is non-empty:** post a single consolidated response:
+
+```bash
+gh api repos/AbianS/rustrak/pulls/{pr_number}/reviews \
+  --method POST \
+  -f body="All comments in this review have been analyzed and processed. See recent commits." \
+  -f event="COMMENT"
+```
+
+### 6. Final Summary
+
+```
+✅ PR #{pr_number} — {pr_title}
+{pr_url}
+
+Comments:  {total_analyzed} analyzed · {count_real} real · {count_fp} FP
+Fixes:     {count_fix_applied} applied{if skipped: " · {count} skipped"}
+{if commit_sha: "Commit:    {commit_sha} → {pr_head_branch}"}
+Resolved:  {count_resolved} threads
+{if resolve_errors: "⚠️  API errors: {count} — resolve manually at {pr_url}"}
+```
+
+End of workflow.

--- a/.claude/skills/analyze-pr-feedback/references/step-05-resolve.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-05-resolve.md
@@ -31,6 +31,8 @@ Proceed? [Y/N]
 
 Halt. N → stop.
 
+Initialize: `count_resolved = 0`, `resolve_errors = []`.
+
 ### 2. Resolve Fixed Threads
 
 For each thread in `approved_fixes` where `fix_applied = true`:
@@ -45,7 +47,7 @@ gh api graphql -f query='
 ' -F threadId="{thread_id}"
 ```
 
-On error: store in `resolve_errors`, continue.
+On success: `count_resolved += 1`. On error: store in `resolve_errors`, continue.
 
 ### 3. Reply + Resolve FP Threads
 
@@ -53,19 +55,18 @@ For each thread where `verdict = FALSE_POSITIVE`:
 
 **a. Post reply:**
 ```bash
+jq -n \
+  --arg body "> {first 60 chars of comment_claim}...\n\nReviewed: {fp_explanation}. No changes needed." \
+  --argjson id {comment_db_id} \
+  '{"body": $body, "in_reply_to": $id}' | \
 gh api repos/{repo_owner}/{repo_name}/pulls/{pr_number}/comments \
   --method POST \
-  --input - << 'BODY'
-{
-  "body": "> {first 60 chars of comment_claim}...\n\nReviewed: {fp_explanation}. No changes needed.",
-  "in_reply_to": {comment_id}
-}
-BODY
+  --input -
 ```
 
 **b. Resolve thread** (same GraphQL mutation as step 2).
 
-On error: store in `resolve_errors`, continue.
+On success: `count_resolved += 1`. On error: store in `resolve_errors`, continue.
 
 ### 4. Reply + Resolve Skipped Threads
 
@@ -73,7 +74,7 @@ For each thread in `skipped_fixes`:
 
 Reply: `Reviewed. The proposed fix requires broader changes ({skip_reason}). Will be addressed in a separate commit.`
 
-Then resolve via GraphQL.
+Then resolve via GraphQL. On success: `count_resolved += 1`. On error: store in `resolve_errors`, continue.
 
 ### 5. Reply to General Reviews
 


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/analyze-pr-feedback/` — a 5-step workflow for analyzing and resolving PR review comments on Rustrak
- Fetches all inline threads (GraphQL) and general reviews (REST) for a given PR
- Loads full project context (all CLAUDE.md files + relevant docs) before analyzing — gives the LLM authoritative knowledge of Rustrak conventions
- Produces evidence-based verdicts: `REAL` or `FALSE_POSITIVE` per thread, with explicit skepticism toward bot comments (CodeRabbit, SonarQube, etc.)
- Adaptive lint/test pipeline: `cargo fmt + clippy + test` for Rust, `vitest` for `@rustrak/client`, build check for `webview-ui`
- Resolves all threads on GitHub after fixes — fixed ones silently, false positives with an explanation reply

## Test plan

- [ ] Run `/analyze-pr-feedback <pr_number>` on an open PR with bot comments
- [ ] Verify the analysis table renders correctly with REAL/FP verdicts
- [ ] Confirm fixes are applied only to approved items
- [ ] Confirm lint/test pipeline runs the correct tools based on which files were touched
- [ ] Confirm GitHub threads are resolved after step 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /analyze-pr-feedback — an end-to-end PR review analysis workflow that gathers PR metadata and review comments, classifies inline feedback as real or false positive with evidence, proposes fixes, runs targeted lint/test checks, and prepares commits and thread resolutions.
* **Documentation**
  * Detailed interactive step-by-step guidance with explicit pause/confirmation points before applying edits, pushing commits, or resolving review threads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbianS/rustrak/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->