### PR TITLE
fix: decrement project event counts when an issue is deleted

### DIFF
--- a/apps/server/src/services/issue.rs
+++ b/apps/server/src/services/issue.rs
@@ -541,6 +541,8 @@ impl IssueService {
             if result.rows_affected() == 0 {
                 return Err(AppError::NotFound(format!("Issue {} not found", id)));
             }
+
+            return Ok(());
         }
 
         #[cfg(feature = "sqlite")]

--- a/apps/server/src/services/issue.rs
+++ b/apps/server/src/services/issue.rs
@@ -541,8 +541,6 @@ impl IssueService {
             if result.rows_affected() == 0 {
                 return Err(AppError::NotFound(format!("Issue {} not found", id)));
             }
-
-            return Ok(());
         }
 
         #[cfg(feature = "sqlite")]

--- a/apps/server/src/services/issue.rs
+++ b/apps/server/src/services/issue.rs
@@ -521,6 +521,7 @@ impl IssueService {
 
     /// Hard-deletes an issue and all associated events and groupings (via CASCADE)
     pub async fn delete(pool: &DbPool, id: Uuid) -> AppResult<()> {
+        #[cfg(feature = "postgres")]
         let result = sqlx::query(
             "WITH deleted AS (
                 DELETE FROM issues WHERE id = $1
@@ -529,6 +530,22 @@ impl IssueService {
             UPDATE projects SET
                 stored_event_count    = GREATEST(0, projects.stored_event_count    - deleted.stored_event_count),
                 digested_event_count  = GREATEST(0, projects.digested_event_count  - deleted.digested_event_count)
+            FROM deleted
+            WHERE projects.id = deleted.project_id",
+        )
+        .bind(id)
+        .execute(pool)
+        .await?;
+
+        #[cfg(feature = "sqlite")]
+        let result = sqlx::query(
+            "WITH deleted AS (
+                DELETE FROM issues WHERE id = $1
+                RETURNING project_id, stored_event_count, digested_event_count
+            )
+            UPDATE projects SET
+                stored_event_count    = MAX(0, projects.stored_event_count    - deleted.stored_event_count),
+                digested_event_count  = MAX(0, projects.digested_event_count  - deleted.digested_event_count)
             FROM deleted
             WHERE projects.id = deleted.project_id",
         )

--- a/apps/server/src/services/issue.rs
+++ b/apps/server/src/services/issue.rs
@@ -559,10 +559,14 @@ impl IssueService {
                 None => return Err(AppError::NotFound(format!("Issue {} not found", id))),
             };
 
-            sqlx::query("DELETE FROM issues WHERE id = $1")
+            let delete_result = sqlx::query("DELETE FROM issues WHERE id = $1")
                 .bind(id)
                 .execute(&mut *tx)
                 .await?;
+
+            if delete_result.rows_affected() == 0 {
+                return Err(AppError::NotFound(format!("Issue {} not found", id)));
+            }
 
             sqlx::query(
                 "UPDATE projects SET

--- a/apps/server/src/services/issue.rs
+++ b/apps/server/src/services/issue.rs
@@ -521,10 +521,20 @@ impl IssueService {
 
     /// Hard-deletes an issue and all associated events and groupings (via CASCADE)
     pub async fn delete(pool: &DbPool, id: Uuid) -> AppResult<()> {
-        let result = sqlx::query("DELETE FROM issues WHERE id = $1")
-            .bind(id)
-            .execute(pool)
-            .await?;
+        let result = sqlx::query(
+            "WITH deleted AS (
+                DELETE FROM issues WHERE id = $1
+                RETURNING project_id, stored_event_count, digested_event_count
+            )
+            UPDATE projects SET
+                stored_event_count    = GREATEST(0, projects.stored_event_count    - deleted.stored_event_count),
+                digested_event_count  = GREATEST(0, projects.digested_event_count  - deleted.digested_event_count)
+            FROM deleted
+            WHERE projects.id = deleted.project_id",
+        )
+        .bind(id)
+        .execute(pool)
+        .await?;
 
         if result.rows_affected() == 0 {
             return Err(AppError::NotFound(format!("Issue {} not found", id)));

--- a/apps/server/src/services/issue.rs
+++ b/apps/server/src/services/issue.rs
@@ -522,39 +522,61 @@ impl IssueService {
     /// Hard-deletes an issue and all associated events and groupings (via CASCADE)
     pub async fn delete(pool: &DbPool, id: Uuid) -> AppResult<()> {
         #[cfg(feature = "postgres")]
-        let result = sqlx::query(
-            "WITH deleted AS (
-                DELETE FROM issues WHERE id = $1
-                RETURNING project_id, stored_event_count, digested_event_count
+        {
+            let result = sqlx::query(
+                "WITH deleted AS (
+                    DELETE FROM issues WHERE id = $1
+                    RETURNING project_id, stored_event_count, digested_event_count
+                )
+                UPDATE projects SET
+                    stored_event_count    = GREATEST(0, projects.stored_event_count    - deleted.stored_event_count),
+                    digested_event_count  = GREATEST(0, projects.digested_event_count  - deleted.digested_event_count)
+                FROM deleted
+                WHERE projects.id = deleted.project_id",
             )
-            UPDATE projects SET
-                stored_event_count    = GREATEST(0, projects.stored_event_count    - deleted.stored_event_count),
-                digested_event_count  = GREATEST(0, projects.digested_event_count  - deleted.digested_event_count)
-            FROM deleted
-            WHERE projects.id = deleted.project_id",
-        )
-        .bind(id)
-        .execute(pool)
-        .await?;
+            .bind(id)
+            .execute(pool)
+            .await?;
+
+            if result.rows_affected() == 0 {
+                return Err(AppError::NotFound(format!("Issue {} not found", id)));
+            }
+        }
 
         #[cfg(feature = "sqlite")]
-        let result = sqlx::query(
-            "WITH deleted AS (
-                DELETE FROM issues WHERE id = $1
-                RETURNING project_id, stored_event_count, digested_event_count
-            )
-            UPDATE projects SET
-                stored_event_count    = MAX(0, projects.stored_event_count    - deleted.stored_event_count),
-                digested_event_count  = MAX(0, projects.digested_event_count  - deleted.digested_event_count)
-            FROM deleted
-            WHERE projects.id = deleted.project_id",
-        )
-        .bind(id)
-        .execute(pool)
-        .await?;
+        {
+            let mut tx = pool.begin().await?;
 
-        if result.rows_affected() == 0 {
-            return Err(AppError::NotFound(format!("Issue {} not found", id)));
+            let row = sqlx::query_as::<_, (i32, i32, i32)>(
+                "SELECT project_id, stored_event_count, digested_event_count FROM issues WHERE id = $1",
+            )
+            .bind(id)
+            .fetch_optional(&mut *tx)
+            .await?;
+
+            let (project_id, stored, digested) = match row {
+                Some(r) => r,
+                None => return Err(AppError::NotFound(format!("Issue {} not found", id))),
+            };
+
+            sqlx::query("DELETE FROM issues WHERE id = $1")
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+
+            sqlx::query(
+                "UPDATE projects SET
+                    stored_event_count    = MAX(0, stored_event_count    - $1),
+                    digested_event_count  = MAX(0, digested_event_count  - $2)
+                WHERE id = $3",
+            )
+            .bind(stored)
+            .bind(digested)
+            .bind(project_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
         }
 
         Ok(())


### PR DESCRIPTION
Project stored_event_count and digested_event_count were never decremented on issue deletion, causing stale counts in the projects list. Uses an atomic CTE to DELETE the issue and UPDATE the project counters in a single query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected project aggregate counters on issue deletion so they decrement correctly and never become negative.
  * Deletions now update project metrics atomically and consistently across environments, ensuring counts stay in sync.
  * Deletion attempts properly report when the target issue does not exist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustrak/rustrak/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->