### PR TITLE
feat(docs): add blog section

### DIFF
--- a/.changeset/docs-blog-section.md
+++ b/.changeset/docs-blog-section.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Add blog section to documentation site

--- a/apps/docs/content/_meta.js
+++ b/apps/docs/content/_meta.js
@@ -18,6 +18,16 @@ export default {
     type: 'page',
     href: '/getting-started/overview',
   },
+  blog: {
+    title: 'Blog',
+    type: 'page',
+    theme: {
+      sidebar: false,
+      toc: false,
+      breadcrumb: false,
+      pagination: false,
+    },
+  },
   'getting-started': 'Getting Started',
   configuration: 'Configuration',
   usage: 'Usage',

--- a/apps/docs/content/blog/introducing-rustrak.mdx
+++ b/apps/docs/content/blog/introducing-rustrak.mdx
@@ -1,0 +1,103 @@
+---
+title: "Introducing Rustrak: Self-Hosted Error Tracking for the Paranoid"
+description: "Why we built another error tracker, how it works, and what makes Rustrak different from the cloud options you're already paying too much for."
+date: "2026-01-22"
+author: "Abian Suarez"
+tags: ["release", "rust", "architecture"]
+---
+
+Error tracking is one of those things that feels solved. Sentry exists. Rollbar exists. Datadog will happily charge you $400/month to tell you your server is on fire. So why build another one?
+
+Because most teams don't need a SaaS platform. They need a binary that runs in Docker, speaks the Sentry protocol, and doesn't phone home.
+
+## The Problem with the Alternatives
+
+Sentry is excellent. Their open-source self-hosted version is also excellent — and it requires PostgreSQL, Redis, Kafka, Zookeeper, Celery, and a minimum of 8GB RAM to run locally. That's fine for a company. It's overkill for a startup, a side project, or a team that just wants to know when their app crashes.
+
+The lightweight alternatives either abandoned the Sentry SDK ecosystem (forcing you to rewrite your instrumentation) or they're still cloud-only.
+
+## What Rustrak Does
+
+Rustrak is an API server written in Rust that accepts events from any Sentry SDK and stores them in PostgreSQL. That's it.
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌──────────────┐
+│   Your App      │────▶│  Rustrak Server │────▶│  PostgreSQL  │
+│ (Sentry SDK)    │     │  (Rust/Actix)   │     │              │
+└─────────────────┘     └─────────────────┘     └──────────────┘
+```
+
+You point your existing `SENTRY_DSN` at a Rustrak instance and it works. No SDK changes. No vendor lock-in. Your existing error tracking code stays exactly as-is.
+
+## Architecture: Two-Phase Ingestion
+
+One design decision we're particularly happy with is the two-phase ingestion model:
+
+**Phase 1 — Ingest (synchronous, &lt;50ms):** The SDK sends an event envelope. Rustrak parses it, validates the DSN and auth token, stores the raw event, and returns `200 OK`. This phase is intentionally minimal — we prioritize acknowledging the event over processing it.
+
+**Phase 2 — Digest (asynchronous):** A background worker picks up the raw event, calculates its fingerprint, finds or creates the corresponding issue, and updates all the counters. This happens out of band and doesn't affect the SDK's experience.
+
+This matters because ingestion latency directly affects your application. A slow error tracker can cascade into production issues. By keeping Phase 1 under 50ms and doing all the heavy work asynchronously, the SDK always gets a fast response.
+
+## Issue Grouping
+
+Events get grouped into Issues using a deterministic fingerprinting algorithm:
+
+1. If the event has a custom `fingerprint` field, use that.
+2. Otherwise, hash `exception_type + first_line_of_message + transaction`.
+3. For log events, hash `log_message + transaction`.
+4. Fallback to the event type.
+
+The same error happening 1,000 times shows up as one Issue with a count of 1,000. This is the core value of error tracking — noise reduction.
+
+## Memory Footprint
+
+One of our goals was a server that runs comfortably in constrained environments. At idle, Rustrak sits at around 30–50MB of RAM. Under load (hundreds of events/second), it stays well under 100MB. The async runtime (Tokio) and the lightweight HTTP framework (Actix-web) make this possible without any manual tuning.
+
+For comparison: the minimum recommended RAM for Sentry's self-hosted stack is 3GB.
+
+## Getting Started
+
+The fastest way is with Docker — no database setup required, SQLite is included by default.
+
+```yaml
+# docker-compose.yml
+services:
+  server:
+    image: abians7/rustrak-server:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - rustrak_data:/data
+    environment:
+      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY}
+      - CREATE_SUPERUSER=${CREATE_SUPERUSER}
+    restart: unless-stopped
+
+  ui:
+    image: abians7/rustrak-ui:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - RUSTRAK_API_URL=http://server:8080
+    depends_on:
+      - server
+    restart: unless-stopped
+
+volumes:
+  rustrak_data:
+```
+
+```bash
+SESSION_SECRET_KEY=$(openssl rand -hex 32)
+CREATE_SUPERUSER=admin@example.com:changeme123
+docker compose up -d
+```
+
+Open `http://localhost:3000`, log in, create a project, and point your existing Sentry SDK at it:
+
+```javascript
+Sentry.init({ dsn: "http://<key>@localhost:8080/<project_id>" })
+```
+
+No SDK changes. It just works. The [Getting Started guide](/getting-started/overview) covers PostgreSQL, environment variables, and production setup in detail.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,14 +10,17 @@
   "dependencies": {
     "@radix-ui/react-slot": "1.2.4",
     "@scalar/api-reference-react": "0.9.37",
+    "@tailwindcss/typography": "^0.5.19",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "gray-matter": "^4.0.3",
     "lucide-react": "1.16.0",
     "next": "16.2.6",
     "nextra": "4.6.1",
     "nextra-theme-docs": "4.6.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",
+    "reading-time": "^1.5.0",
     "tailwind-merge": "3.6.0"
   },
   "devDependencies": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,17 +10,17 @@
   "dependencies": {
     "@radix-ui/react-slot": "1.2.4",
     "@scalar/api-reference-react": "0.9.37",
-    "@tailwindcss/typography": "^0.5.19",
+    "@tailwindcss/typography": "0.5.19",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
-    "gray-matter": "^4.0.3",
+    "gray-matter": "4.0.3",
     "lucide-react": "1.16.0",
     "next": "16.2.6",
     "nextra": "4.6.1",
     "nextra-theme-docs": "4.6.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "reading-time": "^1.5.0",
+    "reading-time": "1.5.0",
     "tailwind-merge": "3.6.0"
   },
   "devDependencies": {

--- a/apps/docs/src/app/[[...mdxPath]]/page.tsx
+++ b/apps/docs/src/app/[[...mdxPath]]/page.tsx
@@ -1,7 +1,13 @@
 import { generateStaticParamsFor, importPage } from 'nextra/pages';
 import { useMDXComponents } from '../../../mdx-components';
 
-export const generateStaticParams = generateStaticParamsFor('mdxPath');
+export async function generateStaticParams() {
+  const all = await generateStaticParamsFor('mdxPath')();
+  // Blog posts are handled by app/blog/[slug]/page.tsx
+  return all.filter(
+    (p) => !Array.isArray(p.mdxPath) || p.mdxPath[0] !== 'blog',
+  );
+}
 
 // Return 404 for paths not in generateStaticParams
 export const dynamicParams = false;

--- a/apps/docs/src/app/blog/[slug]/page.tsx
+++ b/apps/docs/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,72 @@
+import { notFound } from 'next/navigation';
+import { importPage } from 'nextra/pages';
+import { PostHeader } from '@/components/blog/post-header';
+import { getPost, getPosts } from '@/lib/blog';
+
+type PageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  return getPosts().map((p) => ({ slug: p.slug }));
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params;
+  const result = getPost(slug);
+  if (!result) return {};
+  const { post } = result;
+  return {
+    title: post.title,
+    description: post.description,
+    openGraph: {
+      title: post.title,
+      description: post.description,
+      type: 'article',
+      publishedTime: post.date,
+      authors: [post.author],
+      ...(post.image ? { images: [{ url: post.image }] } : {}),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.description,
+    },
+  };
+}
+
+export default async function BlogPostPage({ params }: PageProps) {
+  const { slug } = await params;
+  const result = getPost(slug);
+  if (!result) notFound();
+
+  const { post } = result;
+
+  let MDXContent: React.ComponentType;
+  try {
+    const imported = await importPage(['blog', slug]);
+    MDXContent = imported.default;
+  } catch {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-16">
+      <PostHeader post={post} />
+      <article className="prose prose-neutral dark:prose-invert max-w-none prose-headings:font-bold prose-headings:tracking-tight prose-a:text-primary prose-code:font-mono prose-pre:bg-transparent prose-pre:p-0">
+        <MDXContent />
+      </article>
+
+      <footer className="mt-16 pt-8 border-t border-neutral-200 dark:border-neutral-800">
+        <a
+          href="/blog"
+          className="text-sm font-medium text-neutral-500 dark:text-neutral-400 hover:text-primary transition-colors"
+        >
+          ← Back to Blog
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/apps/docs/src/app/blog/blog-layout-client.tsx
+++ b/apps/docs/src/app/blog/blog-layout-client.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export function BlogLayoutClient() {
+  useEffect(() => {
+    document.body.classList.add('blog-layout');
+    return () => {
+      document.body.classList.remove('blog-layout');
+    };
+  }, []);
+  return null;
+}

--- a/apps/docs/src/app/blog/layout.tsx
+++ b/apps/docs/src/app/blog/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import { BlogLayoutClient } from './blog-layout-client';
+
+export const metadata: Metadata = {
+  title: {
+    default: 'Blog',
+    template: '%s — Rustrak Blog',
+  },
+  description:
+    'Updates, releases, and engineering notes from the Rustrak project.',
+};
+
+export default function BlogLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <BlogLayoutClient />
+      <div className="blog-section min-h-screen w-full">{children}</div>
+    </>
+  );
+}

--- a/apps/docs/src/app/blog/page.tsx
+++ b/apps/docs/src/app/blog/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next';
+import { PostCard } from '@/components/blog/post-card';
+import { getPosts } from '@/lib/blog';
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description:
+    'Updates, releases, and engineering notes from the Rustrak project.',
+};
+
+export default function BlogPage() {
+  const posts = getPosts();
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-16">
+      <div className="mb-12">
+        <h1 className="text-4xl font-extrabold tracking-tight text-neutral-900 dark:text-neutral-100 mb-3">
+          Blog
+        </h1>
+        <p className="text-lg text-neutral-600 dark:text-neutral-400">
+          Updates, releases, and engineering notes from the Rustrak project.
+        </p>
+      </div>
+
+      {posts.length === 0 ? (
+        <p className="text-neutral-500 dark:text-neutral-400 py-16 text-center">
+          No posts yet. Check back soon.
+        </p>
+      ) : (
+        <div>
+          {posts.map((post) => (
+            <PostCard key={post.slug} post={post} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 @import "nextra-theme-docs/style.css";
 
+@plugin "@tailwindcss/typography";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
@@ -169,4 +171,40 @@ html.dark {
 
 .dark .nextra-toc a[aria-current="true"] {
   color: oklch(0.91 0.18 127);
+}
+
+/* Blog layout: hide sidebar and TOC, use full-width content */
+body.blog-layout .nextra-sidebar-container,
+body.blog-layout .nextra-toc {
+  display: none !important;
+}
+
+body.blog-layout article.nextra-content,
+body.blog-layout .nextra-content {
+  max-width: none !important;
+  padding: 0 !important;
+}
+
+/* Blog prose customization */
+.blog-section .prose {
+  --tw-prose-links: oklch(0.65 0.18 127);
+  --tw-prose-invert-links: oklch(0.91 0.18 127);
+  --tw-prose-code: inherit;
+  --tw-prose-pre-bg: transparent;
+}
+
+.blog-section .prose pre {
+  padding: 0;
+  background: transparent;
+}
+
+.blog-section .prose :not(pre) > code {
+  background: oklch(0.96 0 0);
+  padding: 0.15em 0.35em;
+  border-radius: 0.25rem;
+  font-size: 0.875em;
+}
+
+.dark .blog-section .prose :not(pre) > code {
+  background: oklch(0.22 0 0);
 }

--- a/apps/docs/src/components/blog/post-card.tsx
+++ b/apps/docs/src/components/blog/post-card.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+import type { Post } from '@/lib/blog';
+import { formatDate } from '@/lib/blog';
+import { TagPill } from './tag-pill';
+
+type PostCardProps = {
+  post: Post;
+};
+
+export function PostCard({ post }: PostCardProps) {
+  return (
+    <Link
+      href={`/blog/${post.slug}`}
+      className="group block py-8 border-b border-neutral-200 dark:border-neutral-800 last:border-0"
+    >
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mb-3 text-sm text-neutral-500 dark:text-neutral-400">
+        <time dateTime={post.date}>{formatDate(post.date)}</time>
+        <span aria-hidden>·</span>
+        <span>{post.readingTime}</span>
+        {post.author && (
+          <>
+            <span aria-hidden>·</span>
+            <span>{post.author}</span>
+          </>
+        )}
+      </div>
+
+      <h2 className="text-xl font-bold tracking-tight mb-2 text-neutral-900 dark:text-neutral-100 group-hover:text-primary transition-colors duration-150">
+        {post.title}
+      </h2>
+
+      {post.description && (
+        <p className="text-neutral-600 dark:text-neutral-400 text-sm leading-relaxed line-clamp-2 mb-4">
+          {post.description}
+        </p>
+      )}
+
+      {post.tags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {post.tags.map((tag) => (
+            <TagPill key={tag} tag={tag} />
+          ))}
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/apps/docs/src/components/blog/post-header.tsx
+++ b/apps/docs/src/components/blog/post-header.tsx
@@ -1,0 +1,43 @@
+import type { Post } from '@/lib/blog';
+import { formatDate } from '@/lib/blog';
+import { TagPill } from './tag-pill';
+
+type PostHeaderProps = {
+  post: Post;
+};
+
+export function PostHeader({ post }: PostHeaderProps) {
+  return (
+    <header className="mb-12 pb-8 border-b border-neutral-200 dark:border-neutral-800">
+      {post.tags.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-4">
+          {post.tags.map((tag) => (
+            <TagPill key={tag} tag={tag} />
+          ))}
+        </div>
+      )}
+
+      <h1 className="text-4xl font-extrabold tracking-tight text-neutral-900 dark:text-neutral-100 mb-4 leading-tight">
+        {post.title}
+      </h1>
+
+      {post.description && (
+        <p className="text-lg text-neutral-600 dark:text-neutral-400 leading-relaxed mb-6">
+          {post.description}
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-neutral-500 dark:text-neutral-400">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-neutral-700 dark:text-neutral-300">
+            {post.author}
+          </span>
+        </div>
+        <span aria-hidden>·</span>
+        <time dateTime={post.date}>{formatDate(post.date)}</time>
+        <span aria-hidden>·</span>
+        <span>{post.readingTime}</span>
+      </div>
+    </header>
+  );
+}

--- a/apps/docs/src/components/blog/tag-pill.tsx
+++ b/apps/docs/src/components/blog/tag-pill.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+type TagPillProps = {
+  tag: string;
+  href?: string;
+  className?: string;
+};
+
+export function TagPill({ tag, href, className }: TagPillProps) {
+  const classes = cn(
+    'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors',
+    'bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400',
+    'hover:bg-primary/10 hover:text-primary dark:hover:bg-primary/20 dark:hover:text-primary',
+    className,
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className={classes}>
+        {tag}
+      </Link>
+    );
+  }
+
+  return <span className={classes}>{tag}</span>;
+}

--- a/apps/docs/src/components/landing/navbar.tsx
+++ b/apps/docs/src/components/landing/navbar.tsx
@@ -31,6 +31,12 @@ export function LandingNavbar() {
             Documentation
           </Link>
           <Link
+            href="/blog"
+            className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Blog
+          </Link>
+          <Link
             href="https://github.com/AbianS/rustrak"
             target="_blank"
             rel="noopener noreferrer"
@@ -66,6 +72,13 @@ export function LandingNavbar() {
               onClick={() => setIsMenuOpen(false)}
             >
               Documentation
+            </Link>
+            <Link
+              href="/blog"
+              className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors py-2"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              Blog
             </Link>
             <Link
               href="https://github.com/AbianS/rustrak"

--- a/apps/docs/src/lib/blog.ts
+++ b/apps/docs/src/lib/blog.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+import readingTime from 'reading-time';
+
+export type Post = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  author: string;
+  tags: string[];
+  image?: string;
+  readingTime: string;
+  draft: boolean;
+};
+
+const POSTS_DIR = path.join(process.cwd(), 'content/blog');
+
+function ensurePostsDir() {
+  if (!fs.existsSync(POSTS_DIR)) fs.mkdirSync(POSTS_DIR, { recursive: true });
+}
+
+export function getPosts(): Post[] {
+  ensurePostsDir();
+  return fs
+    .readdirSync(POSTS_DIR)
+    .filter((f) => f.endsWith('.mdx'))
+    .map((filename) => {
+      const raw = fs.readFileSync(path.join(POSTS_DIR, filename), 'utf-8');
+      const { data, content } = matter(raw);
+      return {
+        slug: filename.replace('.mdx', ''),
+        title: data.title ?? 'Untitled',
+        description: data.description ?? '',
+        date: data.date ?? new Date().toISOString().split('T')[0],
+        author: data.author ?? 'Rustrak Team',
+        tags: Array.isArray(data.tags) ? data.tags : [],
+        image: data.image,
+        readingTime: readingTime(content).text,
+        draft: data.draft ?? false,
+      };
+    })
+    .filter((p) => process.env.NODE_ENV === 'development' || !p.draft)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
+export function getPost(slug: string): { post: Post; content: string } | null {
+  ensurePostsDir();
+  const filePath = path.join(POSTS_DIR, `${slug}.mdx`);
+  if (!fs.existsSync(filePath)) return null;
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const { data, content } = matter(raw);
+  const post: Post = {
+    slug,
+    title: data.title ?? 'Untitled',
+    description: data.description ?? '',
+    date: data.date ?? new Date().toISOString().split('T')[0],
+    author: data.author ?? 'Rustrak Team',
+    tags: Array.isArray(data.tags) ? data.tags : [],
+    image: data.image,
+    readingTime: readingTime(content).text,
+    draft: data.draft ?? false,
+  };
+  return { post, content };
+}
+
+export function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/apps/docs/src/lib/blog.ts
+++ b/apps/docs/src/lib/blog.ts
@@ -21,6 +21,11 @@ function ensurePostsDir() {
   if (!fs.existsSync(POSTS_DIR)) fs.mkdirSync(POSTS_DIR, { recursive: true });
 }
 
+function safeDate(s: string): Date | null {
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
 export function getPosts(): Post[] {
   ensurePostsDir();
   return fs
@@ -30,10 +35,13 @@ export function getPosts(): Post[] {
       const raw = fs.readFileSync(path.join(POSTS_DIR, filename), 'utf-8');
       const { data, content } = matter(raw);
       return {
-        slug: filename.replace('.mdx', ''),
+        slug: filename.replace(/\.mdx$/, ''),
         title: data.title ?? 'Untitled',
         description: data.description ?? '',
-        date: data.date ?? new Date().toISOString().split('T')[0],
+        date:
+          data.date instanceof Date
+            ? data.date.toISOString().split('T')[0]
+            : String(data.date ?? new Date().toISOString().split('T')[0]),
         author: data.author ?? 'Rustrak Team',
         tags: Array.isArray(data.tags) ? data.tags : [],
         image: data.image,
@@ -42,7 +50,10 @@ export function getPosts(): Post[] {
       };
     })
     .filter((p) => process.env.NODE_ENV === 'development' || !p.draft)
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    .sort(
+      (a, b) =>
+        (safeDate(b.date)?.getTime() ?? 0) - (safeDate(a.date)?.getTime() ?? 0),
+    );
 }
 
 export function getPost(slug: string): { post: Post; content: string } | null {
@@ -55,7 +66,10 @@ export function getPost(slug: string): { post: Post; content: string } | null {
     slug,
     title: data.title ?? 'Untitled',
     description: data.description ?? '',
-    date: data.date ?? new Date().toISOString().split('T')[0],
+    date:
+      data.date instanceof Date
+        ? data.date.toISOString().split('T')[0]
+        : String(data.date ?? new Date().toISOString().split('T')[0]),
     author: data.author ?? 'Rustrak Team',
     tags: Array.isArray(data.tags) ? data.tags : [],
     image: data.image,
@@ -66,7 +80,9 @@ export function getPost(slug: string): { post: Post; content: string } | null {
 }
 
 export function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString('en-US', {
+  const d = safeDate(dateStr);
+  if (!d) return dateStr;
+  return d.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: 0.9.37
         version: 0.9.37(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@tailwindcss/typography':
-        specifier: ^0.5.19
+        specifier: 0.5.19
         version: 0.5.19(tailwindcss@4.3.0)
       class-variance-authority:
         specifier: 0.7.1
@@ -45,7 +45,7 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       gray-matter:
-        specifier: ^4.0.3
+        specifier: 4.0.3
         version: 4.0.3
       lucide-react:
         specifier: 1.16.0
@@ -66,7 +66,7 @@ importers:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
       reading-time:
-        specifier: ^1.5.0
+        specifier: 1.5.0
         version: 1.5.0
       tailwind-merge:
         specifier: 3.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,12 +35,18 @@ importers:
       '@scalar/api-reference-react':
         specifier: 0.9.37
         version: 0.9.37(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.3.0)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       lucide-react:
         specifier: 1.16.0
         version: 1.16.0(react@19.2.6)
@@ -59,6 +65,9 @@ importers:
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
+      reading-time:
+        specifier: ^1.5.0
+        version: 1.5.0
       tailwind-merge:
         specifier: 3.6.0
         version: 3.6.0
@@ -3004,6 +3013,11 @@ packages:
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tanstack/react-virtual@3.13.18':
     resolution: {integrity: sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==}
     peerDependencies:
@@ -3731,6 +3745,11 @@ packages:
   css-selector-parser@3.3.0:
     resolution: {integrity: sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==}
 
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -4124,6 +4143,10 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -4293,6 +4316,10 @@ packages:
   graphql@16.13.2:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
 
   guess-json-indent@3.0.1:
     resolution: {integrity: sha512-LWZ3Vr8BG7DHE3TzPYFqkhjNRw4vYgFSsv2nfMuHklAlOfiy54/EwiDQuQfFVLxENCVv20wpbjfTayooQHrEhQ==}
@@ -4498,6 +4525,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -4633,6 +4664,10 @@ packages:
 
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   knip@6.14.0:
     resolution: {integrity: sha512-yEI9ysdGQ3h77gLObvovH0KUYs6ITtJ1f6owmXRalOO32TbolYvHY7Z+2AEOXqw0ZWeh9219/agh2K/GmtfsxQ==}
@@ -5342,6 +5377,10 @@ packages:
       yaml:
         optional: true
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5708,6 +5747,10 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -5845,6 +5888,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -6179,6 +6226,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -9314,6 +9364,11 @@ snapshots:
       postcss: 8.5.12
       tailwindcss: 4.3.0
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.3.0)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.3.0
+
   '@tanstack/react-virtual@3.13.18(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/virtual-core': 3.13.18
@@ -10050,6 +10105,8 @@ snapshots:
 
   css-selector-parser@3.3.0: {}
 
+  cssesc@3.0.0: {}
+
   csstype@3.2.3: {}
 
   csv-parse@6.1.0: {}
@@ -10525,6 +10582,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
@@ -10704,6 +10765,13 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   guess-json-indent@3.0.1: {}
 
@@ -11004,6 +11072,8 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-extendable@0.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -11108,6 +11178,8 @@ snapshots:
       commander: 8.3.0
 
   khroma@2.1.0: {}
+
+  kind-of@6.0.3: {}
 
   knip@6.14.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
@@ -12174,6 +12246,11 @@ snapshots:
       tsx: 4.22.0
       yaml: 2.9.0
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -12726,6 +12803,11 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@7.7.3: {}
 
   send@1.2.1:
@@ -12905,6 +12987,8 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 
@@ -13250,6 +13334,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:
       react: 19.2.6
+
+  util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
 


### PR DESCRIPTION
## Summary

- Blog listing page at `/blog` with post cards showing date, reading time, author and tags
- Individual post pages using Nextra's `importPage` pipeline (Shiki syntax highlighting included for free)
- Sidebar/TOC hidden on all blog routes via a client body-class override
- `@tailwindcss/typography` wired up for long-form prose styling with full dark mode support
- Blog link added to the landing page navbar and the Nextra top nav
- `gray-matter` + `reading-time` for frontmatter parsing and read time calculation
- First post: *Introducing Rustrak: Self-Hosted Error Tracking for the Paranoid*

## Adding a new post

Drop a `.mdx` file in `apps/docs/content/blog/` with this frontmatter:

```yaml
---
title: "Post title"
description: "One-line summary for SEO and card preview"
date: "2026-01-22"
author: "Abian Suarez"
tags: ["release", "rust"]
---
```

It appears automatically in the listing and gets its own static page.

## Test plan

- [ ] `/blog` listing renders with post cards
- [ ] `/blog/introducing-rustrak` renders full post with header, prose and back link
- [ ] Dark mode looks correct on both pages
- [ ] "Blog" link visible in landing navbar and Nextra top nav
- [ ] `pnpm build` passes with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated blog section to the documentation site
  * Integrated blog navigation link in the main navbar
  * Added blog listing page with post cards and metadata display
  * Included introductory blog post about Rustrak, a self-hosted error tracking solution

* **Documentation**
  * Added initial blog content with setup and deployment instructions

* **Chores**
  * Updated dependencies to support blog functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbianS/rustrak/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->