### PR TITLE
feat(docs): add changelog page with version history

### DIFF
--- a/.changeset/bumpy-games-fetch.md
+++ b/.changeset/bumpy-games-fetch.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Add changelog page with version history to documentation

--- a/apps/docs/content/_meta.js
+++ b/apps/docs/content/_meta.js
@@ -18,6 +18,16 @@ export default {
     type: 'page',
     href: '/getting-started/overview',
   },
+  changelog: {
+    title: 'Changelog',
+    type: 'page',
+    theme: {
+      sidebar: false,
+      toc: false,
+      breadcrumb: false,
+      pagination: false,
+    },
+  },
   blog: {
     title: 'Blog',
     type: 'page',

--- a/apps/docs/content/changelog/01-v0-1-x-early-development.mdx
+++ b/apps/docs/content/changelog/01-v0-1-x-early-development.mdx
@@ -1,0 +1,33 @@
+---
+version: v0.1.x
+title: Early Development & Infrastructure
+description: Initial project setup, CI/CD pipelines, Docker publishing, and foundational documentation.
+date: 2026-01-22
+tags: [infra, ci, docker, docs]
+---
+
+## Project Initialization
+
+The Rustrak project was born. Initial setup included:
+
+- Monorepo structure with pnpm workspaces and Turborepo
+- Rust server with Actix-web framework
+- Next.js web UI with Tailwind CSS
+- TypeScript client package with Zod validation
+- PostgreSQL database with SQLx
+
+## CI/CD & Infrastructure
+
+- GitHub Actions workflows for CI, release, and Docker publishing
+- Changeset-based version management
+- GitHub Pages deployment for documentation
+- Multi-architecture Docker image builds
+- CodeRabbit AI code review integration
+
+## Documentation
+
+- Initial documentation site with Nextra
+- Getting started, installation, and quickstart guides
+- Configuration and environment variable docs
+- API reference and architecture documentation
+- README files for all packages

--- a/apps/docs/content/changelog/02-v0-1-2-alerting-system.mdx
+++ b/apps/docs/content/changelog/02-v0-1-2-alerting-system.mdx
@@ -1,0 +1,28 @@
+---
+version: v0.1.2
+title: Alerting System & Benchmarks
+description: Notification channels, alert rules, server benchmarking suite, and system alerts.
+date: 2026-01-25
+tags: [server, ui, alerts, benchmarks]
+---
+
+## Alerting System
+
+- Email (SMTP) and Slack notification channels
+- Configurable alert rules with conditions
+- System-level alerts for operational events
+- Full CRUD management UI
+- Client package API resources
+
+## Server Benchmarks
+
+- Ingestion throughput benchmarking
+- Latency percentile tracking
+- Automated benchmark environment setup
+
+## Improvements
+
+- Responsive mobile menu for landing page
+- CONTRIBUTING.md documentation
+- Fixed stale state after channel deletion
+- Security and concurrency fixes from CodeRabbit review

--- a/apps/docs/content/changelog/03-v0-1-3-ci-optimization.mdx
+++ b/apps/docs/content/changelog/03-v0-1-3-ci-optimization.mdx
@@ -1,0 +1,21 @@
+---
+version: v0.1.3
+title: CI Optimization & Multi-Arch
+description: Faster CI with sccache caching, native ARM runners, and multi-architecture Docker images.
+date: 2026-02-24
+tags: [infra, ci, docker]
+---
+
+## CI Optimization
+
+- sccache Rust compilation caching
+- Native ARM64 GitHub runners
+- Parallel job execution
+- SHA-pinned GitHub Actions for security
+- Stable multi-architecture Docker builds
+
+## Docker
+
+- AMD64 and ARM64 Docker image support
+- Apple Silicon and ARM server compatibility
+- Optimized layer caching

--- a/apps/docs/content/changelog/04-v0-1-4-sqlite-support.mdx
+++ b/apps/docs/content/changelog/04-v0-1-4-sqlite-support.mdx
@@ -1,0 +1,20 @@
+---
+version: v0.1.4
+title: SQLite Support
+description: SQLite becomes the default database backend with PostgreSQL as an optional upgrade for production.
+date: 2026-03-09
+tags: [server, database, docker, sqlite]
+---
+
+## SQLite Support
+
+- SQLite is now the default database — zero configuration needed
+- PostgreSQL remains fully supported for production workloads
+- Feature flags for compile-time database selection
+- Cross-database compatible SQL queries
+- Dual migration directories
+
+## Docker
+
+- Two image variants: `latest-sqlite` and `latest-postgres`
+- Lighter footprint for the SQLite variant

--- a/apps/docs/content/changelog/05-v0-2-0-initial-release.mdx
+++ b/apps/docs/content/changelog/05-v0-2-0-initial-release.mdx
@@ -1,0 +1,37 @@
+---
+version: v0.2.0
+title: Initial Public Release
+description: The first public release of Rustrak — a self-hosted, Sentry-compatible error tracking system.
+date: 2026-04-24
+tags: [server, ui, docs, client]
+---
+
+## Server
+
+- Event ingestion with full Sentry envelope protocol support
+- Automatic issue grouping for similar errors
+- Project management — create and manage multiple projects
+- Email/password authentication with session management
+- Bearer token authentication for SDKs
+- PostgreSQL backend with Docker and docker-compose support
+
+## Web UI
+
+- Dashboard with overview of projects and recent issues
+- Issue detail view with stack traces, breadcrumbs, tags, and context
+- Project settings and basic user management
+- Responsive design for desktop and mobile
+
+## Client Package
+
+- `@rustrak/client` — TypeScript API client with full type safety
+- Resource-based API for projects, issues, and events
+- Zod validation for runtime type safety
+- Lightweight ky HTTP client
+
+## Infrastructure
+
+- GitHub Actions CI/CD with automated releases
+- Docker image publishing to Docker Hub
+- GitHub Pages documentation deployment
+- Changeset-based version management

--- a/apps/docs/content/changelog/06-v0-2-1-openapi.mdx
+++ b/apps/docs/content/changelog/06-v0-2-1-openapi.mdx
@@ -1,0 +1,38 @@
+---
+version: v0.2.1
+title: OpenAPI Spec & Interactive API Reference
+description: Auto-generated OpenAPI specification and interactive API reference documentation.
+date: 2026-04-29
+tags: [docs, server, openapi]
+---
+
+## OpenAPI Specification
+
+The Rustrak server now generates a full OpenAPI 3.0 specification:
+
+- Auto-generated from utoipa annotations on all endpoints
+- Feature-gated behind `openapi` feature flag
+- Committed to the repository for reference
+- CI-generated on each build
+
+## Interactive API Reference
+
+A new interactive API reference page powered by Scalar:
+
+- Try endpoints directly from the browser
+- Full request/response schemas
+- Searchable endpoint listing
+- Available at `/api-reference`
+
+## Security Hardening
+
+- CodeQL SAST scanning added to CI
+- Rust supply chain security scanning
+- cargo-deny configuration for dependency auditing
+- Fixed all clippy, fmt, and audit failures
+
+## Improvements
+
+- Updated dependencies across all packages
+- TypeScript 6.0 migration
+- Fixed CI release workflows

--- a/apps/docs/content/changelog/07-v0-2-2-ui-polish.mdx
+++ b/apps/docs/content/changelog/07-v0-2-2-ui-polish.mdx
@@ -1,0 +1,24 @@
+---
+version: v0.2.2
+title: UI Polish & Responsive Design
+description: Major UI improvements including responsive layouts, skeleton loading states, and Base UI migration.
+date: 2026-05-15
+tags: [ui, responsive, a11y]
+---
+
+## UI Improvements
+
+Major UI polish pass:
+
+- Responsive design for projects, issues, events, and settings pages
+- Skeleton loading states for issue and event detail routes
+- Base UI migration from Radix UI for better accessibility
+- New Rustrak bolt icon replacing generic Terminal icon
+- Sticky event sidebar for better navigation
+- Mobile-friendly global header
+
+## Improvements
+
+- Fixed stale state on dropdown actions
+- Fixed Docker UI build with pnpm global bin
+- Security audit fixes addressing 6 vulnerabilities

--- a/apps/docs/content/changelog/08-v0-2-3-slack-bearer-auth.mdx
+++ b/apps/docs/content/changelog/08-v0-2-3-slack-bearer-auth.mdx
@@ -1,0 +1,32 @@
+---
+version: v0.2.3
+title: Slack Multi-Method & Bearer Auth
+description: Slack bot token support, Bearer token API authentication, and security hardening.
+date: 2026-05-16
+tags: [server, auth, slack, security]
+---
+
+## Slack Multi-Method Configuration
+
+Slack integration now supports two authentication methods:
+
+- Incoming Webhooks — simple URL-based integration
+- Bot Tokens — full Slack bot token support with channel listing
+- Token redaction on edits to prevent silent data loss
+- Whitespace-only channel validation
+
+## Bearer Token API Authentication
+
+API authentication overhaul:
+
+- Bearer tokens accepted on all management API endpoints
+- Per-IP rate limiting on login and register endpoints
+- Proper error propagation instead of masking as 401
+- Docker compose builds with postgres feature
+
+## Improvements
+
+- Fixed alert issue URL to use project ID instead of slug
+- Retry slug INSERT on unique violation instead of returning 409
+- Delete temp files when process_event fails
+- Raised ingest payload limit to 100MB

--- a/apps/docs/content/changelog/09-v0-2-4-mcp-package.mdx
+++ b/apps/docs/content/changelog/09-v0-2-4-mcp-package.mdx
@@ -1,0 +1,26 @@
+---
+version: v0.2.4
+title: MCP Package
+description: New @rustrak/mcp package for AI-assisted error management, published on npm.
+date: 2026-05-17
+tags: [mcp, npm, ai]
+---
+
+## MCP Package
+
+Introducing `@rustrak/mcp` — a Model Context Protocol server for AI-assisted error management:
+
+- List projects and browse all your Rustrak projects
+- List and filter issues by project
+- View full issue details with stack traces
+- Update issue status — resolve, ignore, or bookmark
+- List alert rule configurations
+- Published on npm as `@rustrak/mcp`
+
+## Client Package
+
+`@rustrak/client` now published on npm with full documentation:
+
+- NPM metadata and comprehensive README
+- Improved build configuration
+- Type-safe API client for all resources

--- a/apps/docs/content/changelog/10-v0-2-5-alert-integrations.mdx
+++ b/apps/docs/content/changelog/10-v0-2-5-alert-integrations.mdx
@@ -1,0 +1,33 @@
+---
+version: v0.2.5
+title: Alert Integrations
+description: Two-tier alert integrations with global credentials and per-rule routing, plus improved event display.
+date: 2026-05-21
+tags: [server, ui, alerts, events]
+---
+
+## Alert Integrations
+
+Major improvements to the alerting system with a two-tier integration architecture:
+
+- Global credentials — configure Slack webhooks and bot tokens at the organization level
+- Per-rule routing — route alerts to specific channels per alert rule
+- Slack bot token support alongside incoming webhooks
+- Redesigned UI with collapsible integration sections
+- Client package with full integration resource API
+
+## Event Display Improvements
+
+Better visualization of error events:
+
+- Improved event titles and descriptions
+- Better tag rendering and breadcrumb display
+- Fixed hydration mismatch in stack trace syntax highlighting
+
+## Improvements
+
+- Hard delete replaces soft delete for issues
+- DSN generation now uses PUBLIC_URL environment variable
+- Rate limiting on login and register endpoints
+- Fixed orphaned temp files on digest errors
+- Slug TOCTOU retry on collision

--- a/apps/docs/content/changelog/11-v0-2-6-source-maps.mdx
+++ b/apps/docs/content/changelog/11-v0-2-6-source-maps.mdx
@@ -1,0 +1,38 @@
+---
+version: v0.2.6
+title: Source Map Processing
+description: Full source map upload, storage, and frame rewriting pipeline for readable stack traces.
+date: 2026-05-28
+tags: [server, client, sourcemaps]
+---
+
+## Source Map Processing
+
+Complete source map support:
+
+- Artifact bundle upload via Sentry-compatible API
+- Chunked uploads for large source map bundles
+- Frame rewriting — automatic resolution of minified stack traces
+- Background assembly jobs with validation
+- Automatic retry of failed jobs with backoff
+
+## Client Package
+
+`@rustrak/client` now includes a `SourceMapsResource`:
+
+- Upload artifact bundles
+- List and delete artifacts
+- Full type safety with Zod validation
+
+## Documentation
+
+- New source maps usage guide
+- Blog post: "Source Maps in Rustrak"
+- Updated API reference with source map endpoints
+
+## Improvements
+
+- Fixed permanently-failed jobs and chunk batching
+- Corrected protocol gaps for Sentry SDK compatibility
+- Preserved filenames when token source name is empty
+- Proper HTTP 200 response for assembly error states

--- a/apps/docs/content/changelog/12-v0-3-0-alert-integrations-hub.mdx
+++ b/apps/docs/content/changelog/12-v0-3-0-alert-integrations-hub.mdx
@@ -1,0 +1,25 @@
+---
+version: v0.3.0
+title: Alert Integrations Hub
+description: Redesigned integrations experience with collapsible sections, redesigned forms, and full client API.
+date: 2026-06-01
+tags: [server, ui, client, alerts]
+---
+
+## Alert Integrations Hub
+
+A redesigned integrations experience:
+
+- Collapsible section layout for cleaner UX
+- Redesigned alert rule form dialog
+- Full client package integration resource API
+- Fixed admin permission checks on alert channel listing
+- Hidden global admins from add-member dropdown
+
+## Agent Rusty
+
+A new AI agent skill for Sentry protocol expertise:
+
+- Deep Relay source analysis
+- Protocol compatibility tracking
+- BOND.md documentation of implementation state and gaps

--- a/apps/docs/content/changelog/13-v0-3-1-org-migration.mdx
+++ b/apps/docs/content/changelog/13-v0-3-1-org-migration.mdx
@@ -1,0 +1,22 @@
+---
+version: v0.3.1
+title: Organization Migration
+description: Rustrak moves to its own GitHub organization and Docker Hub namespace.
+date: 2026-06-04
+tags: [infra, docker, docs]
+---
+
+## Organization Migration
+
+Rustrak has moved to its own GitHub organization and Docker Hub namespace:
+
+- New GitHub org: [github.com/rustrak](https://github.com/rustrak)
+- New Docker Hub: [hub.docker.com/r/rustrak](https://hub.docker.com/r/rustrak)
+- All references updated across the codebase
+- Migration notice added for existing v0.x users
+
+## Improvements
+
+- Updated all Docker image references from `abians7/` to `rustrak/`
+- Fixed remaining owner references in skill files
+- Documentation updated with new URLs and migration guide

--- a/apps/docs/content/changelog/14-v0-3-2-sourcemap-fixes-uptime.mdx
+++ b/apps/docs/content/changelog/14-v0-3-2-sourcemap-fixes-uptime.mdx
@@ -1,0 +1,31 @@
+---
+version: v0.3.2
+title: Source Map Fixes & Uptime Monitoring
+description: Robust source map processing fixes and the foundation for uptime monitoring.
+date: 2026-06-06
+tags: [server, sourcemaps, uptime]
+---
+
+## Source Map Processing Fixes
+
+Multiple correctness and reliability improvements:
+
+- Accept non-SHA1 multipart field names in chunk uploads for broader SDK compatibility
+- Fixed event count decrement when issues are deleted
+- SQLite compatibility fixes for issue deletion
+- Guarded against concurrent deletes with proper locking
+
+## Uptime Monitoring (Backend)
+
+The foundation for uptime monitoring is now in place:
+
+- Probe scheduling and execution engine
+- Manual check endpoint for on-demand verification
+- DNS rebinding protection for security
+- Alert channel assignment for monitors
+
+## Improvements
+
+- Fixed scheduler probe slot claiming at fetch time
+- SSRF protection with conditional imports
+- OpenAPI spec regeneration

--- a/apps/docs/content/changelog/15-v0-3-3-team-rbac.mdx
+++ b/apps/docs/content/changelog/15-v0-3-3-team-rbac.mdx
@@ -1,0 +1,17 @@
+---
+version: v0.3.3
+title: Team RBAC
+description: Project-level role-based access control with team management and granular permissions.
+date: 2026-06-08
+tags: [server, ui, client, rbac]
+---
+
+## Team Management & RBAC
+
+Project-level role-based access control:
+
+- Roles: Admin, Member, Viewer — each with appropriate permissions
+- Team management — add and remove members from projects
+- New team management interface in project settings
+- MCP tools for AI-assisted team management
+- Client package with full team resource API

--- a/apps/docs/content/changelog/16-v0-4-0-team-rbac-integrations.mdx
+++ b/apps/docs/content/changelog/16-v0-4-0-team-rbac-integrations.mdx
@@ -1,0 +1,32 @@
+---
+version: v0.4.0
+title: Team RBAC & Alert Integrations Hub
+description: Granular project-level permissions, team management, and a unified integrations hub for alerts.
+date: 2026-06-08
+tags: [server, ui, client, rbac, alerts]
+---
+
+## Team Management & RBAC
+
+Project-level role-based access control is here:
+
+- Roles: Admin, Member, Viewer with appropriate permissions
+- Add and remove members from projects
+- New team management interface in project settings
+- MCP tools for AI-assisted workflows
+- Client package with full team resource API
+
+## Alert Integrations Hub
+
+A redesigned integrations experience:
+
+- Two-tier architecture — global credentials + per-rule routing
+- Collapsible sections for cleaner UX
+- Redesigned alert rule form dialog
+- Client package with full integration resource API
+
+## Improvements
+
+- Fixed admin permission checks on alert channel listing
+- Hidden global admins from add-member dropdown
+- Fixed MCP alerts resource integration

--- a/apps/docs/content/changelog/17-v0-4-1-session-tracking.mdx
+++ b/apps/docs/content/changelog/17-v0-4-1-session-tracking.mdx
@@ -1,0 +1,31 @@
+---
+version: v0.4.1
+title: Session Tracking & Release Health
+description: Track user sessions, monitor release health, and get real-time insights into application stability.
+date: 2026-06-09
+tags: [server, sessions, release-health]
+---
+
+## Session Tracking
+
+Rustrak now tracks user sessions with full Sentry SDK compatibility:
+
+- **Session lifecycle** — automatic creation, update, and termination
+- **Release health** — track crash-free rates per release
+- **Aggregation** — sessions are aggregated into release health statistics
+
+## Release Health Dashboard
+
+The new release health feature provides:
+
+- Crash-free session rate per release
+- Crash-free user rate per release
+- Session count and duration statistics
+- Automatic aggregation from incoming session events
+
+## Improvements
+
+- Session-only envelopes without event_id are now accepted
+- Removed unused imports in session API tests
+- Extracted release health row type alias for cleaner code
+- Addressed PR review feedback for session tracking implementation

--- a/apps/docs/src/app/[[...mdxPath]]/page.tsx
+++ b/apps/docs/src/app/[[...mdxPath]]/page.tsx
@@ -4,8 +4,9 @@ import { useMDXComponents } from '../../../mdx-components';
 export async function generateStaticParams() {
   const all = await generateStaticParamsFor('mdxPath')();
   // Blog posts are handled by app/blog/[slug]/page.tsx
+  // Changelog posts are handled by app/changelog/page.tsx
   return all.filter(
-    (p) => !Array.isArray(p.mdxPath) || p.mdxPath[0] !== 'blog',
+    (p) => !Array.isArray(p.mdxPath) || (p.mdxPath[0] !== 'blog' && p.mdxPath[0] !== 'changelog'),
   );
 }
 

--- a/apps/docs/src/app/changelog/layout.tsx
+++ b/apps/docs/src/app/changelog/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: {
+    default: 'Changelog',
+    template: '%s — Rustrak Changelog',
+  },
+  description: 'Release notes and version history for the Rustrak project.',
+};
+
+export default function ChangelogLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <div className="min-h-screen w-full">{children}</div>;
+}

--- a/apps/docs/src/app/changelog/page.tsx
+++ b/apps/docs/src/app/changelog/page.tsx
@@ -1,0 +1,133 @@
+import type { Metadata } from 'next';
+import { importPage } from 'nextra/pages';
+import { formatDateShort, getReleases } from '@/lib/changelog';
+
+export const metadata: Metadata = {
+  title: 'Changelog',
+  description: 'Release notes and version history for the Rustrak project.',
+};
+
+function DotIcon() {
+  return (
+    <svg viewBox="0 0 16 16" className="h-3 w-3" fill="currentColor">
+      <circle cx="8" cy="8" r="4" />
+    </svg>
+  );
+}
+
+function Tag({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
+      {label}
+    </span>
+  );
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-xs font-semibold tracking-widest uppercase text-neutral-400 dark:text-neutral-500 mb-6 flex items-center gap-3">
+      <span>{children}</span>
+      <span className="flex-1 h-px bg-neutral-200 dark:bg-neutral-800" />
+    </h2>
+  );
+}
+
+export default async function ChangelogPage() {
+  const releases = getReleases();
+
+  const mdxModules = await Promise.all(
+    releases.map((r) =>
+      importPage(['changelog', r.slug]).catch(() => ({ default: null })),
+    ),
+  );
+
+  const grouped = releases.reduce(
+    (acc, r) => {
+      const year = r.date.slice(0, 4);
+      if (!acc[year]) acc[year] = [];
+      acc[year].push(r);
+      return acc;
+    },
+    {} as Record<string, typeof releases>,
+  );
+
+  const years = Object.keys(grouped).sort((a, b) => Number(b) - Number(a));
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-16">
+      <div className="mb-16">
+        <h1 className="text-4xl font-extrabold tracking-tight text-neutral-900 dark:text-neutral-100 mb-3">
+          Changelog
+        </h1>
+        <p className="text-lg text-neutral-600 dark:text-neutral-400">
+          Every release of Rustrak, from the first commit to the latest feature.
+        </p>
+      </div>
+
+      <div className="relative">
+        <div className="absolute left-3.75 top-3 bottom-3 w-px bg-neutral-200 dark:bg-neutral-800" />
+
+        {years.map((year) => (
+          <div key={year} className="mb-16 last:mb-0">
+            <div className="relative pl-12 mb-10">
+              <div className="absolute left-0 top-0 flex items-center justify-center w-7.75 h-7.75 rounded-full bg-neutral-100 dark:bg-neutral-800 border-2 border-white dark:border-neutral-950 z-10">
+                <span className="text-xs font-bold text-neutral-500 dark:text-neutral-400">
+                  {year.slice(2)}
+                </span>
+              </div>
+              <SectionHeading>{year}</SectionHeading>
+            </div>
+
+            <div className="space-y-14">
+              {grouped[year].map((release) => {
+                const idx = releases.indexOf(release);
+                const MDXContent = mdxModules[idx]?.default;
+
+                return (
+                  <div key={release.slug} className="relative pl-12 group">
+                    <div className="absolute left-0 top-1 flex items-center justify-center w-7.75 h-7.75 rounded-full bg-white dark:bg-neutral-950 border-2 border-neutral-300 dark:border-neutral-700 z-10 group-hover:border-primary transition-colors duration-200">
+                      <DotIcon />
+                    </div>
+
+                    <div className="min-w-0 pt-1">
+                      <div className="flex flex-wrap items-center gap-2.5 mb-3">
+                        <span className="font-mono text-sm font-bold tracking-tight text-primary bg-primary/10 dark:bg-primary/20 px-2.5 py-0.5 rounded-md">
+                          {release.version}
+                        </span>
+                        <time
+                          className="text-sm text-neutral-400 dark:text-neutral-500"
+                          dateTime={release.date}
+                        >
+                          {formatDateShort(release.date)}
+                        </time>
+                        {release.tags.map((tag) => (
+                          <Tag key={tag} label={tag} />
+                        ))}
+                      </div>
+
+                      <h3 className="text-xl font-bold tracking-tight text-neutral-900 dark:text-neutral-100 mb-3">
+                        {release.title}
+                      </h3>
+
+                      {release.description && (
+                        <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-5 leading-relaxed">
+                          {release.description}
+                        </p>
+                      )}
+
+                      {MDXContent && (
+                        <article className="prose prose-neutral dark:prose-invert max-w-none prose-headings:font-bold prose-headings:tracking-tight prose-a:text-primary prose-code:font-mono prose-headings:text-base prose-headings:mt-0 prose-p:text-sm prose-p:leading-relaxed prose-p:text-neutral-600 dark:prose-p:text-neutral-400 prose-ul:mt-2 prose-li:text-sm prose-li:leading-relaxed prose-li:text-neutral-600 dark:prose-li:text-neutral-400 prose-hr:my-6">
+                          <MDXContent />
+                        </article>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/components/landing/navbar.tsx
+++ b/apps/docs/src/components/landing/navbar.tsx
@@ -13,7 +13,7 @@ export function LandingNavbar() {
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/80 backdrop-blur-md">
-      <nav className="mx-auto flex h-16 max-w-[1400px] items-center justify-between px-6 md:px-12">
+      <nav className="mx-auto flex h-16 max-w-350 items-center justify-between px-6 md:px-12">
         {/* Logo */}
         <Link href="/" className="flex items-center gap-2 font-bold">
           <RustrakLogoIcon className="size-8" />
@@ -29,6 +29,12 @@ export function LandingNavbar() {
             className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
           >
             Documentation
+          </Link>
+          <Link
+            href="/changelog"
+            className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Changelog
           </Link>
           <Link
             href="/blog"
@@ -72,6 +78,13 @@ export function LandingNavbar() {
               onClick={() => setIsMenuOpen(false)}
             >
               Documentation
+            </Link>
+            <Link
+              href="/changelog"
+              className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors py-2"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              Changelog
             </Link>
             <Link
               href="/blog"

--- a/apps/docs/src/lib/changelog.ts
+++ b/apps/docs/src/lib/changelog.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+export type Release = {
+  slug: string;
+  version: string;
+  title: string;
+  description: string;
+  date: string;
+  tags: string[];
+  content: string;
+};
+
+const CHANGELOG_DIR = path.join(process.cwd(), 'content/changelog');
+
+function ensureDir() {
+  if (!fs.existsSync(CHANGELOG_DIR))
+    fs.mkdirSync(CHANGELOG_DIR, { recursive: true });
+}
+
+function safeDate(s: string): Date | null {
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function getReleases(): Release[] {
+  ensureDir();
+  return fs
+    .readdirSync(CHANGELOG_DIR)
+    .filter((f) => f.endsWith('.mdx'))
+    .map((filename) => {
+      const raw = fs.readFileSync(path.join(CHANGELOG_DIR, filename), 'utf-8');
+      const { data, content } = matter(raw);
+      return {
+        slug: filename.replace(/\.mdx$/, ''),
+        version: data.version ?? '',
+        title: data.title ?? 'Untitled',
+        description: data.description ?? '',
+        date:
+          data.date instanceof Date
+            ? data.date.toISOString().split('T')[0]
+            : String(data.date ?? new Date().toISOString().split('T')[0]),
+        tags: Array.isArray(data.tags) ? data.tags : [],
+        content: content.trim(),
+      };
+    })
+    .sort(
+      (a, b) =>
+        (safeDate(b.date)?.getTime() ?? 0) - (safeDate(a.date)?.getTime() ?? 0),
+    );
+}
+
+export function formatDateShort(dateStr: string): string {
+  const d = safeDate(dateStr);
+  if (!d) return dateStr;
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/apps/docs/src/lib/changelog.ts
+++ b/apps/docs/src/lib/changelog.ts
@@ -46,8 +46,12 @@ export function getReleases(): Release[] {
       };
     })
     .sort(
-      (a, b) =>
-        (safeDate(b.date)?.getTime() ?? 0) - (safeDate(a.date)?.getTime() ?? 0),
+      (a, b) => {
+        const byDate =
+          (safeDate(b.date)?.getTime() ?? 0) - (safeDate(a.date)?.getTime() ?? 0);
+        if (byDate !== 0) return byDate;
+        return b.slug.localeCompare(a.slug);
+      },
     );
 }
 


### PR DESCRIPTION
Adds a comprehensive changelog page to the docs site with version history from v0.1.x through v0.4.1, covering all major features including alerting system, SQLite support, OpenAPI, UI polish, Slack/bearer auth, MCP package, alert integrations, source maps, org migration, team RBAC, and session tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated changelog area with year-grouped release timeline, page/layout, and site header links (desktop & mobile)
  * Docs-side changelog loader and utilities (release parsing, short date formatting)

* **Documentation**
  * Added detailed changelog entries v0.1.x–v0.4.1 (alerts, CI/multi-arch, DB options, OpenAPI, UI, integrations, source maps, uptime, RBAC, session tracking, initial release)
  * Added site metadata entry for a changelog page (UI chrome disabled)

* **Chores**
  * Added a documentation changeset entry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->