### PR TITLE
chore: migrate to rustrak GitHub org and Docker Hub

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "AbianS/rustrak" }],
+  "changelog": ["@changesets/changelog-github", { "repo": "rustrak/rustrak" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.claude/skills/analyze-pr-feedback/references/step-01-init-fetch.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-01-init-fetch.md
@@ -13,7 +13,7 @@ Resolve the PR, fetch all active review threads and general reviews. No analysis
 ## CONSTANTS
 
 - `repo` = `rustrak/rustrak`
-- `repo_owner` = `AbianS`
+- `repo_owner` = `rustrak`
 - `repo_name` = `rustrak`
 
 ## SEQUENCE
@@ -66,7 +66,7 @@ gh api graphql -f query='
       }
     }
   }
-' -F owner="AbianS" -F repo="rustrak" -F pr={pr_number}
+' -F owner="rustrak" -F repo="rustrak" -F pr={pr_number}
 ```
 
 Per thread store: `thread_id`, `is_resolved`, `is_outdated`, and per comment: `comment_id` (GraphQL node ID), `comment_db_id` (integer `databaseId`, used for REST `in_reply_to`), `author_login`, `body`, `path`, `line`, `diff_hunk`.

--- a/.claude/skills/analyze-pr-feedback/references/step-01-init-fetch.md
+++ b/.claude/skills/analyze-pr-feedback/references/step-01-init-fetch.md
@@ -12,7 +12,7 @@ Resolve the PR, fetch all active review threads and general reviews. No analysis
 
 ## CONSTANTS
 
-- `repo` = `AbianS/rustrak`
+- `repo` = `rustrak/rustrak`
 - `repo_owner` = `AbianS`
 - `repo_name` = `rustrak`
 
@@ -29,7 +29,7 @@ Resolve the PR, fetch all active review threads and general reviews. No analysis
 ### 2. Fetch PR Metadata
 
 ```bash
-gh pr view {pr_number} --repo AbianS/rustrak --json number,title,headRefName,baseRefName,state,url,reviewDecision,author
+gh pr view {pr_number} --repo rustrak/rustrak --json number,title,headRefName,baseRefName,state,url,reviewDecision,author
 ```
 
 Store: `pr_title`, `pr_head_branch`, `pr_base_branch`, `pr_state`, `pr_url`, `pr_review_decision`, `pr_author`.
@@ -74,7 +74,7 @@ Per thread store: `thread_id`, `is_resolved`, `is_outdated`, and per comment: `c
 ### 4. Fetch General Reviews (REST)
 
 ```bash
-gh api repos/AbianS/rustrak/pulls/{pr_number}/reviews
+gh api repos/rustrak/rustrak/pulls/{pr_number}/reviews
 ```
 
 Store reviews with non-empty `body` and state CHANGES_REQUESTED or COMMENTED as `general_reviews` array (fields: `review_id`, `author_login`, `body`, `state`, `submitted_at`).

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,7 +103,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: FEATURES=sqlite
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          tags: abians7/rustrak-server
+          tags: rustrak/rustrak-server
           cache-from: type=gha,scope=server-sqlite-${{ matrix.runner }}
           cache-to: type=gha,mode=max,scope=server-sqlite-${{ matrix.runner }}
 
@@ -143,14 +143,14 @@ jobs:
         run: |
           VERSION="${{ needs.detect-package.outputs.version }}"
           docker buildx imagetools create \
-            -t abians7/rustrak-server:v${VERSION} \
-            -t abians7/rustrak-server:latest \
-            $(printf 'abians7/rustrak-server@sha256:%s ' *)
+            -t rustrak/rustrak-server:v${VERSION} \
+            -t rustrak/rustrak-server:latest \
+            $(printf 'rustrak/rustrak-server@sha256:%s ' *)
 
       - name: Inspect image
         run: |
           VERSION="${{ needs.detect-package.outputs.version }}"
-          docker buildx imagetools inspect abians7/rustrak-server:v${VERSION}
+          docker buildx imagetools inspect rustrak/rustrak-server:v${VERSION}
 
   # ── PostgreSQL image ──────────────────────────────────────────────────────────
 
@@ -189,7 +189,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: FEATURES=postgres
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          tags: abians7/rustrak-server
+          tags: rustrak/rustrak-server
           cache-from: type=gha,scope=server-postgres-${{ matrix.runner }}
           cache-to: type=gha,mode=max,scope=server-postgres-${{ matrix.runner }}
 
@@ -229,14 +229,14 @@ jobs:
         run: |
           VERSION="${{ needs.detect-package.outputs.version }}"
           docker buildx imagetools create \
-            -t abians7/rustrak-server:v${VERSION}-postgres \
-            -t abians7/rustrak-server:postgres \
-            $(printf 'abians7/rustrak-server@sha256:%s ' *)
+            -t rustrak/rustrak-server:v${VERSION}-postgres \
+            -t rustrak/rustrak-server:postgres \
+            $(printf 'rustrak/rustrak-server@sha256:%s ' *)
 
       - name: Inspect image
         run: |
           VERSION="${{ needs.detect-package.outputs.version }}"
-          docker buildx imagetools inspect abians7/rustrak-server:v${VERSION}-postgres
+          docker buildx imagetools inspect rustrak/rustrak-server:v${VERSION}-postgres
 
   # ── UI image ──────────────────────────────────────────────────────────────────
 
@@ -275,7 +275,7 @@ jobs:
           file: ./apps/webview-ui/Dockerfile
           platforms: ${{ matrix.platform }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          tags: abians7/rustrak-ui
+          tags: rustrak/rustrak-ui
           cache-from: type=gha,scope=ui-${{ matrix.runner }}
           cache-to: type=gha,mode=max,scope=ui-${{ matrix.runner }}
 
@@ -315,14 +315,14 @@ jobs:
         run: |
           VERSION="${{ needs.detect-package.outputs.version }}"
           docker buildx imagetools create \
-            -t abians7/rustrak-ui:v${VERSION} \
-            -t abians7/rustrak-ui:latest \
-            $(printf 'abians7/rustrak-ui@sha256:%s ' *)
+            -t rustrak/rustrak-ui:v${VERSION} \
+            -t rustrak/rustrak-ui:latest \
+            $(printf 'rustrak/rustrak-ui@sha256:%s ' *)
 
       - name: Inspect image
         run: |
           VERSION="${{ needs.detect-package.outputs.version }}"
-          docker buildx imagetools inspect abians7/rustrak-ui:v${VERSION}
+          docker buildx imagetools inspect rustrak/rustrak-ui:v${VERSION}
 
   # ── Docs ──────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ npx @rustrak/mcp
 
 ## Docker Images
 
+> **Migrating from v0.x?** Images moved from `abians7/rustrak-*` to `rustrak/rustrak-*` starting from v0.4.0.
+> Update your `docker-compose.yml` image references and pull from the new location.
+> Old images on `abians7` remain available but will no longer receive updates.
+
 Available on Docker Hub:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/AbianS/rustrak/main/apps/docs/public/logo.svg" alt="Rustrak" width="80" height="80" />
+  <img src="https://raw.githubusercontent.com/rustrak/rustrak/main/apps/docs/public/logo.svg" alt="Rustrak" width="80" height="80" />
   <h1>Rustrak</h1>
   <p><strong>Ultra-lightweight, self-hosted error tracking compatible with Sentry SDKs</strong></p>
 
   <p>
-    <a href="https://github.com/AbianS/rustrak/actions/workflows/ci.yml">
-      <img src="https://github.com/AbianS/rustrak/actions/workflows/ci.yml/badge.svg" alt="CI" />
+    <a href="https://github.com/rustrak/rustrak/actions/workflows/ci.yml">
+      <img src="https://github.com/rustrak/rustrak/actions/workflows/ci.yml/badge.svg" alt="CI" />
     </a>
-    <a href="https://github.com/AbianS/rustrak/blob/main/LICENSE">
+    <a href="https://github.com/rustrak/rustrak/blob/main/LICENSE">
       <img src="https://img.shields.io/badge/license-GPL--3.0-blue.svg" alt="License" />
     </a>
-    <a href="https://github.com/AbianS/rustrak/releases">
-      <img src="https://img.shields.io/github/v/release/AbianS/rustrak" alt="Release" />
+    <a href="https://github.com/rustrak/rustrak/releases">
+      <img src="https://img.shields.io/github/v/release/rustrak/rustrak" alt="Release" />
     </a>
   </p>
 
   <p>
-    <a href="https://abians.github.io/rustrak">Documentation</a>
+    <a href="https://rustrak.github.io/rustrak">Documentation</a>
     ·
-    <a href="https://github.com/AbianS/rustrak/issues">Report Bug</a>
+    <a href="https://github.com/rustrak/rustrak/issues">Report Bug</a>
     ·
-    <a href="https://github.com/AbianS/rustrak/issues">Request Feature</a>
+    <a href="https://github.com/rustrak/rustrak/issues">Request Feature</a>
   </p>
 </div>
 
@@ -48,7 +48,7 @@ The default image uses SQLite. No PostgreSQL needed.
 ```yaml
 services:
   server:
-    image: abians7/rustrak-server:latest
+    image: rustrak/rustrak-server:latest
     ports:
       - "8080:8080"
     volumes:
@@ -59,7 +59,7 @@ services:
     restart: unless-stopped
 
   ui:
-    image: abians7/rustrak-ui:latest
+    image: rustrak/rustrak-ui:latest
     ports:
       - "3000:3000"
     environment:
@@ -104,7 +104,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: abians7/rustrak-server:postgres
+    image: rustrak/rustrak-server:postgres
     ports:
       - "${SERVER_PORT}:8080"
     environment:
@@ -119,7 +119,7 @@ services:
     restart: unless-stopped
 
   ui:
-    image: abians7/rustrak-ui:latest
+    image: rustrak/rustrak-ui:latest
     ports:
       - "${UI_PORT}:3000"
     environment:
@@ -228,9 +228,9 @@ npx @rustrak/mcp
 Available on Docker Hub:
 
 ```bash
-docker pull abians7/rustrak-server         # SQLite (default)
-docker pull abians7/rustrak-server:postgres # PostgreSQL
-docker pull abians7/rustrak-ui
+docker pull rustrak/rustrak-server         # SQLite (default)
+docker pull rustrak/rustrak-server:postgres # PostgreSQL
+docker pull rustrak/rustrak-ui
 ```
 
 | Image | Tag | Size | Description |
@@ -274,12 +274,12 @@ The docs site copies the spec automatically at build time — `apps/docs/public/
 
 ## Documentation
 
-Full documentation is available at **[docs](https://abians.github.io/rustrak/)**
+Full documentation is available at **[docs](https://rustrak.github.io/rustrak/)**
 
-- [Getting Started](https://abians.github.io/rustrak/getting-started)
-- [Configuration](https://abians.github.io/rustrak/configuration)
-- [API Reference](https://abians.github.io/rustrak/api)
-- [Self-Hosting Guide](https://abians.github.io/rustrak/self-hosting)
+- [Getting Started](https://rustrak.github.io/rustrak/getting-started)
+- [Configuration](https://rustrak.github.io/rustrak/configuration)
+- [API Reference](https://rustrak.github.io/rustrak/api)
+- [Self-Hosting Guide](https://rustrak.github.io/rustrak/self-hosting)
 
 ## Contributing
 

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [`fd768de`](https://github.com/AbianS/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b) Thanks [@AbianS](https://github.com/AbianS)! - Add source map upload and stack frame rewriting support.
+- [`fd768de`](https://github.com/rustrak/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b) Thanks [@AbianS](https://github.com/AbianS)! - Add source map upload and stack frame rewriting support.
 
   ## @rustrak/server
 
@@ -21,7 +21,7 @@
 
   ## webview-ui
 
-  - Fix breadcrumb rendering — level badge and message display corrected after PR [#89](https://github.com/AbianS/rustrak/issues/89) review
+  - Fix breadcrumb rendering — level badge and message display corrected after PR [#89](https://github.com/rustrak/rustrak/issues/89) review
   - Fix event display — improved titles, tags layout, and breadcrumb columns in event detail view
 
   ## docs
@@ -34,7 +34,7 @@
 
 ### Patch Changes
 
-- [`324cefd`](https://github.com/AbianS/rustrak/commit/324cefdfbd305d1e53e79ac10c55ca52cc8ef8a4) Thanks [@AbianS](https://github.com/AbianS)! - Fix PUBLIC_URL env var for DSN generation, replace issue soft delete with hard delete, and bump astral-tokio-tar to address RUSTSEC-2026-0145.
+- [`324cefd`](https://github.com/rustrak/rustrak/commit/324cefdfbd305d1e53e79ac10c55ca52cc8ef8a4) Thanks [@AbianS](https://github.com/AbianS)! - Fix PUBLIC_URL env var for DSN generation, replace issue soft delete with hard delete, and bump astral-tokio-tar to address RUSTSEC-2026-0145.
 
   - `@rustrak/server`: Add `PUBLIC_URL` environment variable support so the DSN returned by the server uses the correct public-facing host instead of the internal bind address
   - `@rustrak/server`: Replace issue soft delete with hard delete — issues and their child events/groupings are now removed permanently via CASCADE on DELETE
@@ -45,13 +45,13 @@
 
 ### Patch Changes
 
-- [#79](https://github.com/AbianS/rustrak/pull/79) [`55fa648`](https://github.com/AbianS/rustrak/commit/55fa648963cb9d9cb4055520383fa35653c53052) Thanks [@AbianS](https://github.com/AbianS)! - Add blog section to documentation site
+- [#79](https://github.com/rustrak/rustrak/pull/79) [`55fa648`](https://github.com/rustrak/rustrak/commit/55fa648963cb9d9cb4055520383fa35653c53052) Thanks [@AbianS](https://github.com/AbianS)! - Add blog section to documentation site
 
 ## 0.1.14
 
 ### Patch Changes
 
-- [`6a8b860`](https://github.com/AbianS/rustrak/commit/6a8b860eda0fa199a31089e295a102aef3da6122) Thanks [@AbianS](https://github.com/AbianS)! - Improve npm package metadata, READMEs, and official documentation.
+- [`6a8b860`](https://github.com/rustrak/rustrak/commit/6a8b860eda0fa199a31089e295a102aef3da6122) Thanks [@AbianS](https://github.com/AbianS)! - Improve npm package metadata, READMEs, and official documentation.
 
   - Add `homepage`, `repository` (with monorepo `directory`), `bugs`, `author`, and `engines` fields to both packages
   - Expand `keywords` for better npm search discoverability
@@ -63,7 +63,7 @@
 
 ### Patch Changes
 
-- [`3fc4abb`](https://github.com/AbianS/rustrak/commit/3fc4abba96170c7fbbac708aeb0296c7e759818c) Thanks [@AbianS](https://github.com/AbianS)! - ## webview-ui
+- [`3fc4abb`](https://github.com/rustrak/rustrak/commit/3fc4abba96170c7fbbac708aeb0296c7e759818c) Thanks [@AbianS](https://github.com/AbianS)! - ## webview-ui
 
   ### Features
 
@@ -95,13 +95,13 @@
 
 ### Patch Changes
 
-- [#46](https://github.com/AbianS/rustrak/pull/46) [`c64ebe0`](https://github.com/AbianS/rustrak/commit/c64ebe09d1e2700faf956c757cb21402aa062e5a) Thanks [@AbianS](https://github.com/AbianS)! - Add interactive API reference powered by OpenAPI spec
+- [#46](https://github.com/rustrak/rustrak/pull/46) [`c64ebe0`](https://github.com/rustrak/rustrak/commit/c64ebe09d1e2700faf956c757cb21402aa062e5a) Thanks [@AbianS](https://github.com/AbianS)! - Add interactive API reference powered by OpenAPI spec
 
 ## 0.1.11
 
 ### Patch Changes
 
-- [#44](https://github.com/AbianS/rustrak/pull/44) [`4a84415`](https://github.com/AbianS/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242) Thanks [@AbianS](https://github.com/AbianS)! - Upgrade all dependencies to latest versions across the monorepo.
+- [#44](https://github.com/rustrak/rustrak/pull/44) [`4a84415`](https://github.com/rustrak/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242) Thanks [@AbianS](https://github.com/AbianS)! - Upgrade all dependencies to latest versions across the monorepo.
 
   - TypeScript 6.0.3 + Node.js engines >=22 across all packages
   - ky 2.x migration: `prefix` (was `prefixUrl`), updated hook signatures, removed 429 from retry list to avoid `Retry-After` sleep
@@ -112,18 +112,18 @@
 
 ### Patch Changes
 
-- [#39](https://github.com/AbianS/rustrak/pull/39) [`447596b`](https://github.com/AbianS/rustrak/commit/447596b77655e6c8bc24257c603d1a992fb4cb03) Thanks [@kervel](https://github.com/kervel)! - SQLite is now the default database backend
+- [#39](https://github.com/rustrak/rustrak/pull/39) [`447596b`](https://github.com/rustrak/rustrak/commit/447596b77655e6c8bc24257c603d1a992fb4cb03) Thanks [@kervel](https://github.com/kervel)! - SQLite is now the default database backend
 
   BREAKING CHANGE: The `latest` Docker image now uses SQLite instead of PostgreSQL.
 
-  If you are using `abians7/rustrak-server:latest` with PostgreSQL, update your image tag:
+  If you are using `rustrak/rustrak-server:latest` with PostgreSQL, update your image tag:
 
   ```yaml
   # Before
-  image: abians7/rustrak-server:latest
+  image: rustrak/rustrak-server:latest
 
   # After
-  image: abians7/rustrak-server:postgres
+  image: rustrak/rustrak-server:postgres
   ```
 
   No data migration required — only the image tag changes.
@@ -141,52 +141,52 @@
 
 ### Patch Changes
 
-- [#34](https://github.com/AbianS/rustrak/pull/34) [`54efbba`](https://github.com/AbianS/rustrak/commit/54efbba72d56130d3d3b987faf9b829c6041ab3e) Thanks [@AbianS](https://github.com/AbianS)! - chore: update dependencies
+- [#34](https://github.com/rustrak/rustrak/pull/34) [`54efbba`](https://github.com/rustrak/rustrak/commit/54efbba72d56130d3d3b987faf9b829c6041ab3e) Thanks [@AbianS](https://github.com/AbianS)! - chore: update dependencies
 
 ## 0.1.8
 
 ### Patch Changes
 
-- [#23](https://github.com/AbianS/rustrak/pull/23) [`169dc0c`](https://github.com/AbianS/rustrak/commit/169dc0ce73fee276b169f403daa0ed4a00404726) Thanks [@AbianS](https://github.com/AbianS)! - feat: system alert
+- [#23](https://github.com/rustrak/rustrak/pull/23) [`169dc0c`](https://github.com/rustrak/rustrak/commit/169dc0ce73fee276b169f403daa0ed4a00404726) Thanks [@AbianS](https://github.com/AbianS)! - feat: system alert
 
 ## 0.1.7
 
 ### Patch Changes
 
-- [`931d8c9`](https://github.com/AbianS/rustrak/commit/931d8c96d86354ec8069ce317eef3a4426ca8cac) Thanks [@AbianS](https://github.com/AbianS)! - fix: video source github pages
+- [`931d8c9`](https://github.com/rustrak/rustrak/commit/931d8c96d86354ec8069ce317eef3a4426ca8cac) Thanks [@AbianS](https://github.com/AbianS)! - fix: video source github pages
 
 ## 0.1.6
 
 ### Patch Changes
 
-- [`17291c5`](https://github.com/AbianS/rustrak/commit/17291c54ed7e41f9577588aeef29107194186199) Thanks [@AbianS](https://github.com/AbianS)! - fix: favicon
+- [`17291c5`](https://github.com/rustrak/rustrak/commit/17291c54ed7e41f9577588aeef29107194186199) Thanks [@AbianS](https://github.com/AbianS)! - fix: favicon
 
 ## 0.1.5
 
 ### Patch Changes
 
-- [`433921b`](https://github.com/AbianS/rustrak/commit/433921b77a864f6974f467bc932fd943a6b908e1) Thanks [@AbianS](https://github.com/AbianS)! - fix: docs installation
+- [`433921b`](https://github.com/rustrak/rustrak/commit/433921b77a864f6974f467bc932fd943a6b908e1) Thanks [@AbianS](https://github.com/AbianS)! - fix: docs installation
 
 ## 0.1.4
 
 ### Patch Changes
 
-- [`8a3cf61`](https://github.com/AbianS/rustrak/commit/8a3cf618d6d2cd48dbdbab4fa62cc2b8c53e4e22) Thanks [@AbianS](https://github.com/AbianS)! - fix: css
+- [`8a3cf61`](https://github.com/rustrak/rustrak/commit/8a3cf618d6d2cd48dbdbab4fa62cc2b8c53e4e22) Thanks [@AbianS](https://github.com/AbianS)! - fix: css
 
 ## 0.1.3
 
 ### Patch Changes
 
-- [`1d9438d`](https://github.com/AbianS/rustrak/commit/1d9438d83f35ffe8460d7399ccc1d4c58d6b0b3a) Thanks [@AbianS](https://github.com/AbianS)! - chore: publish docs
+- [`1d9438d`](https://github.com/rustrak/rustrak/commit/1d9438d83f35ffe8460d7399ccc1d4c58d6b0b3a) Thanks [@AbianS](https://github.com/AbianS)! - chore: publish docs
 
 ## 0.1.2
 
 ### Patch Changes
 
-- [`2f7a450`](https://github.com/AbianS/rustrak/commit/2f7a450263e2fc3357c5cda614e24774810fa373) Thanks [@AbianS](https://github.com/AbianS)! - chore: second version
+- [`2f7a450`](https://github.com/rustrak/rustrak/commit/2f7a450263e2fc3357c5cda614e24774810fa373) Thanks [@AbianS](https://github.com/AbianS)! - chore: second version
 
 ## 0.1.1
 
 ### Patch Changes
 
-- [`08a1262`](https://github.com/AbianS/rustrak/commit/08a12627dbdf1a044d3a66b25b1ee113583f57f8) Thanks [@AbianS](https://github.com/AbianS)! - chore: first version
+- [`08a1262`](https://github.com/rustrak/rustrak/commit/08a12627dbdf1a044d3a66b25b1ee113583f57f8) Thanks [@AbianS](https://github.com/AbianS)! - chore: first version

--- a/apps/server/CHANGELOG.md
+++ b/apps/server/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- [`fd768de`](https://github.com/AbianS/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b) Thanks [@AbianS](https://github.com/AbianS)! - Add source map upload and stack frame rewriting support.
+- [`fd768de`](https://github.com/rustrak/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b) Thanks [@AbianS](https://github.com/AbianS)! - Add source map upload and stack frame rewriting support.
 
   ## @rustrak/server
 
@@ -21,7 +21,7 @@
 
   ## webview-ui
 
-  - Fix breadcrumb rendering — level badge and message display corrected after PR [#89](https://github.com/AbianS/rustrak/issues/89) review
+  - Fix breadcrumb rendering — level badge and message display corrected after PR [#89](https://github.com/rustrak/rustrak/issues/89) review
   - Fix event display — improved titles, tags layout, and breadcrumb columns in event detail view
 
   ## docs
@@ -34,7 +34,7 @@
 
 ### Patch Changes
 
-- [`324cefd`](https://github.com/AbianS/rustrak/commit/324cefdfbd305d1e53e79ac10c55ca52cc8ef8a4) Thanks [@AbianS](https://github.com/AbianS)! - Fix PUBLIC_URL env var for DSN generation, replace issue soft delete with hard delete, and bump astral-tokio-tar to address RUSTSEC-2026-0145.
+- [`324cefd`](https://github.com/rustrak/rustrak/commit/324cefdfbd305d1e53e79ac10c55ca52cc8ef8a4) Thanks [@AbianS](https://github.com/AbianS)! - Fix PUBLIC_URL env var for DSN generation, replace issue soft delete with hard delete, and bump astral-tokio-tar to address RUSTSEC-2026-0145.
 
   - `@rustrak/server`: Add `PUBLIC_URL` environment variable support so the DSN returned by the server uses the correct public-facing host instead of the internal bind address
   - `@rustrak/server`: Replace issue soft delete with hard delete — issues and their child events/groupings are now removed permanently via CASCADE on DELETE
@@ -45,7 +45,7 @@
 
 ### Patch Changes
 
-- [`40ba761`](https://github.com/AbianS/rustrak/commit/40ba76136d2c455fc22fcc1b99850eb3d29769bd) Thanks [@AbianS](https://github.com/AbianS)! - **server**: migrate all alert-channel and alert-rule endpoints from `AuthenticatedUser` to `ApiAuth` extractor, enabling bearer token access to the alerts API
+- [`40ba761`](https://github.com/rustrak/rustrak/commit/40ba76136d2c455fc22fcc1b99850eb3d29769bd) Thanks [@AbianS](https://github.com/AbianS)! - **server**: migrate all alert-channel and alert-rule endpoints from `AuthenticatedUser` to `ApiAuth` extractor, enabling bearer token access to the alerts API
 
   **client**: remove `private` flag and add `publishConfig` for npm publishing; bump zod to 4.4.3, msw to 2.14.6, vitest to 4.1.6, @types/node to 25.8.0
 
@@ -55,7 +55,7 @@
 
 ### Patch Changes
 
-- [`7fd41b8`](https://github.com/AbianS/rustrak/commit/7fd41b8669b24e57582673c4502c52662482b085) Thanks [@AbianS](https://github.com/AbianS)! - Bug fixes for ingest, auth, Slack alerts, and UI stability
+- [`7fd41b8`](https://github.com/rustrak/rustrak/commit/7fd41b8669b24e57582673c4502c52662482b085) Thanks [@AbianS](https://github.com/AbianS)! - Bug fixes for ingest, auth, Slack alerts, and UI stability
 
   - fix(ingest): raise payload size limit to 100MB
   - fix(digest): delete orphaned temp files on processing error
@@ -70,7 +70,7 @@
 
 ### Patch Changes
 
-- [`3fc4abb`](https://github.com/AbianS/rustrak/commit/3fc4abba96170c7fbbac708aeb0296c7e759818c) Thanks [@AbianS](https://github.com/AbianS)! - ## webview-ui
+- [`3fc4abb`](https://github.com/rustrak/rustrak/commit/3fc4abba96170c7fbbac708aeb0296c7e759818c) Thanks [@AbianS](https://github.com/AbianS)! - ## webview-ui
 
   ### Features
 
@@ -102,7 +102,7 @@
 
 ### Patch Changes
 
-- [#44](https://github.com/AbianS/rustrak/pull/44) [`4a84415`](https://github.com/AbianS/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242) Thanks [@AbianS](https://github.com/AbianS)! - Upgrade all dependencies to latest versions across the monorepo.
+- [#44](https://github.com/rustrak/rustrak/pull/44) [`4a84415`](https://github.com/rustrak/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242) Thanks [@AbianS](https://github.com/AbianS)! - Upgrade all dependencies to latest versions across the monorepo.
 
   - TypeScript 6.0.3 + Node.js engines >=22 across all packages
   - ky 2.x migration: `prefix` (was `prefixUrl`), updated hook signatures, removed 429 from retry list to avoid `Retry-After` sleep
@@ -113,18 +113,18 @@
 
 ### Minor Changes
 
-- [#39](https://github.com/AbianS/rustrak/pull/39) [`447596b`](https://github.com/AbianS/rustrak/commit/447596b77655e6c8bc24257c603d1a992fb4cb03) Thanks [@kervel](https://github.com/kervel)! - SQLite is now the default database backend
+- [#39](https://github.com/rustrak/rustrak/pull/39) [`447596b`](https://github.com/rustrak/rustrak/commit/447596b77655e6c8bc24257c603d1a992fb4cb03) Thanks [@kervel](https://github.com/kervel)! - SQLite is now the default database backend
 
   BREAKING CHANGE: The `latest` Docker image now uses SQLite instead of PostgreSQL.
 
-  If you are using `abians7/rustrak-server:latest` with PostgreSQL, update your image tag:
+  If you are using `rustrak/rustrak-server:latest` with PostgreSQL, update your image tag:
 
   ```yaml
   # Before
-  image: abians7/rustrak-server:latest
+  image: rustrak/rustrak-server:latest
 
   # After
-  image: abians7/rustrak-server:postgres
+  image: rustrak/rustrak-server:postgres
   ```
 
   No data migration required — only the image tag changes.
@@ -142,22 +142,22 @@
 
 ### Patch Changes
 
-- [#34](https://github.com/AbianS/rustrak/pull/34) [`54efbba`](https://github.com/AbianS/rustrak/commit/54efbba72d56130d3d3b987faf9b829c6041ab3e) Thanks [@AbianS](https://github.com/AbianS)! - chore: update dependencies
+- [#34](https://github.com/rustrak/rustrak/pull/34) [`54efbba`](https://github.com/rustrak/rustrak/commit/54efbba72d56130d3d3b987faf9b829c6041ab3e) Thanks [@AbianS](https://github.com/AbianS)! - chore: update dependencies
 
 ## 0.1.3
 
 ### Patch Changes
 
-- [#23](https://github.com/AbianS/rustrak/pull/23) [`169dc0c`](https://github.com/AbianS/rustrak/commit/169dc0ce73fee276b169f403daa0ed4a00404726) Thanks [@AbianS](https://github.com/AbianS)! - feat: system alert
+- [#23](https://github.com/rustrak/rustrak/pull/23) [`169dc0c`](https://github.com/rustrak/rustrak/commit/169dc0ce73fee276b169f403daa0ed4a00404726) Thanks [@AbianS](https://github.com/AbianS)! - feat: system alert
 
 ## 0.1.2
 
 ### Patch Changes
 
-- [`2f7a450`](https://github.com/AbianS/rustrak/commit/2f7a450263e2fc3357c5cda614e24774810fa373) Thanks [@AbianS](https://github.com/AbianS)! - chore: second version
+- [`2f7a450`](https://github.com/rustrak/rustrak/commit/2f7a450263e2fc3357c5cda614e24774810fa373) Thanks [@AbianS](https://github.com/AbianS)! - chore: second version
 
 ## 0.1.1
 
 ### Patch Changes
 
-- [`08a1262`](https://github.com/AbianS/rustrak/commit/08a12627dbdf1a044d3a66b25b1ee113583f57f8) Thanks [@AbianS](https://github.com/AbianS)! - chore: first version
+- [`08a1262`](https://github.com/rustrak/rustrak/commit/08a12627dbdf1a044d3a66b25b1ee113583f57f8) Thanks [@AbianS](https://github.com/AbianS)! - chore: first version

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -31,11 +31,11 @@ cargo run
 ## Docker
 
 ```bash
-docker pull abians7/rustrak-server
+docker pull rustrak/rustrak-server
 docker run -d -p 8080:8080 \
   -e DATABASE_URL="postgres://user:pass@localhost:5432/rustrak" \
   -e SESSION_SECRET_KEY="your-secret-key" \
-  abians7/rustrak-server
+  rustrak/rustrak-server
 ```
 
 ## Environment Variables

--- a/apps/webview-ui/CHANGELOG.md
+++ b/apps/webview-ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [`fd768de`](https://github.com/AbianS/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b) Thanks [@AbianS](https://github.com/AbianS)! - Add source map upload and stack frame rewriting support.
+- [`fd768de`](https://github.com/rustrak/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b) Thanks [@AbianS](https://github.com/AbianS)! - Add source map upload and stack frame rewriting support.
 
   ## @rustrak/server
 
@@ -21,7 +21,7 @@
 
   ## webview-ui
 
-  - Fix breadcrumb rendering — level badge and message display corrected after PR [#89](https://github.com/AbianS/rustrak/issues/89) review
+  - Fix breadcrumb rendering — level badge and message display corrected after PR [#89](https://github.com/rustrak/rustrak/issues/89) review
   - Fix event display — improved titles, tags layout, and breadcrumb columns in event detail view
 
   ## docs
@@ -30,28 +30,28 @@
   - Blog post: "Source Maps in Rust" covering the implementation approach
   - Updated environment reference with source map related config
 
-- Updated dependencies [[`fd768de`](https://github.com/AbianS/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b)]:
+- Updated dependencies [[`fd768de`](https://github.com/rustrak/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b)]:
   - @rustrak/client@0.2.0
 
 ## 0.2.3
 
 ### Patch Changes
 
-- Updated dependencies [[`6a8b860`](https://github.com/AbianS/rustrak/commit/6a8b860eda0fa199a31089e295a102aef3da6122)]:
+- Updated dependencies [[`6a8b860`](https://github.com/rustrak/rustrak/commit/6a8b860eda0fa199a31089e295a102aef3da6122)]:
   - @rustrak/client@0.1.3
 
 ## 0.2.2
 
 ### Patch Changes
 
-- Updated dependencies [[`40ba761`](https://github.com/AbianS/rustrak/commit/40ba76136d2c455fc22fcc1b99850eb3d29769bd)]:
+- Updated dependencies [[`40ba761`](https://github.com/rustrak/rustrak/commit/40ba76136d2c455fc22fcc1b99850eb3d29769bd)]:
   - @rustrak/client@0.1.2
 
 ## 0.2.1
 
 ### Patch Changes
 
-- [`7fd41b8`](https://github.com/AbianS/rustrak/commit/7fd41b8669b24e57582673c4502c52662482b085) Thanks [@AbianS](https://github.com/AbianS)! - Bug fixes for ingest, auth, Slack alerts, and UI stability
+- [`7fd41b8`](https://github.com/rustrak/rustrak/commit/7fd41b8669b24e57582673c4502c52662482b085) Thanks [@AbianS](https://github.com/AbianS)! - Bug fixes for ingest, auth, Slack alerts, and UI stability
 
   - fix(ingest): raise payload size limit to 100MB
   - fix(digest): delete orphaned temp files on processing error
@@ -66,7 +66,7 @@
 
 ### Minor Changes
 
-- [`3fc4abb`](https://github.com/AbianS/rustrak/commit/3fc4abba96170c7fbbac708aeb0296c7e759818c) Thanks [@AbianS](https://github.com/AbianS)! - ## webview-ui
+- [`3fc4abb`](https://github.com/rustrak/rustrak/commit/3fc4abba96170c7fbbac708aeb0296c7e759818c) Thanks [@AbianS](https://github.com/AbianS)! - ## webview-ui
 
   ### Features
 
@@ -98,42 +98,42 @@
 
 ### Patch Changes
 
-- [#44](https://github.com/AbianS/rustrak/pull/44) [`4a84415`](https://github.com/AbianS/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242) Thanks [@AbianS](https://github.com/AbianS)! - Upgrade all dependencies to latest versions across the monorepo.
+- [#44](https://github.com/rustrak/rustrak/pull/44) [`4a84415`](https://github.com/rustrak/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242) Thanks [@AbianS](https://github.com/AbianS)! - Upgrade all dependencies to latest versions across the monorepo.
 
   - TypeScript 6.0.3 + Node.js engines >=22 across all packages
   - ky 2.x migration: `prefix` (was `prefixUrl`), updated hook signatures, removed 429 from retry list to avoid `Retry-After` sleep
   - lucide-react 1.x: replaced removed `Github` brand icon with inline SVG component
   - Rust: actix-web 4.13, actix-session 0.11, tokio 1.52, sqlx 0.8.6, rand 0.10 (`RngExt`), sha2 0.11 (`hex::encode`), hmac 0.13 (`KeyInit`)
 
-- Updated dependencies [[`4a84415`](https://github.com/AbianS/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242)]:
+- Updated dependencies [[`4a84415`](https://github.com/rustrak/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242)]:
   - @rustrak/client@0.1.1
 
 ## 0.1.5
 
 ### Patch Changes
 
-- [#34](https://github.com/AbianS/rustrak/pull/34) [`54efbba`](https://github.com/AbianS/rustrak/commit/54efbba72d56130d3d3b987faf9b829c6041ab3e) Thanks [@AbianS](https://github.com/AbianS)! - chore: update dependencies
+- [#34](https://github.com/rustrak/rustrak/pull/34) [`54efbba`](https://github.com/rustrak/rustrak/commit/54efbba72d56130d3d3b987faf9b829c6041ab3e) Thanks [@AbianS](https://github.com/AbianS)! - chore: update dependencies
 
 ## 0.1.4
 
 ### Patch Changes
 
-- [#23](https://github.com/AbianS/rustrak/pull/23) [`169dc0c`](https://github.com/AbianS/rustrak/commit/169dc0ce73fee276b169f403daa0ed4a00404726) Thanks [@AbianS](https://github.com/AbianS)! - feat: system alert
+- [#23](https://github.com/rustrak/rustrak/pull/23) [`169dc0c`](https://github.com/rustrak/rustrak/commit/169dc0ce73fee276b169f403daa0ed4a00404726) Thanks [@AbianS](https://github.com/AbianS)! - feat: system alert
 
 ## 0.1.3
 
 ### Patch Changes
 
-- [`17291c5`](https://github.com/AbianS/rustrak/commit/17291c54ed7e41f9577588aeef29107194186199) Thanks [@AbianS](https://github.com/AbianS)! - fix: favicon
+- [`17291c5`](https://github.com/rustrak/rustrak/commit/17291c54ed7e41f9577588aeef29107194186199) Thanks [@AbianS](https://github.com/AbianS)! - fix: favicon
 
 ## 0.1.2
 
 ### Patch Changes
 
-- [`2f7a450`](https://github.com/AbianS/rustrak/commit/2f7a450263e2fc3357c5cda614e24774810fa373) Thanks [@AbianS](https://github.com/AbianS)! - chore: second version
+- [`2f7a450`](https://github.com/rustrak/rustrak/commit/2f7a450263e2fc3357c5cda614e24774810fa373) Thanks [@AbianS](https://github.com/AbianS)! - chore: second version
 
 ## 0.1.1
 
 ### Patch Changes
 
-- [`08a1262`](https://github.com/AbianS/rustrak/commit/08a12627dbdf1a044d3a66b25b1ee113583f57f8) Thanks [@AbianS](https://github.com/AbianS)! - chore: first version
+- [`08a1262`](https://github.com/rustrak/rustrak/commit/08a12627dbdf1a044d3a66b25b1ee113583f57f8) Thanks [@AbianS](https://github.com/AbianS)! - chore: first version

--- a/apps/webview-ui/README.md
+++ b/apps/webview-ui/README.md
@@ -32,10 +32,10 @@ pnpm dev
 ## Docker
 
 ```bash
-docker pull abians7/rustrak-ui
+docker pull rustrak/rustrak-ui
 docker run -d -p 3000:3000 \
   -e RUSTRAK_API_URL="http://your-server:8080" \
-  abians7/rustrak-ui
+  rustrak/rustrak-ui
 ```
 
 ## Environment Variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: abians7/rustrak-server:latest
+    image: rustrak/rustrak-server:latest
     ports:
       - "${SERVER_PORT}:8080"
     environment:
@@ -34,7 +34,7 @@ services:
     restart: unless-stopped
 
   ui:
-    image: abians7/rustrak-ui:latest
+    image: rustrak/rustrak-ui:latest
     ports:
       - "${UI_PORT}:3000"
     environment:

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -8,9 +8,9 @@ Rustrak has a **decoupled deployment architecture**: the server and dashboard ca
 
 | Component | Docker Image | RAM | Disk |
 |-----------|-------------|-----|------|
-| Server (SQLite) | `abians7/rustrak-server:latest` | ~50MB | ~20MB image |
-| Server (PostgreSQL) | `abians7/rustrak-server:postgres` | ~50MB | ~20MB image |
-| Dashboard | `abians7/rustrak-ui:latest` | ~100MB | ~150MB image |
+| Server (SQLite) | `rustrak/rustrak-server:latest` | ~50MB | ~20MB image |
+| Server (PostgreSQL) | `rustrak/rustrak-server:postgres` | ~50MB | ~20MB image |
+| Dashboard | `rustrak/rustrak-ui:latest` | ~100MB | ~150MB image |
 | Docs | GitHub Pages | — | static |
 
 **Supported architectures:** `linux/amd64`, `linux/arm64`
@@ -42,7 +42,7 @@ services:
     restart: unless-stopped
 
   server:
-    image: abians7/rustrak-server:postgres
+    image: rustrak/rustrak-server:postgres
     ports:
       - "${SERVER_PORT}:8080"
     environment:
@@ -55,7 +55,7 @@ services:
     restart: unless-stopped
 
   ui:
-    image: abians7/rustrak-ui:latest
+    image: rustrak/rustrak-ui:latest
     ports:
       - "${UI_PORT}:3000"
     environment:
@@ -105,7 +105,7 @@ docker run -d \
   -e CREATE_SUPERUSER=admin@example.com:your-password \
   -e INGEST_DIR=/tmp/rustrak/ingest \
   --restart unless-stopped \
-  abians7/rustrak-server:latest
+  rustrak/rustrak-server:latest
 ```
 
 Access dashboard at: http://localhost:8080 (server only) or run UI separately.
@@ -126,7 +126,7 @@ docker run -d \
   -e CREATE_SUPERUSER=admin@example.com:password \
   -e SSL_PROXY=true \
   --restart unless-stopped \
-  abians7/rustrak-server:postgres
+  rustrak/rustrak-server:postgres
 ```
 
 ```bash
@@ -249,12 +249,12 @@ git push origin feat/my-feature
 
 | Tag | Description |
 |-----|-------------|
-| `abians7/rustrak-server:latest` | Latest SQLite build |
-| `abians7/rustrak-server:vX.Y.Z` | Specific SQLite version |
-| `abians7/rustrak-server:postgres` | Latest PostgreSQL build |
-| `abians7/rustrak-server:vX.Y.Z-postgres` | Specific PostgreSQL version |
-| `abians7/rustrak-ui:latest` | Latest UI build |
-| `abians7/rustrak-ui:vX.Y.Z` | Specific UI version |
+| `rustrak/rustrak-server:latest` | Latest SQLite build |
+| `rustrak/rustrak-server:vX.Y.Z` | Specific SQLite version |
+| `rustrak/rustrak-server:postgres` | Latest PostgreSQL build |
+| `rustrak/rustrak-server:vX.Y.Z-postgres` | Specific PostgreSQL version |
+| `rustrak/rustrak-ui:latest` | Latest UI build |
+| `rustrak/rustrak-ui:vX.Y.Z` | Specific UI version |
 
 All images are multi-arch (`linux/amd64` + `linux/arm64`).
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -29,7 +29,7 @@ npm install -g pnpm@10
 
 ```bash
 # Clone repo
-git clone https://github.com/AbianS/rustrak
+git clone https://github.com/rustrak/rustrak
 cd rustrak
 
 # Install Node.js dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 - **Type:** Turborepo Monorepo — 6 parts
 - **Primary Language:** Rust (server), TypeScript (UI, client, tools)
 - **Architecture:** Decoupled server + optional dashboard, Sentry SDK compatible
-- **Repository:** https://github.com/AbianS/rustrak
+- **Repository:** https://github.com/rustrak/rustrak
 
 ### Quick Reference by Part
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -158,7 +158,7 @@ docker run -d \
   -e DATABASE_URL=sqlite:/data/rustrak.db \
   -e SESSION_SECRET_KEY=$(openssl rand -hex 32) \
   -e CREATE_SUPERUSER=admin@example.com:yourpassword \
-  abians7/rustrak-server:latest
+  rustrak/rustrak-server:latest
 ```
 
 Then configure your app's Sentry SDK with:
@@ -166,4 +166,4 @@ Then configure your app's Sentry SDK with:
 http://<project_sentry_key>@localhost:8080/<project_id>
 ```
 
-See [full documentation](https://abians.github.io/rustrak) for more.
+See [full documentation](https://rustrak.github.io/rustrak) for more.

--- a/docs/source-tree-analysis.md
+++ b/docs/source-tree-analysis.md
@@ -344,6 +344,6 @@ packages/benchmarks/
 5. `docs@X.Y.Z` tag → builds and deploys to GitHub Pages
 
 **Docker images:**
-- `abians7/rustrak-server:latest` (SQLite, linux/amd64 + linux/arm64)
-- `abians7/rustrak-server:postgres` (PostgreSQL, linux/amd64 + linux/arm64)
-- `abians7/rustrak-ui:latest` (linux/amd64 + linux/arm64)
+- `rustrak/rustrak-server:latest` (SQLite, linux/amd64 + linux/arm64)
+- `rustrak/rustrak-server:postgres` (PostgreSQL, linux/amd64 + linux/arm64)
+- `rustrak/rustrak-ui:latest` (linux/amd64 + linux/arm64)

--- a/packages/benchmarks/CHANGELOG.md
+++ b/packages/benchmarks/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [#44](https://github.com/AbianS/rustrak/pull/44) [`4a84415`](https://github.com/AbianS/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242) Thanks [@AbianS](https://github.com/AbianS)! - Upgrade all dependencies to latest versions across the monorepo.
+- [#44](https://github.com/rustrak/rustrak/pull/44) [`4a84415`](https://github.com/rustrak/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242) Thanks [@AbianS](https://github.com/AbianS)! - Upgrade all dependencies to latest versions across the monorepo.
 
   - TypeScript 6.0.3 + Node.js engines >=22 across all packages
   - ky 2.x migration: `prefix` (was `prefixUrl`), updated hook signatures, removed 429 from retry list to avoid `Retry-After` sleep

--- a/packages/benchmarks/docker-compose.benchmark.yml
+++ b/packages/benchmarks/docker-compose.benchmark.yml
@@ -43,7 +43,7 @@ services:
 
   # Rustrak server with fixed resource limits
   server-bench:
-    image: abians7/rustrak-server:latest
+    image: rustrak/rustrak-server:latest
     container_name: rustrak-server-bench
     build:
       context: ../../apps/server

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- [`fd768de`](https://github.com/AbianS/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b) Thanks [@AbianS](https://github.com/AbianS)! - Add source map upload and stack frame rewriting support.
+- [`fd768de`](https://github.com/rustrak/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b) Thanks [@AbianS](https://github.com/AbianS)! - Add source map upload and stack frame rewriting support.
 
   ## @rustrak/server
 
@@ -21,7 +21,7 @@
 
   ## webview-ui
 
-  - Fix breadcrumb rendering — level badge and message display corrected after PR [#89](https://github.com/AbianS/rustrak/issues/89) review
+  - Fix breadcrumb rendering — level badge and message display corrected after PR [#89](https://github.com/rustrak/rustrak/issues/89) review
   - Fix event display — improved titles, tags layout, and breadcrumb columns in event detail view
 
   ## docs
@@ -34,7 +34,7 @@
 
 ### Patch Changes
 
-- [`6a8b860`](https://github.com/AbianS/rustrak/commit/6a8b860eda0fa199a31089e295a102aef3da6122) Thanks [@AbianS](https://github.com/AbianS)! - Improve npm package metadata, READMEs, and official documentation.
+- [`6a8b860`](https://github.com/rustrak/rustrak/commit/6a8b860eda0fa199a31089e295a102aef3da6122) Thanks [@AbianS](https://github.com/AbianS)! - Improve npm package metadata, READMEs, and official documentation.
 
   - Add `homepage`, `repository` (with monorepo `directory`), `bugs`, `author`, and `engines` fields to both packages
   - Expand `keywords` for better npm search discoverability
@@ -46,7 +46,7 @@
 
 ### Patch Changes
 
-- [`40ba761`](https://github.com/AbianS/rustrak/commit/40ba76136d2c455fc22fcc1b99850eb3d29769bd) Thanks [@AbianS](https://github.com/AbianS)! - **server**: migrate all alert-channel and alert-rule endpoints from `AuthenticatedUser` to `ApiAuth` extractor, enabling bearer token access to the alerts API
+- [`40ba761`](https://github.com/rustrak/rustrak/commit/40ba76136d2c455fc22fcc1b99850eb3d29769bd) Thanks [@AbianS](https://github.com/AbianS)! - **server**: migrate all alert-channel and alert-rule endpoints from `AuthenticatedUser` to `ApiAuth` extractor, enabling bearer token access to the alerts API
 
   **client**: remove `private` flag and add `publishConfig` for npm publishing; bump zod to 4.4.3, msw to 2.14.6, vitest to 4.1.6, @types/node to 25.8.0
 
@@ -56,7 +56,7 @@
 
 ### Patch Changes
 
-- [#44](https://github.com/AbianS/rustrak/pull/44) [`4a84415`](https://github.com/AbianS/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242) Thanks [@AbianS](https://github.com/AbianS)! - Upgrade all dependencies to latest versions across the monorepo.
+- [#44](https://github.com/rustrak/rustrak/pull/44) [`4a84415`](https://github.com/rustrak/rustrak/commit/4a84415d867b5a1f15f11006278527671d62b242) Thanks [@AbianS](https://github.com/AbianS)! - Upgrade all dependencies to latest versions across the monorepo.
 
   - TypeScript 6.0.3 + Node.js engines >=22 across all packages
   - ky 2.x migration: `prefix` (was `prefixUrl`), updated hook signatures, removed 429 from retry list to avoid `Retry-After` sleep

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,9 +1,9 @@
 <div align="center">
-  <a href="https://abians.github.io/rustrak">
-    <img src="https://raw.githubusercontent.com/AbianS/rustrak/main/apps/docs/public/logo.svg" alt="Rustrak" width="64" height="64" />
+  <a href="https://rustrak.github.io/rustrak">
+    <img src="https://raw.githubusercontent.com/rustrak/rustrak/main/apps/docs/public/logo.svg" alt="Rustrak" width="64" height="64" />
   </a>
   <h1>@rustrak/client</h1>
-  <p>Official TypeScript client for the <a href="https://abians.github.io/rustrak">Rustrak</a> self-hosted error tracking API</p>
+  <p>Official TypeScript client for the <a href="https://rustrak.github.io/rustrak">Rustrak</a> self-hosted error tracking API</p>
 
   <p>
     <a href="https://www.npmjs.com/package/@rustrak/client">
@@ -15,26 +15,26 @@
     <a href="https://bundlephobia.com/package/@rustrak/client">
       <img src="https://img.shields.io/bundlephobia/minzip/@rustrak/client?style=flat-square&label=bundle" alt="bundle size" />
     </a>
-    <a href="https://github.com/AbianS/rustrak/blob/main/LICENSE">
+    <a href="https://github.com/rustrak/rustrak/blob/main/LICENSE">
       <img src="https://img.shields.io/npm/l/@rustrak/client?style=flat-square" alt="license" />
     </a>
-    <a href="https://github.com/AbianS/rustrak/actions/workflows/ci.yml">
-      <img src="https://img.shields.io/github/actions/workflow/status/AbianS/rustrak/ci.yml?style=flat-square&label=CI" alt="CI" />
+    <a href="https://github.com/rustrak/rustrak/actions/workflows/ci.yml">
+      <img src="https://img.shields.io/github/actions/workflow/status/rustrak/rustrak/ci.yml?style=flat-square&label=CI" alt="CI" />
     </a>
   </p>
 
   <p>
-    <a href="https://abians.github.io/rustrak/sdks/client">Documentation</a>
+    <a href="https://rustrak.github.io/rustrak/sdks/client">Documentation</a>
     ·
-    <a href="https://github.com/AbianS/rustrak">GitHub</a>
+    <a href="https://github.com/rustrak/rustrak">GitHub</a>
     ·
-    <a href="https://github.com/AbianS/rustrak/issues">Report a Bug</a>
+    <a href="https://github.com/rustrak/rustrak/issues">Report a Bug</a>
   </p>
 </div>
 
 ---
 
-`@rustrak/client` is the official TypeScript client for [Rustrak](https://abians.github.io/rustrak) — an ultra-lightweight, self-hosted error tracking system compatible with any Sentry SDK. This package wraps the Rustrak REST API with full type safety, runtime validation via Zod, built-in retry logic, and structured error handling. Total bundle size: ~28 KB.
+`@rustrak/client` is the official TypeScript client for [Rustrak](https://rustrak.github.io/rustrak) — an ultra-lightweight, self-hosted error tracking system compatible with any Sentry SDK. This package wraps the Rustrak REST API with full type safety, runtime validation via Zod, built-in retry logic, and structured error handling. Total bundle size: ~28 KB.
 
 ## Installation
 
@@ -71,7 +71,7 @@ const { items, next_cursor, has_more } = await client.issues.list(1, {
 await client.issues.updateState(1, 'issue-id', { is_resolved: true });
 ```
 
-**[Full documentation →](https://abians.github.io/rustrak/sdks/client)**
+**[Full documentation →](https://rustrak.github.io/rustrak/sdks/client)**
 
 ## Features
 
@@ -231,13 +231,13 @@ import type {
 
 ## What is Rustrak?
 
-[Rustrak](https://abians.github.io/rustrak) is a self-hosted error tracking server written in Rust that is fully compatible with any Sentry SDK. Drop-in replacement for Sentry — no code changes needed. Runs on ~50 MB of memory as a single binary or Docker image.
+[Rustrak](https://rustrak.github.io/rustrak) is a self-hosted error tracking server written in Rust that is fully compatible with any Sentry SDK. Drop-in replacement for Sentry — no code changes needed. Runs on ~50 MB of memory as a single binary or Docker image.
 
-- [Getting Started](https://abians.github.io/rustrak/getting-started/overview)
-- [Self-Hosting Guide](https://abians.github.io/rustrak/configuration/production)
-- [API Reference](https://abians.github.io/rustrak/api-reference)
-- [GitHub](https://github.com/AbianS/rustrak)
+- [Getting Started](https://rustrak.github.io/rustrak/getting-started/overview)
+- [Self-Hosting Guide](https://rustrak.github.io/rustrak/configuration/production)
+- [API Reference](https://rustrak.github.io/rustrak/api-reference)
+- [GitHub](https://github.com/rustrak/rustrak)
 
 ## License
 
-[GPL-3.0](https://github.com/AbianS/rustrak/blob/main/LICENSE)
+[GPL-3.0](https://github.com/rustrak/rustrak/blob/main/LICENSE)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,14 +2,14 @@
   "name": "@rustrak/client",
   "version": "0.2.0",
   "description": "Type-safe TypeScript client for the Rustrak self-hosted error tracking API",
-  "homepage": "https://abians.github.io/rustrak/sdks/client",
+  "homepage": "https://rustrak.github.io/rustrak/sdks/client",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AbianS/rustrak.git",
+    "url": "https://github.com/rustrak/rustrak.git",
     "directory": "packages/client"
   },
   "bugs": {
-    "url": "https://github.com/AbianS/rustrak/issues"
+    "url": "https://github.com/rustrak/rustrak/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`fd768de`](https://github.com/AbianS/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b)]:
+- Updated dependencies [[`fd768de`](https://github.com/rustrak/rustrak/commit/fd768de0816ba6eeeaa26ed8893d82bd6224fd2b)]:
   - @rustrak/client@0.2.0
 
 ## 0.1.2
 
 ### Patch Changes
 
-- [`6a8b860`](https://github.com/AbianS/rustrak/commit/6a8b860eda0fa199a31089e295a102aef3da6122) Thanks [@AbianS](https://github.com/AbianS)! - Improve npm package metadata, READMEs, and official documentation.
+- [`6a8b860`](https://github.com/rustrak/rustrak/commit/6a8b860eda0fa199a31089e295a102aef3da6122) Thanks [@AbianS](https://github.com/AbianS)! - Improve npm package metadata, READMEs, and official documentation.
 
   - Add `homepage`, `repository` (with monorepo `directory`), `bugs`, `author`, and `engines` fields to both packages
   - Expand `keywords` for better npm search discoverability
@@ -19,18 +19,18 @@
   - Rewrite both package READMEs: badge row, prominent docs link, cross-references between packages, Cursor and Continue.dev config examples in `@rustrak/mcp`
   - Add new "SDKs & Integrations" section to the docs site with dedicated pages for `@rustrak/client` and `@rustrak/mcp` covering installation, full API reference, error handling, and AI client setup
 
-- Updated dependencies [[`6a8b860`](https://github.com/AbianS/rustrak/commit/6a8b860eda0fa199a31089e295a102aef3da6122)]:
+- Updated dependencies [[`6a8b860`](https://github.com/rustrak/rustrak/commit/6a8b860eda0fa199a31089e295a102aef3da6122)]:
   - @rustrak/client@0.1.3
 
 ## 0.1.1
 
 ### Patch Changes
 
-- [`40ba761`](https://github.com/AbianS/rustrak/commit/40ba76136d2c455fc22fcc1b99850eb3d29769bd) Thanks [@AbianS](https://github.com/AbianS)! - **server**: migrate all alert-channel and alert-rule endpoints from `AuthenticatedUser` to `ApiAuth` extractor, enabling bearer token access to the alerts API
+- [`40ba761`](https://github.com/rustrak/rustrak/commit/40ba76136d2c455fc22fcc1b99850eb3d29769bd) Thanks [@AbianS](https://github.com/AbianS)! - **server**: migrate all alert-channel and alert-rule endpoints from `AuthenticatedUser` to `ApiAuth` extractor, enabling bearer token access to the alerts API
 
   **client**: remove `private` flag and add `publishConfig` for npm publishing; bump zod to 4.4.3, msw to 2.14.6, vitest to 4.1.6, @types/node to 25.8.0
 
   **mcp**: wire npm publish in CI pipeline for initial public release of `@rustrak/mcp`
 
-- Updated dependencies [[`40ba761`](https://github.com/AbianS/rustrak/commit/40ba76136d2c455fc22fcc1b99850eb3d29769bd)]:
+- Updated dependencies [[`40ba761`](https://github.com/rustrak/rustrak/commit/40ba76136d2c455fc22fcc1b99850eb3d29769bd)]:
   - @rustrak/client@0.1.2

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,9 +1,9 @@
 <div align="center">
-  <a href="https://abians.github.io/rustrak">
-    <img src="https://raw.githubusercontent.com/AbianS/rustrak/main/apps/docs/public/logo.svg" alt="Rustrak" width="64" height="64" />
+  <a href="https://rustrak.github.io/rustrak">
+    <img src="https://raw.githubusercontent.com/rustrak/rustrak/main/apps/docs/public/logo.svg" alt="Rustrak" width="64" height="64" />
   </a>
   <h1>@rustrak/mcp</h1>
-  <p>MCP server that gives AI assistants full control of your <a href="https://abians.github.io/rustrak">Rustrak</a> error tracking</p>
+  <p>MCP server that gives AI assistants full control of your <a href="https://rustrak.github.io/rustrak">Rustrak</a> error tracking</p>
 
   <p>
     <a href="https://www.npmjs.com/package/@rustrak/mcp">
@@ -12,28 +12,28 @@
     <a href="https://www.npmjs.com/package/@rustrak/mcp">
       <img src="https://img.shields.io/npm/dw/@rustrak/mcp?style=flat-square" alt="weekly downloads" />
     </a>
-    <a href="https://github.com/AbianS/rustrak/blob/main/LICENSE">
+    <a href="https://github.com/rustrak/rustrak/blob/main/LICENSE">
       <img src="https://img.shields.io/npm/l/@rustrak/mcp?style=flat-square" alt="license" />
     </a>
-    <a href="https://github.com/AbianS/rustrak/actions/workflows/ci.yml">
-      <img src="https://img.shields.io/github/actions/workflow/status/AbianS/rustrak/ci.yml?style=flat-square&label=CI" alt="CI" />
+    <a href="https://github.com/rustrak/rustrak/actions/workflows/ci.yml">
+      <img src="https://img.shields.io/github/actions/workflow/status/rustrak/rustrak/ci.yml?style=flat-square&label=CI" alt="CI" />
     </a>
   </p>
 
   <p>
-    <a href="https://abians.github.io/rustrak/sdks/mcp">Documentation</a>
+    <a href="https://rustrak.github.io/rustrak/sdks/mcp">Documentation</a>
     ·
-    <a href="https://github.com/AbianS/rustrak">GitHub</a>
+    <a href="https://github.com/rustrak/rustrak">GitHub</a>
     ·
-    <a href="https://github.com/AbianS/rustrak/issues">Report a Bug</a>
+    <a href="https://github.com/rustrak/rustrak/issues">Report a Bug</a>
   </p>
 </div>
 
 ---
 
-`@rustrak/mcp` is a [Model Context Protocol](https://modelcontextprotocol.io) server for [Rustrak](https://abians.github.io/rustrak) — the self-hosted, Sentry-compatible error tracker. Connect it to Claude Desktop, Cursor, Continue.dev, or any MCP-compatible AI assistant and get 18 tools to list projects, inspect issues, view stack traces, resolve errors, and manage tokens without leaving your AI tool.
+`@rustrak/mcp` is a [Model Context Protocol](https://modelcontextprotocol.io) server for [Rustrak](https://rustrak.github.io/rustrak) — the self-hosted, Sentry-compatible error tracker. Connect it to Claude Desktop, Cursor, Continue.dev, or any MCP-compatible AI assistant and get 18 tools to list projects, inspect issues, view stack traces, resolve errors, and manage tokens without leaving your AI tool.
 
-**[Full documentation →](https://abians.github.io/rustrak/sdks/mcp)**
+**[Full documentation →](https://rustrak.github.io/rustrak/sdks/mcp)**
 
 ## Quick Start
 
@@ -196,11 +196,11 @@ The server runs as a local process over stdio — no open network port, no daemo
 
 ## What is Rustrak?
 
-[Rustrak](https://abians.github.io/rustrak) is a self-hosted error tracking server written in Rust that is fully compatible with any Sentry SDK. No code changes needed if you're migrating from Sentry. Runs on ~50 MB of memory as a single binary or Docker image.
+[Rustrak](https://rustrak.github.io/rustrak) is a self-hosted error tracking server written in Rust that is fully compatible with any Sentry SDK. No code changes needed if you're migrating from Sentry. Runs on ~50 MB of memory as a single binary or Docker image.
 
-- [Getting Started](https://abians.github.io/rustrak/getting-started/overview)
-- [Self-Hosting Guide](https://abians.github.io/rustrak/configuration/production)
-- [GitHub](https://github.com/AbianS/rustrak)
+- [Getting Started](https://rustrak.github.io/rustrak/getting-started/overview)
+- [Self-Hosting Guide](https://rustrak.github.io/rustrak/configuration/production)
+- [GitHub](https://github.com/rustrak/rustrak)
 
 ## Development
 
@@ -220,4 +220,4 @@ pnpm --filter @rustrak/mcp dev
 
 ## License
 
-[GPL-3.0](https://github.com/AbianS/rustrak/blob/main/LICENSE)
+[GPL-3.0](https://github.com/rustrak/rustrak/blob/main/LICENSE)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,14 +2,14 @@
   "name": "@rustrak/mcp",
   "version": "0.1.3",
   "description": "MCP server that gives AI assistants (Claude, Cursor, Continue) full control of your Rustrak error tracking",
-  "homepage": "https://abians.github.io/rustrak/sdks/mcp",
+  "homepage": "https://rustrak.github.io/rustrak/sdks/mcp",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AbianS/rustrak.git",
+    "url": "https://github.com/rustrak/rustrak.git",
     "directory": "packages/mcp"
   },
   "bugs": {
-    "url": "https://github.com/AbianS/rustrak/issues"
+    "url": "https://github.com/rustrak/rustrak/issues"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

This PR updates all hardcoded references in the codebase to reflect the repository migration from the personal account to the **rustrak** organization.

- **GitHub repo:** `AbianS/rustrak` → `rustrak/rustrak`
- **Docker Hub server image:** `abians7/rustrak-server` → `rustrak/rustrak-server`
- **Docker Hub UI image:** `abians7/rustrak-ui` → `rustrak/rustrak-ui`
- **Docs site:** `abians.github.io/rustrak` → `rustrak.github.io/rustrak`

## Files changed (23)

| Category | Files |
|----------|-------|
| CI/CD | `.github/workflows/docker-publish.yml` |
| Monorepo config | `.changeset/config.json` |
| Compose files | `docker-compose.yml`, `packages/benchmarks/docker-compose.benchmark.yml` |
| Package metadata | `packages/client/package.json`, `packages/mcp/package.json` |
| READMEs | `README.md`, `apps/server/README.md`, `apps/webview-ui/README.md`, `packages/client/README.md`, `packages/mcp/README.md` |
| Docs | `docs/deployment-guide.md`, `docs/development-guide.md`, `docs/index.md`, `docs/project-overview.md`, `docs/source-tree-analysis.md` |
| Changelogs | All `CHANGELOG.md` files (historical links updated) |

## ⚠️ GitHub Secrets to update after merging

Before the Docker publish workflow works in the new org, update these secrets in the **new** repository settings:

| Secret | Action |
|--------|--------|
| `DOCKERHUB_USERNAME` | Update to the `rustrak` Docker Hub account username |
| `DOCKERHUB_TOKEN` | Generate a new access token from the `rustrak` Docker Hub account |
| `PAT_TOKEN` | Create a new PAT with repo scope on the organization |

## ⚠️ Post-merge checklist

- [ ] Transfer repository on GitHub: Settings → Transfer → to `rustrak` org
- [ ] Confirm GitHub Pages is enabled on the new org repo (for docs at `rustrak.github.io/rustrak`)
- [ ] Update `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `PAT_TOKEN` secrets in new repo
- [ ] Push Docker images from new account (`docker tag` + `docker push rustrak/rustrak-server`)
- [ ] Update npm package publishing credentials if needed (`NPM_TOKEN` secret)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated repository organization references across all documentation and configuration files
- Docker images relocated to new `rustrak/` namespace
- Repository migrated to `rustrak/rustrak` GitHub organization  
- Installation, deployment, and development guides updated with new image locations and repository URLs
- External documentation links updated to reflect organizational changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->