### PR TITLE
fix: decrement project event counts when an issue is deleted

### DIFF
--- a/apps/server/src/services/issue.rs
+++ b/apps/server/src/services/issue.rs
@@ -521,10 +521,20 @@ impl IssueService {
 
     /// Hard-deletes an issue and all associated events and groupings (via CASCADE)
     pub async fn delete(pool: &DbPool, id: Uuid) -> AppResult<()> {
-        let result = sqlx::query("DELETE FROM issues WHERE id = $1")
-            .bind(id)
-            .execute(pool)
-            .await?;
+        let result = sqlx::query(
+            "WITH deleted AS (
+                DELETE FROM issues WHERE id = $1
+                RETURNING project_id, stored_event_count, digested_event_count
+            )
+            UPDATE projects SET
+                stored_event_count    = GREATEST(0, projects.stored_event_count    - deleted.stored_event_count),
+                digested_event_count  = GREATEST(0, projects.digested_event_count  - deleted.digested_event_count)
+            FROM deleted
+            WHERE projects.id = deleted.project_id",
+        )
+        .bind(id)
+        .execute(pool)
+        .await?;
 
         if result.rows_affected() == 0 {
             return Err(AppError::NotFound(format!("Issue {} not found", id)));


### PR DESCRIPTION
## Summary

- `IssueService::delete()` was only deleting the issue row but never updating `stored_event_count` / `digested_event_count` on `projects`, causing the project list to show stale (accumulating) counts forever.

## Fix

Replaced the plain `DELETE` with a single atomic CTE that deletes the issue and decrements the project counters in one query:

```sql
WITH deleted AS (
    DELETE FROM issues WHERE id = $1
    RETURNING project_id, stored_event_count, digested_event_count
)
UPDATE projects SET
    stored_event_count   = GREATEST(0, projects.stored_event_count   - deleted.stored_event_count),
    digested_event_count = GREATEST(0, projects.digested_event_count - deleted.digested_event_count)
FROM deleted
WHERE projects.id = deleted.project_id
```

`GREATEST(0, ...)` prevents the counters from going negative if data is inconsistent.

## Test plan

- [ ] Delete a single issue — verify project event count decreases by that issue's event count
- [ ] Delete all issues — verify project event counts reach 0
- [ ] Deleting a non-existent issue still returns 404