### PR TITLE
fix(release): sync Cargo.lock and OpenAPI spec on version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       # Rust setup + caching
       # sccache caches individual crate compilations; rust-cache caches the registry/index.
       # Both are complementary: sccache speeds up recompilation, rust-cache avoids re-downloading.
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: 'latest'
           cache: pnpm
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version: 'latest'
           cache: pnpm
+      - uses: dtolnay/rust-toolchain@stable
 
       - run: pnpm install --frozen-lockfile
 

--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -10,7 +10,7 @@
       "name": "GPL-3.0-only",
       "identifier": "GPL-3.0-only"
     },
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "paths": {
     "/api/0/organizations/{org_slug}/": {

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -31,4 +31,7 @@ if ! grep -Eq "^version = \"$VERSION\"$" "$CARGO_TOML"; then
   exit 1
 fi
 
+cd "$SERVER_DIR" && cargo generate-lockfile
+cd "$SERVER_DIR" && cargo run --bin gen_openapi --features openapi
+
 echo "Synced version $VERSION to Cargo.toml"


### PR DESCRIPTION
## Summary

- `sync-version.sh` now runs `cargo generate-lockfile` after patching `Cargo.toml`, keeping `Cargo.lock` in sync on every version bump
- `sync-version.sh` also regenerates `apps/server/openapi.json` via `cargo run --bin gen_openapi --features openapi`, so `info.version` in the spec is always current
- `release.yml` adds `dtolnay/rust-toolchain@stable` so `cargo` is available during the changesets version step

## Test plan

- [ ] Merge a changeset PR and verify the bot-created version commit includes updated `Cargo.lock` and `openapi.json`
- [ ] Confirm `openapi.json` `info.version` matches the new semver after bump
- [ ] Confirm `Cargo.lock` references the new crate version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped public API version to 0.4.1.
  * Release and CI workflows updated to include a pinned Rust toolchain installation for stable builds.
  * Version sync script now refreshes dependency lockfile and regenerates the OpenAPI artifact as part of the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->