### PR TITLE
fix(sourcemaps): accept non-SHA1 multipart field names in chunk upload

### DIFF
--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -15,9 +15,7 @@
   "paths": {
     "/api/0/organizations/{org_slug}/": {
       "get": {
-        "tags": [
-          "Source Maps"
-        ],
+        "tags": ["Source Maps"],
         "summary": "GET /api/0/organizations/{org_slug}/\nAlways returns 200 with synthetic org data — sentry-cli validates this before uploading.",
         "operationId": "org_details",
         "parameters": [
@@ -40,9 +38,7 @@
     },
     "/api/0/organizations/{org_slug}/artifactbundle/assemble/": {
       "post": {
-        "tags": [
-          "Source Maps"
-        ],
+        "tags": ["Source Maps"],
         "summary": "POST /api/0/organizations/{org_slug}/artifactbundle/assemble/",
         "operationId": "artifact_bundle_assemble",
         "parameters": [
@@ -127,9 +123,7 @@
     },
     "/api/0/organizations/{org_slug}/chunk-upload/": {
       "get": {
-        "tags": [
-          "Source Maps"
-        ],
+        "tags": ["Source Maps"],
         "summary": "GET /api/0/organizations/{org_slug}/chunk-upload/",
         "operationId": "chunk_upload_capability",
         "parameters": [
@@ -165,9 +159,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "Source Maps"
-        ],
+        "tags": ["Source Maps"],
         "summary": "POST /api/0/organizations/{org_slug}/chunk-upload/",
         "operationId": "chunk_upload",
         "parameters": [
@@ -182,7 +174,7 @@
           }
         ],
         "requestBody": {
-          "description": "One or more binary chunk files. Each multipart field name is the SHA-1 hex of its content (as used by sentry-cli).",
+          "description": "One or more binary chunk files. Field names may be SHA-1 hashes (v2 protocol) or arbitrary names like 'file' (v3.x protocol).",
           "content": {
             "multipart/form-data": {
               "schema": {
@@ -226,9 +218,7 @@
     },
     "/api/0/projects/{org_slug}/{project_slug}/files/source-maps/": {
       "get": {
-        "tags": [
-          "Source Maps"
-        ],
+        "tags": ["Source Maps"],
         "summary": "GET /api/0/projects/{org_slug}/{project_slug}/files/source-maps/",
         "operationId": "list_source_maps",
         "parameters": [
@@ -285,9 +275,7 @@
     },
     "/api/alert-channels": {
       "get": {
-        "tags": [
-          "Alert Channels"
-        ],
+        "tags": ["Alert Channels"],
         "summary": "GET /api/alert-channels",
         "operationId": "list_channels",
         "responses": {
@@ -322,9 +310,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "Alert Channels"
-        ],
+        "tags": ["Alert Channels"],
         "summary": "POST /api/alert-channels",
         "operationId": "create_channel",
         "requestBody": {
@@ -368,9 +354,7 @@
     },
     "/api/alert-channels/{id}": {
       "get": {
-        "tags": [
-          "Alert Channels"
-        ],
+        "tags": ["Alert Channels"],
         "summary": "GET /api/alert-channels/{id}",
         "operationId": "get_channel",
         "parameters": [
@@ -424,9 +408,7 @@
         ]
       },
       "delete": {
-        "tags": [
-          "Alert Channels"
-        ],
+        "tags": ["Alert Channels"],
         "summary": "DELETE /api/alert-channels/{id}",
         "operationId": "delete_channel",
         "parameters": [
@@ -473,9 +455,7 @@
         ]
       },
       "patch": {
-        "tags": [
-          "Alert Channels"
-        ],
+        "tags": ["Alert Channels"],
         "summary": "PATCH /api/alert-channels/{id}",
         "operationId": "update_channel",
         "parameters": [
@@ -541,9 +521,7 @@
     },
     "/api/alert-channels/{id}/test": {
       "post": {
-        "tags": [
-          "Alert Channels"
-        ],
+        "tags": ["Alert Channels"],
         "summary": "POST /api/alert-channels/{id}/test",
         "operationId": "test_channel",
         "parameters": [
@@ -592,9 +570,7 @@
     },
     "/api/projects": {
       "get": {
-        "tags": [
-          "Projects"
-        ],
+        "tags": ["Projects"],
         "summary": "GET /api/projects - List projects with pagination",
         "operationId": "list_projects",
         "parameters": [
@@ -739,9 +715,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "Projects"
-        ],
+        "tags": ["Projects"],
         "summary": "POST /api/projects - Create a new project",
         "operationId": "create_project",
         "requestBody": {
@@ -795,9 +769,7 @@
     },
     "/api/projects/{id}": {
       "get": {
-        "tags": [
-          "Projects"
-        ],
+        "tags": ["Projects"],
         "summary": "GET /api/projects/{id} - Get a project by ID",
         "operationId": "get_project",
         "parameters": [
@@ -851,9 +823,7 @@
         ]
       },
       "delete": {
-        "tags": [
-          "Projects"
-        ],
+        "tags": ["Projects"],
         "summary": "DELETE /api/projects/{id} - Delete a project",
         "operationId": "delete_project",
         "parameters": [
@@ -900,9 +870,7 @@
         ]
       },
       "patch": {
-        "tags": [
-          "Projects"
-        ],
+        "tags": ["Projects"],
         "summary": "PATCH /api/projects/{id} - Update a project",
         "operationId": "update_project",
         "parameters": [
@@ -978,9 +946,7 @@
     },
     "/api/projects/{project_id}/alert-history": {
       "get": {
-        "tags": [
-          "Alert Rules"
-        ],
+        "tags": ["Alert Rules"],
         "summary": "GET /api/projects/{project_id}/alert-history",
         "operationId": "list_history",
         "parameters": [
@@ -1049,9 +1015,7 @@
     },
     "/api/projects/{project_id}/alert-rules": {
       "get": {
-        "tags": [
-          "Alert Rules"
-        ],
+        "tags": ["Alert Rules"],
         "summary": "GET /api/projects/{project_id}/alert-rules",
         "operationId": "list_rules",
         "parameters": [
@@ -1108,9 +1072,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "Alert Rules"
-        ],
+        "tags": ["Alert Rules"],
         "summary": "POST /api/projects/{project_id}/alert-rules",
         "operationId": "create_rule",
         "parameters": [
@@ -1176,9 +1138,7 @@
     },
     "/api/projects/{project_id}/alert-rules/{rule_id}": {
       "get": {
-        "tags": [
-          "Alert Rules"
-        ],
+        "tags": ["Alert Rules"],
         "summary": "GET /api/projects/{project_id}/alert-rules/{rule_id}",
         "operationId": "get_rule",
         "parameters": [
@@ -1242,9 +1202,7 @@
         ]
       },
       "delete": {
-        "tags": [
-          "Alert Rules"
-        ],
+        "tags": ["Alert Rules"],
         "summary": "DELETE /api/projects/{project_id}/alert-rules/{rule_id}",
         "operationId": "delete_rule",
         "parameters": [
@@ -1301,9 +1259,7 @@
         ]
       },
       "patch": {
-        "tags": [
-          "Alert Rules"
-        ],
+        "tags": ["Alert Rules"],
         "summary": "PATCH /api/projects/{project_id}/alert-rules/{rule_id}",
         "operationId": "update_rule",
         "parameters": [
@@ -1379,9 +1335,7 @@
     },
     "/api/projects/{project_id}/issues": {
       "get": {
-        "tags": [
-          "Issues"
-        ],
+        "tags": ["Issues"],
         "summary": "GET /api/projects/{project_id}/issues\nLists issues for a project with offset-based pagination",
         "operationId": "list_issues",
         "parameters": [
@@ -1503,16 +1457,10 @@
                             "format": "date-time"
                           },
                           "level": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
+                            "type": ["string", "null"]
                           },
                           "platform": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
+                            "type": ["string", "null"]
                           },
                           "project_id": {
                             "type": "integer",
@@ -1581,9 +1529,7 @@
     },
     "/api/projects/{project_id}/issues/{issue_id}": {
       "get": {
-        "tags": [
-          "Issues"
-        ],
+        "tags": ["Issues"],
         "summary": "GET /api/projects/{project_id}/issues/{issue_id}\nGets a single issue by ID",
         "operationId": "get_issue",
         "parameters": [
@@ -1647,9 +1593,7 @@
         ]
       },
       "delete": {
-        "tags": [
-          "Issues"
-        ],
+        "tags": ["Issues"],
         "summary": "DELETE /api/projects/{project_id}/issues/{issue_id}\nHard-deletes an issue and all associated events",
         "operationId": "delete_issue",
         "parameters": [
@@ -1706,9 +1650,7 @@
         ]
       },
       "patch": {
-        "tags": [
-          "Issues"
-        ],
+        "tags": ["Issues"],
         "summary": "PATCH /api/projects/{project_id}/issues/{issue_id}\nUpdates issue state (resolve, mute, etc.)",
         "operationId": "update_issue",
         "parameters": [
@@ -1784,9 +1726,7 @@
     },
     "/api/projects/{project_id}/issues/{issue_id}/events": {
       "get": {
-        "tags": [
-          "Events"
-        ],
+        "tags": ["Events"],
         "summary": "GET /api/projects/{project_id}/issues/{issue_id}/events\nLists events for an issue with cursor-based pagination",
         "operationId": "list_events",
         "parameters": [
@@ -1825,10 +1765,7 @@
             "description": "Pagination cursor",
             "required": false,
             "schema": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             }
           }
         ],
@@ -1840,10 +1777,7 @@
                 "schema": {
                   "type": "object",
                   "description": "Paginated response wrapper (cursor-based)",
-                  "required": [
-                    "items",
-                    "has_more"
-                  ],
+                  "required": ["items", "has_more"],
                   "properties": {
                     "has_more": {
                       "type": "boolean"
@@ -1900,10 +1834,7 @@
                       }
                     },
                     "next_cursor": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": ["string", "null"]
                     }
                   }
                 }
@@ -1940,9 +1871,7 @@
     },
     "/api/projects/{project_id}/issues/{issue_id}/events/{event_id}": {
       "get": {
-        "tags": [
-          "Events"
-        ],
+        "tags": ["Events"],
         "summary": "GET /api/projects/{project_id}/issues/{issue_id}/events/{event_id}\nGets a single event with full data",
         "operationId": "get_event",
         "parameters": [
@@ -2018,9 +1947,7 @@
     },
     "/api/tokens": {
       "get": {
-        "tags": [
-          "Tokens"
-        ],
+        "tags": ["Tokens"],
         "summary": "GET /api/tokens - List all tokens (masked)",
         "operationId": "list_tokens",
         "responses": {
@@ -2055,9 +1982,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "Tokens"
-        ],
+        "tags": ["Tokens"],
         "summary": "POST /api/tokens - Create a new token",
         "operationId": "create_token",
         "requestBody": {
@@ -2101,9 +2026,7 @@
     },
     "/api/tokens/{id}": {
       "delete": {
-        "tags": [
-          "Tokens"
-        ],
+        "tags": ["Tokens"],
         "summary": "DELETE /api/tokens/{id} - Revoke a token",
         "operationId": "delete_token",
         "parameters": [
@@ -2152,9 +2075,7 @@
     },
     "/auth/login": {
       "post": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "summary": "POST /auth/login\nAuthenticate user and create session",
         "operationId": "login",
         "requestBody": {
@@ -2189,16 +2110,12 @@
             }
           }
         },
-        "security": [
-          {}
-        ]
+        "security": [{}]
       }
     },
     "/auth/logout": {
       "post": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "summary": "POST /auth/logout\nClear session",
         "operationId": "logout",
         "responses": {
@@ -2215,9 +2132,7 @@
     },
     "/auth/me": {
       "get": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "summary": "GET /auth/me\nGet current authenticated user",
         "operationId": "get_current_user",
         "responses": {
@@ -2251,9 +2166,7 @@
     },
     "/auth/register": {
       "post": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "summary": "POST /auth/register\nCreate new user account",
         "operationId": "register",
         "requestBody": {
@@ -2298,16 +2211,12 @@
             }
           }
         },
-        "security": [
-          {}
-        ]
+        "security": [{}]
       }
     },
     "/health": {
       "get": {
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "summary": "Liveness check - is the process running?\nReturns 200 if the server is alive.",
         "operationId": "liveness",
         "responses": {
@@ -2326,9 +2235,7 @@
     },
     "/health/ready": {
       "get": {
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "summary": "Readiness check - is the service ready to handle requests?\nReturns 200 if all dependencies are available, 503 otherwise.",
         "operationId": "readiness",
         "responses": {
@@ -2373,10 +2280,7 @@
         ],
         "properties": {
           "alert_rule_id": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "int32"
           },
           "alert_type": {
@@ -2387,10 +2291,7 @@
             "format": "int32"
           },
           "channel_id": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "int32"
           },
           "channel_name": {
@@ -2404,16 +2305,10 @@
             "format": "date-time"
           },
           "error_message": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "http_status_code": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "int32"
           },
           "id": {
@@ -2424,31 +2319,19 @@
             "type": "string"
           },
           "issue_id": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "uuid"
           },
           "next_retry_at": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time"
           },
           "project_id": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "int32"
           },
           "sent_at": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time"
           },
           "status": {
@@ -2501,10 +2384,7 @@
             "type": "boolean"
           },
           "last_triggered_at": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time"
           },
           "name": {
@@ -2523,29 +2403,16 @@
       "AlertStatus": {
         "type": "string",
         "description": "Status of an alert delivery attempt",
-        "enum": [
-          "pending",
-          "sent",
-          "failed",
-          "skipped"
-        ]
+        "enum": ["pending", "sent", "failed", "skipped"]
       },
       "AlertType": {
         "type": "string",
         "description": "Type of alert trigger",
-        "enum": [
-          "new_issue",
-          "regression",
-          "unmute"
-        ]
+        "enum": ["new_issue", "regression", "unmute"]
       },
       "AssembleBody": {
         "type": "object",
-        "required": [
-          "checksum",
-          "chunks",
-          "projects"
-        ],
+        "required": ["checksum", "chunks", "projects"],
         "properties": {
           "checksum": {
             "type": "string"
@@ -2566,16 +2433,10 @@
       },
       "AssembleResponse": {
         "type": "object",
-        "required": [
-          "state",
-          "missingChunks"
-        ],
+        "required": ["state", "missingChunks"],
         "properties": {
           "detail": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "missingChunks": {
             "type": "array",
@@ -2590,9 +2451,7 @@
       },
       "AuthResponse": {
         "type": "object",
-        "required": [
-          "user"
-        ],
+        "required": ["user"],
         "properties": {
           "user": {
             "$ref": "#/components/schemas/UserResponse"
@@ -2602,21 +2461,14 @@
       "AuthTokenCreatedResponse": {
         "type": "object",
         "description": "Response that includes the full token (only on creation)",
-        "required": [
-          "id",
-          "token",
-          "created_at"
-        ],
+        "required": ["id", "token", "created_at"],
         "properties": {
           "created_at": {
             "type": "string",
             "format": "date-time"
           },
           "description": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "id": {
             "type": "integer",
@@ -2630,31 +2482,21 @@
       "AuthTokenResponse": {
         "type": "object",
         "description": "Response for listing (token is masked)",
-        "required": [
-          "id",
-          "token_prefix",
-          "created_at"
-        ],
+        "required": ["id", "token_prefix", "created_at"],
         "properties": {
           "created_at": {
             "type": "string",
             "format": "date-time"
           },
           "description": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "id": {
             "type": "integer",
             "format": "int32"
           },
           "last_used_at": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time"
           },
           "token_prefix": {
@@ -2665,23 +2507,16 @@
       "ChannelType": {
         "type": "string",
         "description": "Type of notification channel",
-        "enum": [
-          "webhook",
-          "email",
-          "slack"
-        ]
+        "enum": ["webhook", "email", "slack"]
       },
       "ChunkUploadBody": {
         "type": "object",
-        "description": "Multipart chunk upload.\nEach part's **field name** is the SHA-1 hex digest of that part's binary content\n(e.g. `da39a3ee5e6b4b0d3255bfef95601890afd80709`). Field names are arbitrary — do not send\na literal field named `file`. Up to 64 parts per request; each part body is raw binary."
+        "description": "Multipart chunk upload.\nEach part's **field name** may be the SHA-1 hex digest of that part's binary content\n(sentry-cli v2 protocol, e.g. `da39a3ee5e6b4b0d3255bfef95601890afd80709`) or an arbitrary\nname like `file` (sentry-cli v3.x). Up to 64 parts per request; each part body is raw binary."
       },
       "CreateAlertRule": {
         "type": "object",
         "description": "DTO for creating an alert rule",
-        "required": [
-          "name",
-          "alert_type"
-        ],
+        "required": ["name", "alert_type"],
         "properties": {
           "alert_type": {
             "$ref": "#/components/schemas/AlertType"
@@ -2710,21 +2545,14 @@
         "description": "DTO for creating a new token",
         "properties": {
           "description": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         }
       },
       "CreateNotificationChannel": {
         "type": "object",
         "description": "DTO for creating a notification channel",
-        "required": [
-          "name",
-          "channel_type",
-          "config"
-        ],
+        "required": ["name", "channel_type", "config"],
         "properties": {
           "channel_type": {
             "$ref": "#/components/schemas/ChannelType"
@@ -2743,27 +2571,19 @@
       "CreateProject": {
         "type": "object",
         "description": "DTO for creating a new project",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
           },
           "slug": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         }
       },
       "CreateUserRequest": {
         "type": "object",
-        "required": [
-          "email",
-          "password"
-        ],
+        "required": ["email", "password"],
         "properties": {
           "email": {
             "type": "string"
@@ -2775,10 +2595,7 @@
       },
       "ErrorDetail": {
         "type": "object",
-        "required": [
-          "type",
-          "message"
-        ],
+        "required": ["type", "message"],
         "properties": {
           "message": {
             "type": "string"
@@ -2791,9 +2608,7 @@
       "ErrorResponse": {
         "type": "object",
         "description": "JSON error response structure",
-        "required": [
-          "error"
-        ],
+        "required": ["error"],
         "properties": {
           "error": {
             "$ref": "#/components/schemas/ErrorDetail"
@@ -2956,16 +2771,10 @@
             "format": "date-time"
           },
           "level": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "platform": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "project_id": {
             "type": "integer",
@@ -2984,9 +2793,7 @@
       },
       "LivenessResponse": {
         "type": "object",
-        "required": [
-          "status"
-        ],
+        "required": ["status"],
         "properties": {
           "status": {
             "type": "string"
@@ -2995,10 +2802,7 @@
       },
       "LoginRequest": {
         "type": "object",
-        "required": [
-          "email",
-          "password"
-        ],
+        "required": ["email", "password"],
         "properties": {
           "email": {
             "type": "string"
@@ -3044,23 +2848,14 @@
             "type": "boolean"
           },
           "last_failure_at": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time"
           },
           "last_failure_message": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "last_success_at": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time"
           },
           "name": {
@@ -3124,9 +2919,7 @@
       },
       "ReadinessChecks": {
         "type": "object",
-        "required": [
-          "database"
-        ],
+        "required": ["database"],
         "properties": {
           "database": {
             "type": "string"
@@ -3135,10 +2928,7 @@
       },
       "ReadinessResponse": {
         "type": "object",
-        "required": [
-          "status",
-          "checks"
-        ],
+        "required": ["status", "checks"],
         "properties": {
           "checks": {
             "$ref": "#/components/schemas/ReadinessChecks"
@@ -3153,39 +2943,24 @@
         "description": "DTO for updating an alert rule",
         "properties": {
           "channel_ids": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "items": {
               "type": "integer",
               "format": "int32"
             }
           },
           "conditions": {
-            "type": [
-              "object",
-              "null"
-            ]
+            "type": ["object", "null"]
           },
           "cooldown_minutes": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "int32"
           },
           "is_enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "name": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         }
       },
@@ -3194,16 +2969,10 @@
         "description": "Request to update issue state",
         "properties": {
           "is_muted": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "is_resolved": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           }
         }
       },
@@ -3212,22 +2981,13 @@
         "description": "DTO for updating a notification channel",
         "properties": {
           "config": {
-            "type": [
-              "object",
-              "null"
-            ]
+            "type": ["object", "null"]
           },
           "is_enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "name": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         }
       },
@@ -3236,20 +2996,13 @@
         "description": "DTO for updating a project",
         "properties": {
           "name": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         }
       },
       "UserResponse": {
         "type": "object",
-        "required": [
-          "id",
-          "email",
-          "is_admin"
-        ],
+        "required": ["id", "email", "is_admin"],
         "properties": {
           "email": {
             "type": "string"

--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -15,7 +15,9 @@
   "paths": {
     "/api/0/organizations/{org_slug}/": {
       "get": {
-        "tags": ["Source Maps"],
+        "tags": [
+          "Source Maps"
+        ],
         "summary": "GET /api/0/organizations/{org_slug}/\nAlways returns 200 with synthetic org data — sentry-cli validates this before uploading.",
         "operationId": "org_details",
         "parameters": [
@@ -38,7 +40,9 @@
     },
     "/api/0/organizations/{org_slug}/artifactbundle/assemble/": {
       "post": {
-        "tags": ["Source Maps"],
+        "tags": [
+          "Source Maps"
+        ],
         "summary": "POST /api/0/organizations/{org_slug}/artifactbundle/assemble/",
         "operationId": "artifact_bundle_assemble",
         "parameters": [
@@ -123,7 +127,9 @@
     },
     "/api/0/organizations/{org_slug}/chunk-upload/": {
       "get": {
-        "tags": ["Source Maps"],
+        "tags": [
+          "Source Maps"
+        ],
         "summary": "GET /api/0/organizations/{org_slug}/chunk-upload/",
         "operationId": "chunk_upload_capability",
         "parameters": [
@@ -159,7 +165,9 @@
         ]
       },
       "post": {
-        "tags": ["Source Maps"],
+        "tags": [
+          "Source Maps"
+        ],
         "summary": "POST /api/0/organizations/{org_slug}/chunk-upload/",
         "operationId": "chunk_upload",
         "parameters": [
@@ -218,7 +226,9 @@
     },
     "/api/0/projects/{org_slug}/{project_slug}/files/source-maps/": {
       "get": {
-        "tags": ["Source Maps"],
+        "tags": [
+          "Source Maps"
+        ],
         "summary": "GET /api/0/projects/{org_slug}/{project_slug}/files/source-maps/",
         "operationId": "list_source_maps",
         "parameters": [
@@ -275,7 +285,9 @@
     },
     "/api/alert-channels": {
       "get": {
-        "tags": ["Alert Channels"],
+        "tags": [
+          "Alert Channels"
+        ],
         "summary": "GET /api/alert-channels",
         "operationId": "list_channels",
         "responses": {
@@ -310,7 +322,9 @@
         ]
       },
       "post": {
-        "tags": ["Alert Channels"],
+        "tags": [
+          "Alert Channels"
+        ],
         "summary": "POST /api/alert-channels",
         "operationId": "create_channel",
         "requestBody": {
@@ -354,7 +368,9 @@
     },
     "/api/alert-channels/{id}": {
       "get": {
-        "tags": ["Alert Channels"],
+        "tags": [
+          "Alert Channels"
+        ],
         "summary": "GET /api/alert-channels/{id}",
         "operationId": "get_channel",
         "parameters": [
@@ -408,7 +424,9 @@
         ]
       },
       "delete": {
-        "tags": ["Alert Channels"],
+        "tags": [
+          "Alert Channels"
+        ],
         "summary": "DELETE /api/alert-channels/{id}",
         "operationId": "delete_channel",
         "parameters": [
@@ -455,7 +473,9 @@
         ]
       },
       "patch": {
-        "tags": ["Alert Channels"],
+        "tags": [
+          "Alert Channels"
+        ],
         "summary": "PATCH /api/alert-channels/{id}",
         "operationId": "update_channel",
         "parameters": [
@@ -521,7 +541,9 @@
     },
     "/api/alert-channels/{id}/test": {
       "post": {
-        "tags": ["Alert Channels"],
+        "tags": [
+          "Alert Channels"
+        ],
         "summary": "POST /api/alert-channels/{id}/test",
         "operationId": "test_channel",
         "parameters": [
@@ -570,7 +592,9 @@
     },
     "/api/projects": {
       "get": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "GET /api/projects - List projects with pagination",
         "operationId": "list_projects",
         "parameters": [
@@ -715,7 +739,9 @@
         ]
       },
       "post": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "POST /api/projects - Create a new project",
         "operationId": "create_project",
         "requestBody": {
@@ -769,7 +795,9 @@
     },
     "/api/projects/{id}": {
       "get": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "GET /api/projects/{id} - Get a project by ID",
         "operationId": "get_project",
         "parameters": [
@@ -823,7 +851,9 @@
         ]
       },
       "delete": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "DELETE /api/projects/{id} - Delete a project",
         "operationId": "delete_project",
         "parameters": [
@@ -870,7 +900,9 @@
         ]
       },
       "patch": {
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "summary": "PATCH /api/projects/{id} - Update a project",
         "operationId": "update_project",
         "parameters": [
@@ -946,7 +978,9 @@
     },
     "/api/projects/{project_id}/alert-history": {
       "get": {
-        "tags": ["Alert Rules"],
+        "tags": [
+          "Alert Rules"
+        ],
         "summary": "GET /api/projects/{project_id}/alert-history",
         "operationId": "list_history",
         "parameters": [
@@ -1015,7 +1049,9 @@
     },
     "/api/projects/{project_id}/alert-rules": {
       "get": {
-        "tags": ["Alert Rules"],
+        "tags": [
+          "Alert Rules"
+        ],
         "summary": "GET /api/projects/{project_id}/alert-rules",
         "operationId": "list_rules",
         "parameters": [
@@ -1072,7 +1108,9 @@
         ]
       },
       "post": {
-        "tags": ["Alert Rules"],
+        "tags": [
+          "Alert Rules"
+        ],
         "summary": "POST /api/projects/{project_id}/alert-rules",
         "operationId": "create_rule",
         "parameters": [
@@ -1138,7 +1176,9 @@
     },
     "/api/projects/{project_id}/alert-rules/{rule_id}": {
       "get": {
-        "tags": ["Alert Rules"],
+        "tags": [
+          "Alert Rules"
+        ],
         "summary": "GET /api/projects/{project_id}/alert-rules/{rule_id}",
         "operationId": "get_rule",
         "parameters": [
@@ -1202,7 +1242,9 @@
         ]
       },
       "delete": {
-        "tags": ["Alert Rules"],
+        "tags": [
+          "Alert Rules"
+        ],
         "summary": "DELETE /api/projects/{project_id}/alert-rules/{rule_id}",
         "operationId": "delete_rule",
         "parameters": [
@@ -1259,7 +1301,9 @@
         ]
       },
       "patch": {
-        "tags": ["Alert Rules"],
+        "tags": [
+          "Alert Rules"
+        ],
         "summary": "PATCH /api/projects/{project_id}/alert-rules/{rule_id}",
         "operationId": "update_rule",
         "parameters": [
@@ -1335,7 +1379,9 @@
     },
     "/api/projects/{project_id}/issues": {
       "get": {
-        "tags": ["Issues"],
+        "tags": [
+          "Issues"
+        ],
         "summary": "GET /api/projects/{project_id}/issues\nLists issues for a project with offset-based pagination",
         "operationId": "list_issues",
         "parameters": [
@@ -1457,10 +1503,16 @@
                             "format": "date-time"
                           },
                           "level": {
-                            "type": ["string", "null"]
+                            "type": [
+                              "string",
+                              "null"
+                            ]
                           },
                           "platform": {
-                            "type": ["string", "null"]
+                            "type": [
+                              "string",
+                              "null"
+                            ]
                           },
                           "project_id": {
                             "type": "integer",
@@ -1529,7 +1581,9 @@
     },
     "/api/projects/{project_id}/issues/{issue_id}": {
       "get": {
-        "tags": ["Issues"],
+        "tags": [
+          "Issues"
+        ],
         "summary": "GET /api/projects/{project_id}/issues/{issue_id}\nGets a single issue by ID",
         "operationId": "get_issue",
         "parameters": [
@@ -1593,7 +1647,9 @@
         ]
       },
       "delete": {
-        "tags": ["Issues"],
+        "tags": [
+          "Issues"
+        ],
         "summary": "DELETE /api/projects/{project_id}/issues/{issue_id}\nHard-deletes an issue and all associated events",
         "operationId": "delete_issue",
         "parameters": [
@@ -1650,7 +1706,9 @@
         ]
       },
       "patch": {
-        "tags": ["Issues"],
+        "tags": [
+          "Issues"
+        ],
         "summary": "PATCH /api/projects/{project_id}/issues/{issue_id}\nUpdates issue state (resolve, mute, etc.)",
         "operationId": "update_issue",
         "parameters": [
@@ -1726,7 +1784,9 @@
     },
     "/api/projects/{project_id}/issues/{issue_id}/events": {
       "get": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "GET /api/projects/{project_id}/issues/{issue_id}/events\nLists events for an issue with cursor-based pagination",
         "operationId": "list_events",
         "parameters": [
@@ -1765,7 +1825,10 @@
             "description": "Pagination cursor",
             "required": false,
             "schema": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         ],
@@ -1777,7 +1840,10 @@
                 "schema": {
                   "type": "object",
                   "description": "Paginated response wrapper (cursor-based)",
-                  "required": ["items", "has_more"],
+                  "required": [
+                    "items",
+                    "has_more"
+                  ],
                   "properties": {
                     "has_more": {
                       "type": "boolean"
@@ -1834,7 +1900,10 @@
                       }
                     },
                     "next_cursor": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
                 }
@@ -1871,7 +1940,9 @@
     },
     "/api/projects/{project_id}/issues/{issue_id}/events/{event_id}": {
       "get": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "GET /api/projects/{project_id}/issues/{issue_id}/events/{event_id}\nGets a single event with full data",
         "operationId": "get_event",
         "parameters": [
@@ -1947,7 +2018,9 @@
     },
     "/api/tokens": {
       "get": {
-        "tags": ["Tokens"],
+        "tags": [
+          "Tokens"
+        ],
         "summary": "GET /api/tokens - List all tokens (masked)",
         "operationId": "list_tokens",
         "responses": {
@@ -1982,7 +2055,9 @@
         ]
       },
       "post": {
-        "tags": ["Tokens"],
+        "tags": [
+          "Tokens"
+        ],
         "summary": "POST /api/tokens - Create a new token",
         "operationId": "create_token",
         "requestBody": {
@@ -2026,7 +2101,9 @@
     },
     "/api/tokens/{id}": {
       "delete": {
-        "tags": ["Tokens"],
+        "tags": [
+          "Tokens"
+        ],
         "summary": "DELETE /api/tokens/{id} - Revoke a token",
         "operationId": "delete_token",
         "parameters": [
@@ -2075,7 +2152,9 @@
     },
     "/auth/login": {
       "post": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "summary": "POST /auth/login\nAuthenticate user and create session",
         "operationId": "login",
         "requestBody": {
@@ -2110,12 +2189,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          {}
+        ]
       }
     },
     "/auth/logout": {
       "post": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "summary": "POST /auth/logout\nClear session",
         "operationId": "logout",
         "responses": {
@@ -2132,7 +2215,9 @@
     },
     "/auth/me": {
       "get": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "summary": "GET /auth/me\nGet current authenticated user",
         "operationId": "get_current_user",
         "responses": {
@@ -2166,7 +2251,9 @@
     },
     "/auth/register": {
       "post": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "summary": "POST /auth/register\nCreate new user account",
         "operationId": "register",
         "requestBody": {
@@ -2211,12 +2298,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          {}
+        ]
       }
     },
     "/health": {
       "get": {
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "summary": "Liveness check - is the process running?\nReturns 200 if the server is alive.",
         "operationId": "liveness",
         "responses": {
@@ -2235,7 +2326,9 @@
     },
     "/health/ready": {
       "get": {
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "summary": "Readiness check - is the service ready to handle requests?\nReturns 200 if all dependencies are available, 503 otherwise.",
         "operationId": "readiness",
         "responses": {
@@ -2280,7 +2373,10 @@
         ],
         "properties": {
           "alert_rule_id": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int32"
           },
           "alert_type": {
@@ -2291,7 +2387,10 @@
             "format": "int32"
           },
           "channel_id": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int32"
           },
           "channel_name": {
@@ -2305,10 +2404,16 @@
             "format": "date-time"
           },
           "error_message": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "http_status_code": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int32"
           },
           "id": {
@@ -2319,19 +2424,31 @@
             "type": "string"
           },
           "issue_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "uuid"
           },
           "next_retry_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "project_id": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int32"
           },
           "sent_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "status": {
@@ -2384,7 +2501,10 @@
             "type": "boolean"
           },
           "last_triggered_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "name": {
@@ -2403,16 +2523,29 @@
       "AlertStatus": {
         "type": "string",
         "description": "Status of an alert delivery attempt",
-        "enum": ["pending", "sent", "failed", "skipped"]
+        "enum": [
+          "pending",
+          "sent",
+          "failed",
+          "skipped"
+        ]
       },
       "AlertType": {
         "type": "string",
         "description": "Type of alert trigger",
-        "enum": ["new_issue", "regression", "unmute"]
+        "enum": [
+          "new_issue",
+          "regression",
+          "unmute"
+        ]
       },
       "AssembleBody": {
         "type": "object",
-        "required": ["checksum", "chunks", "projects"],
+        "required": [
+          "checksum",
+          "chunks",
+          "projects"
+        ],
         "properties": {
           "checksum": {
             "type": "string"
@@ -2433,10 +2566,16 @@
       },
       "AssembleResponse": {
         "type": "object",
-        "required": ["state", "missingChunks"],
+        "required": [
+          "state",
+          "missingChunks"
+        ],
         "properties": {
           "detail": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "missingChunks": {
             "type": "array",
@@ -2451,7 +2590,9 @@
       },
       "AuthResponse": {
         "type": "object",
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "properties": {
           "user": {
             "$ref": "#/components/schemas/UserResponse"
@@ -2461,14 +2602,21 @@
       "AuthTokenCreatedResponse": {
         "type": "object",
         "description": "Response that includes the full token (only on creation)",
-        "required": ["id", "token", "created_at"],
+        "required": [
+          "id",
+          "token",
+          "created_at"
+        ],
         "properties": {
           "created_at": {
             "type": "string",
             "format": "date-time"
           },
           "description": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "type": "integer",
@@ -2482,21 +2630,31 @@
       "AuthTokenResponse": {
         "type": "object",
         "description": "Response for listing (token is masked)",
-        "required": ["id", "token_prefix", "created_at"],
+        "required": [
+          "id",
+          "token_prefix",
+          "created_at"
+        ],
         "properties": {
           "created_at": {
             "type": "string",
             "format": "date-time"
           },
           "description": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "type": "integer",
             "format": "int32"
           },
           "last_used_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "token_prefix": {
@@ -2507,7 +2665,11 @@
       "ChannelType": {
         "type": "string",
         "description": "Type of notification channel",
-        "enum": ["webhook", "email", "slack"]
+        "enum": [
+          "webhook",
+          "email",
+          "slack"
+        ]
       },
       "ChunkUploadBody": {
         "type": "object",
@@ -2516,7 +2678,10 @@
       "CreateAlertRule": {
         "type": "object",
         "description": "DTO for creating an alert rule",
-        "required": ["name", "alert_type"],
+        "required": [
+          "name",
+          "alert_type"
+        ],
         "properties": {
           "alert_type": {
             "$ref": "#/components/schemas/AlertType"
@@ -2545,14 +2710,21 @@
         "description": "DTO for creating a new token",
         "properties": {
           "description": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
       "CreateNotificationChannel": {
         "type": "object",
         "description": "DTO for creating a notification channel",
-        "required": ["name", "channel_type", "config"],
+        "required": [
+          "name",
+          "channel_type",
+          "config"
+        ],
         "properties": {
           "channel_type": {
             "$ref": "#/components/schemas/ChannelType"
@@ -2571,19 +2743,27 @@
       "CreateProject": {
         "type": "object",
         "description": "DTO for creating a new project",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
           },
           "slug": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
       "CreateUserRequest": {
         "type": "object",
-        "required": ["email", "password"],
+        "required": [
+          "email",
+          "password"
+        ],
         "properties": {
           "email": {
             "type": "string"
@@ -2595,7 +2775,10 @@
       },
       "ErrorDetail": {
         "type": "object",
-        "required": ["type", "message"],
+        "required": [
+          "type",
+          "message"
+        ],
         "properties": {
           "message": {
             "type": "string"
@@ -2608,7 +2791,9 @@
       "ErrorResponse": {
         "type": "object",
         "description": "JSON error response structure",
-        "required": ["error"],
+        "required": [
+          "error"
+        ],
         "properties": {
           "error": {
             "$ref": "#/components/schemas/ErrorDetail"
@@ -2771,10 +2956,16 @@
             "format": "date-time"
           },
           "level": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "platform": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "project_id": {
             "type": "integer",
@@ -2793,7 +2984,9 @@
       },
       "LivenessResponse": {
         "type": "object",
-        "required": ["status"],
+        "required": [
+          "status"
+        ],
         "properties": {
           "status": {
             "type": "string"
@@ -2802,7 +2995,10 @@
       },
       "LoginRequest": {
         "type": "object",
-        "required": ["email", "password"],
+        "required": [
+          "email",
+          "password"
+        ],
         "properties": {
           "email": {
             "type": "string"
@@ -2848,14 +3044,23 @@
             "type": "boolean"
           },
           "last_failure_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "last_failure_message": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "last_success_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "name": {
@@ -2919,7 +3124,9 @@
       },
       "ReadinessChecks": {
         "type": "object",
-        "required": ["database"],
+        "required": [
+          "database"
+        ],
         "properties": {
           "database": {
             "type": "string"
@@ -2928,7 +3135,10 @@
       },
       "ReadinessResponse": {
         "type": "object",
-        "required": ["status", "checks"],
+        "required": [
+          "status",
+          "checks"
+        ],
         "properties": {
           "checks": {
             "$ref": "#/components/schemas/ReadinessChecks"
@@ -2943,24 +3153,39 @@
         "description": "DTO for updating an alert rule",
         "properties": {
           "channel_ids": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "type": "integer",
               "format": "int32"
             }
           },
           "conditions": {
-            "type": ["object", "null"]
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "cooldown_minutes": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int32"
           },
           "is_enabled": {
-            "type": ["boolean", "null"]
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "name": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -2969,10 +3194,16 @@
         "description": "Request to update issue state",
         "properties": {
           "is_muted": {
-            "type": ["boolean", "null"]
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "is_resolved": {
-            "type": ["boolean", "null"]
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         }
       },
@@ -2981,13 +3212,22 @@
         "description": "DTO for updating a notification channel",
         "properties": {
           "config": {
-            "type": ["object", "null"]
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "is_enabled": {
-            "type": ["boolean", "null"]
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "name": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -2996,13 +3236,20 @@
         "description": "DTO for updating a project",
         "properties": {
           "name": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
       "UserResponse": {
         "type": "object",
-        "required": ["id", "email", "is_admin"],
+        "required": [
+          "id",
+          "email",
+          "is_admin"
+        ],
         "properties": {
           "email": {
             "type": "string"

--- a/apps/server/src/routes/sourcemaps.rs
+++ b/apps/server/src/routes/sourcemaps.rs
@@ -142,7 +142,7 @@ pub async fn chunk_upload(
             .and_then(|cd| cd.get_name().map(|s| s.to_string()))
             .unwrap_or_default();
 
-        // Skip unnamed fields; accept any named field (real sentry-cli uses SHA1 hash as name)
+        // Skip unnamed fields; named fields are validated by chunk_storage_key()
         if field_name.is_empty() {
             continue;
         }
@@ -180,13 +180,8 @@ pub async fn chunk_upload(
         }
 
         let sha1_hex = hex::encode(hasher.finalize());
-        if sha1_hex != field_name {
-            return Err(AppError::Validation(format!(
-                "checksum mismatch for field '{}': content SHA1 is {}",
-                field_name, sha1_hex
-            )));
-        }
-        parts.push((sha1_hex, buf));
+        let key = chunk_storage_key(&field_name, &sha1_hex)?;
+        parts.push((key, buf));
     }
 
     if parts.is_empty() {
@@ -434,6 +429,24 @@ pub async fn list_source_maps(
 // configure
 // ---------------------------------------------------------------------------
 
+/// Returns the storage key for a chunk given the multipart field name and computed SHA1.
+///
+/// sentry-cli v2 uses the SHA1 hash as the field name (verifiable).
+/// sentry-cli v3.x uses "file" or other arbitrary names — in that case we accept the
+/// chunk and key it by the computed SHA1 to stay idempotent with the assemble flow.
+fn chunk_storage_key(field_name: &str, computed_sha1: &str) -> Result<String, AppError> {
+    let is_sha1_name = field_name.len() == 40 && field_name.bytes().all(|b| b.is_ascii_hexdigit());
+
+    if is_sha1_name && computed_sha1 != field_name {
+        return Err(AppError::Validation(format!(
+            "checksum mismatch for field '{}': content SHA1 is {}",
+            field_name, computed_sha1
+        )));
+    }
+
+    Ok(computed_sha1.to_string())
+}
+
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg
         // Organization endpoints
@@ -495,5 +508,42 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["state"], "error");
         assert_eq!(json["missingChunks"], serde_json::json!([]));
+    }
+
+    // sentry-cli v2 / old protocol: field name IS the SHA1 hash
+    #[test]
+    fn test_chunk_storage_key_sha1_field_name_matching_accepted() {
+        let sha1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+        let result = chunk_storage_key(sha1, sha1);
+        assert_eq!(result.unwrap(), sha1);
+    }
+
+    // field name looks like SHA1 but content is different → corruption, reject
+    #[test]
+    fn test_chunk_storage_key_sha1_field_name_mismatch_rejected() {
+        let field_name = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+        let actual_sha1 = "aabbccdd5e6b4b0d3255bfef95601890afd80709";
+        let result = chunk_storage_key(field_name, actual_sha1);
+        assert!(result.is_err());
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(err.contains("checksum mismatch"));
+        assert!(err.contains(field_name));
+        assert!(err.contains(actual_sha1));
+    }
+
+    // sentry-cli v3.4.2: field name is "file", not SHA1 → accept, key by computed SHA1
+    #[test]
+    fn test_chunk_storage_key_file_field_name_accepted_keyed_by_sha1() {
+        let computed_sha1 = "612d44793ab6d1b3d311b9e1b73785e805ef239a";
+        let result = chunk_storage_key("file", computed_sha1);
+        assert_eq!(result.unwrap(), computed_sha1);
+    }
+
+    // any non-SHA1 field name → accept, key by computed SHA1
+    #[test]
+    fn test_chunk_storage_key_arbitrary_field_name_accepted_keyed_by_sha1() {
+        let computed_sha1 = "612d44793ab6d1b3d311b9e1b73785e805ef239a";
+        let result = chunk_storage_key("chunk_0", computed_sha1);
+        assert_eq!(result.unwrap(), computed_sha1);
     }
 }

--- a/apps/server/src/routes/sourcemaps.rs
+++ b/apps/server/src/routes/sourcemaps.rs
@@ -16,9 +16,9 @@ use crate::services::sourcemap::{get_missing_chunks, store_chunks, SourceMapProv
 // ---------------------------------------------------------------------------
 
 /// Multipart chunk upload.
-/// Each part's **field name** is the SHA-1 hex digest of that part's binary content
-/// (e.g. `da39a3ee5e6b4b0d3255bfef95601890afd80709`). Field names are arbitrary — do not send
-/// a literal field named `file`. Up to 64 parts per request; each part body is raw binary.
+/// Each part's **field name** may be the SHA-1 hex digest of that part's binary content
+/// (sentry-cli v2 protocol, e.g. `da39a3ee5e6b4b0d3255bfef95601890afd80709`) or an arbitrary
+/// name like `file` (sentry-cli v3.x). Up to 64 parts per request; each part body is raw binary.
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[allow(dead_code)]
 struct ChunkUploadBody {}
@@ -109,7 +109,7 @@ pub async fn chunk_upload_capability(
     params(("org_slug" = String, Path, description = "Organization slug")),
     request_body(
         content_type = "multipart/form-data",
-        description = "One or more binary chunk files. Each multipart field name is the SHA-1 hex of its content (as used by sentry-cli).",
+        description = "One or more binary chunk files. Field names may be SHA-1 hashes (v2 protocol) or arbitrary names like 'file' (v3.x protocol).",
         content = ChunkUploadBody,
     ),
     responses(
@@ -437,7 +437,7 @@ pub async fn list_source_maps(
 fn chunk_storage_key(field_name: &str, computed_sha1: &str) -> Result<String, AppError> {
     let is_sha1_name = field_name.len() == 40 && field_name.bytes().all(|b| b.is_ascii_hexdigit());
 
-    if is_sha1_name && computed_sha1 != field_name {
+    if is_sha1_name && !computed_sha1.eq_ignore_ascii_case(field_name) {
         return Err(AppError::Validation(format!(
             "checksum mismatch for field '{}': content SHA1 is {}",
             field_name, computed_sha1
@@ -545,5 +545,25 @@ mod tests {
         let computed_sha1 = "612d44793ab6d1b3d311b9e1b73785e805ef239a";
         let result = chunk_storage_key("chunk_0", computed_sha1);
         assert_eq!(result.unwrap(), computed_sha1);
+    }
+
+    // uppercase SHA1 field name with matching content → accept, return lowercase canonical SHA1
+    #[test]
+    fn test_chunk_storage_key_uppercase_sha1_field_name_accepted() {
+        let lowercase_sha1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+        let uppercase_field = "DA39A3EE5E6B4B0D3255BFEF95601890AFD80709";
+        let result = chunk_storage_key(uppercase_field, lowercase_sha1);
+        assert_eq!(result.unwrap(), lowercase_sha1);
+    }
+
+    // uppercase SHA1 field name with mismatched content → reject
+    #[test]
+    fn test_chunk_storage_key_uppercase_sha1_field_name_mismatch_rejected() {
+        let uppercase_field = "DA39A3EE5E6B4B0D3255BFEF95601890AFD80709";
+        let actual_sha1 = "aabbccdd5e6b4b0d3255bfef95601890afd80709";
+        let result = chunk_storage_key(uppercase_field, actual_sha1);
+        assert!(result.is_err());
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(err.contains("checksum mismatch"));
     }
 }


### PR DESCRIPTION
## Summary

- sentry-cli v3.x sends the artifact bundle chunk as a multipart field named `file` instead of the SHA1 hash, causing Rustrak to reject all source map uploads with a 400 `checksum mismatch for field 'file'` error
- Extract `chunk_storage_key()` pure function that accepts any field name: if the name looks like a SHA1, validate it; otherwise accept and key by the computed SHA1
- Backward-compatible: old sentry-cli (v2) still validated, corrupted uploads still rejected

## Root cause

Confirmed via `SENTRY_LOG_LEVEL=debug` trace against production — sentry-cli 3.4.2 (`@sentry/cli-darwin`) uses `file` as the multipart field name in the chunk upload POST, not the SHA1 hash as specified in the Sentry protocol docs.

## Test plan

- [ ] `cargo test --lib "sourcemaps::tests"` — 5 tests, all pass
- [ ] `cargo test` — 166 tests, 0 failures
- [ ] Run `sentry-cli sourcemaps upload` against a local Rustrak instance and confirm 200 response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sourcemap chunk upload now accepts both SHA-1-shaped and arbitrary multipart field names, rejecting only when a hash-shaped name’s content mismatches—improves retry resilience and idempotent assemble behavior.

* **Documentation**
  * Updated API/request docs and inline guidance to explain v2 vs v3.x field-name formats (SHA-1 digests or arbitrary names).

* **Tests**
  * Added comprehensive unit tests covering name formats, case variations, match/mismatch outcomes, and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->