### PR TITLE
feat(skill): deps-updater skill

### DIFF
--- a/.claude/skills/deps-updater/SKILL.md
+++ b/.claude/skills/deps-updater/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: deps-updater
+description: Updates dependencies to exact latest versions across the monorepo. Use when user says 'update dependencies', 'upgrade deps', or 'run dep update'.
+---
+
+# deps-updater
+
+## Overview
+
+Scans every `package.json` and `Cargo.toml` in the workspace, resolves latest versions, pins them as exact, runs available codemods, then verifies nothing broke. Detects breaking changes and researches fixes, asking for user approval in interactive mode. Supports headless mode and scope narrowing (`--workspace`, `--packages`, `--skip-packages`). Act as a senior dependency maintenance engineer — minimize drift while protecting stability.
+
+## Conventions
+
+- Bare paths (e.g. `references/discover-deps.md`) resolve from the skill root.
+- `{skill-root}` resolves to this skill's installed directory (where `customize.toml` lives).
+- `{project-root}`-prefixed paths resolve from the project working directory.
+- `{skill-name}` resolves to the skill directory's basename.
+
+## On Activation
+
+### Step 1: Resolve the Workflow Block
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+
+If the script fails, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying structural merge rules: `{skill-root}/customize.toml`, `{project-root}/_bmad/custom/{skill-name}.toml`, `{project-root}/_bmad/custom/{skill-name}.user.toml`. Scalars override, tables deep-merge, arrays of tables keyed by `code`/`id` replace matching entries and append new ones, all other arrays append.
+
+### Step 2: Execute Prepend Steps
+
+Execute each entry in `{workflow.activation_steps_prepend}` in order before proceeding.
+
+### Step 3: Load Persistent Facts
+
+Treat every entry in `{workflow.persistent_facts}` as foundational context for the whole run. Entries prefixed `file:` are paths or globs — load the referenced contents as facts. All other entries are facts verbatim.
+
+### Step 4: Execute Append Steps
+
+Execute each entry in `{workflow.activation_steps_append}` in order before entering the workflow's first stage.
+
+### Step 5: Detect Headless
+
+If `--headless` or `-H` was passed, set `headless=true` for the run. Read `{workflow.headless_breaking_policy}` to determine breaking-change treatment.
+
+### Step 6: Parse Scope
+
+Parse `--workspace`, `--packages`, and `--skip-packages` from invocation args. Fall back to `{workflow.workspace_scope}`, `{workflow.package_scope}`, `{workflow.skip_packages}` if not provided. Empty means "all".
+
+## Workflow
+
+### Pre-flight
+
+Before any file writes, verify:
+- Git is available and working tree is clean (warn if dirty, block in headless mode).
+- Required tools are installed: `ncu` (npm-check-updates) and `cargo-upgrade` (cargo-edit). If missing, install them.
+- Network is reachable to package registries (npm registry, crates.io).
+- The project has the expected file structure (root `package.json`, `Cargo.toml` for Rust workspaces).
+
+In interactive mode, present a summary of what will be checked and ask to proceed. In headless mode, abort early if any pre-flight check fails.
+
+### Stage 1: Discover Dependencies
+
+Load `references/discover-deps.md` and execute. Applies scope filters to the manifest. Produces a filtered manifest of external deps across JS and Rust workspaces.
+
+Progression: proceed when a complete, filtered manifest has been produced.
+
+**Soft-gate (interactive only):** Present the scope and number of packages to update. "Ready to update {N} packages across {M} workspaces to latest? Any packages to skip or workspaces to exclude?" Let the user adjust scope before proceeding to file mutations.
+
+### Stage 2: Run Codemods
+
+Load `references/run-codemods.md` and execute. For each dep in the manifest with a matching entry in `{workflow.codemod_registry}`, run the registered migration. Codemods run BEFORE version bumps so they can transform code while the old version is still installed.
+
+Progression: proceed when all applicable codemods have been attempted (failures are warnings, not blockers).
+
+### Stage 3: Resolve and Pin
+
+Load `references/resolve-and-pin.md` and execute. Updates all package.json and Cargo.toml to latest exact versions. Save a diff of what changed before proceeding.
+
+Progression: proceed when all deps are at latest exact versions (or breaking changes were deferred to user approval).
+
+### Stage 4: Verify
+
+Load `references/verify-fixes.md` and execute. Run typecheck, lint, build, and tests across the workspace.
+
+Progression: proceed on all-clear. On failures, offer to roll back or fix.
+
+### Stage 5: Handle Breaking Changes
+
+Load `references/detect-breaking.md` and execute. Identify major-version bumps, research migration paths, and in interactive mode ask the user to approve each one before finalizing.
+
+Progression: all breaking changes resolved (approved, reverted, or skipped per headless policy).
+
+### Stage 6: Report
+
+Load `references/report.md` and execute. Summarize what changed, what was verified, and any unresolved issues. In headless mode, this is the final output. In interactive mode, present and ask if the user is satisfied.
+
+## Headless Output
+
+When `headless=true`, emit JSON at the end:
+
+```json
+{
+  "status": "complete",
+  "scope": { "workspaces": ["apps/webview-ui"], "packages": [], "skipped": [] },
+  "updated_packages": 5,
+  "breaking_changes": ["next@17.0.0", "react@20.0.0"],
+  "unresolved": [],
+  "verification": "all-passed"
+}
+```
+
+On verification failure: `"status": "blocked"` with a `"reason"` field.
+
+## Rollback
+
+If verification fails in Stage 4, the user may ask to roll back. Restore from git: `git checkout -- <paths>` for affected files. The diff saved in Stage 2 is the source of truth for what changed.

--- a/.claude/skills/deps-updater/SKILL.md
+++ b/.claude/skills/deps-updater/SKILL.md
@@ -111,4 +111,4 @@ On verification failure: `"status": "blocked"` with a `"reason"` field.
 
 ## Rollback
 
-If verification fails in Stage 4, the user may ask to roll back. Restore from git: `git checkout -- <paths>` for affected files. The diff saved in Stage 2 is the source of truth for what changed.
+If verification fails in Stage 4, the user may ask to roll back. Restore from git: `git checkout -- <paths>` for affected files. The diff saved in Stage 3 is the source of truth for what changed.

--- a/.claude/skills/deps-updater/customize.toml
+++ b/.claude/skills/deps-updater/customize.toml
@@ -1,0 +1,64 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for deps-updater.
+# Team overrides:     {project-root}/_bmad/custom/deps-updater.toml
+# Personal overrides: {project-root}/_bmad/custom/deps-updater.user.toml
+
+[workflow]
+
+activation_steps_prepend = []
+
+activation_steps_append = []
+
+on_complete = ""
+
+persistent_facts = [
+  "file:{project-root}/**/project-context.md",
+]
+
+# --- Scope narrowing defaults ---
+# Applied when the corresponding CLI flag (`--workspace`, `--packages`,
+# `--skip-packages`) is not provided. Empty = all.
+
+workspace_scope = []
+package_scope = []
+skip_packages = []
+
+# --- Codemod registry ---
+# Keyed by package name (`code`). When a package matching `code` is updated,
+# the workflow runs `command`. Use `<transform>` and `<path>` placeholders
+# for tools that accept dynamic transform/directory args.
+#
+# Team overrides append new entries. To disable a codemod from a team/user
+# override, set its `command` to an empty string.
+
+codemod_registry = [
+  { code = "next", command = "npx @next/codemod@latest <transform> <path>" },
+  { code = "react", command = "npx react-codemod <transform> <path>" },
+  { code = "react-dom", command = "npx react-codemod <transform> <path>" },
+  { code = "tailwindcss", command = "npx @tailwindcss/upgrade" },
+  { code = "turbo", command = "npx @turbo/codemod <transform>" },
+]
+
+# --- Workflow behavior scalars ---
+
+# Whether to update Rust Cargo.toml dependencies (in addition to JS/TS).
+update_rust = true
+
+# Custom verification commands. Leave empty to auto-detect from project config.
+test_command = ""
+typecheck_command = ""
+build_command = ""
+lint_command = ""
+
+# In headless mode: "skip" to leave breaking-change deps untouched, "report" to
+# update them and flag in the output.
+headless_breaking_policy = "report"
+
+# Sources to research breaking changes (one per line, supports {owner}/{repo}
+# placeholders resolved from the package's repository URL).
+breaking_change_research_sources = """
+https://github.com/{owner}/{repo}/releases
+https://github.com/{owner}/{repo}/blob/main/CHANGELOG.md
+https://github.com/{owner}/{repo}/blob/main/UPGRADING.md
+"""

--- a/.claude/skills/deps-updater/references/detect-breaking.md
+++ b/.claude/skills/deps-updater/references/detect-breaking.md
@@ -1,0 +1,65 @@
+# Detect and Handle Breaking Changes
+
+Review the diff of what changed for major-version bumps. For each one, research the migration path and handle according to mode. Communicate with the user in `{communication_language}`.
+
+## Identify breaking changes
+
+From the diff, flag any update where the major version changed (e.g. `next@16.x → next@17.x`, `react@19.x → react@20.x`). For Rust deps where semver isn't strictly followed, treat any version change where the first non-zero segment changed as breaking.
+
+## Known breaking-change catalog
+
+Before researching remotely, check this catalog for packages with known, documented migration paths. If a match is found, apply the documented fix directly instead of researching from scratch.
+
+### sqlx 0.8.x → 0.9.x
+
+**Breaking change**: `SqlSafeStr` trait — `sqlx::query_as(&some_string)` no longer compiles because `&String` does not implement `SqlSafeStr`. Only `&'static str` is accepted by default.
+
+**Fix**: Wrap dynamic SQL strings with `sqlx::AssertSqlSafe(&*some_string)` (deref `String` to `&str` first, then wrap). Search for all occurrences of `sqlx::query_as(`, `sqlx::query_scalar(`, `sqlx::query(` in the codebase that pass a `&String` (dereference from local variable). Also check test files.
+
+```rust
+// Before (sqlx 0.8)
+sqlx::query_as::<_, MyType>(&query)
+
+// After (sqlx 0.9)
+sqlx::query_as::<_, MyType>(sqlx::AssertSqlSafe(&*query))
+```
+
+### react 18.x → 19.x
+
+React 19 introduces concurrent features, removed deprecated lifecycle methods (`componentWillMount`, etc.), and changed legacy context API. Run `npx react-codemod` transforms.
+
+### tailwindcss 3.x → 4.x
+
+Tailwind v4 is a complete rewrite — no config file, CSS-first configuration, new theme API. Run `npx @tailwindcss/upgrade` which handles the migration.
+
+## Research migration
+
+For each breaking change, research what changed and how to migrate:
+
+1. Look up the package's repository URL (from its `package.json` `repository` field or `Cargo.toml` metadata).
+2. Check `{workflow.breaking_change_research_sources}` — visit each URL template with `{owner}` and `{repo}` resolved.
+3. For npm packages, also check `https://www.npmjs.com/package/<name>?activeTab=code` and GitHub releases.
+4. Understand the key breaking changes and migration steps.
+
+## Interactive mode
+
+For each breaking change, present to the user in `{communication_language}`:
+
+```
+Package: next 16.2.6 → 17.0.0 (MAJOR)
+Changes: [brief summary of what changed]
+Migration: [key migration steps required]
+Research sources visited: [list of URLs checked]
+
+Approve update? (y/n/skip-all)
+```
+
+- If approved: keep the update, apply any discovered migration steps manually.
+- If rejected: revert that specific dep's change using the diff as reference.
+- If skip-all: defer all breaking-change updates.
+
+## Headless mode (`headless=true`)
+
+Do NOT ask. Follow `{workflow.headless_breaking_policy}`:
+- `"report"`: keep all updates, log breaking changes to the report.
+- `"skip"`: revert all breaking-change deps, include them in the report as skipped.

--- a/.claude/skills/deps-updater/references/discover-deps.md
+++ b/.claude/skills/deps-updater/references/discover-deps.md
@@ -1,0 +1,59 @@
+# Discover Dependencies
+
+Build a complete manifest of every external dependency across the workspace. Exclude `node_modules`, `.git`, `target`, and any build output directories. Apply scope filters from the workflow config.
+
+## What to collect
+
+For **JavaScript/TypeScript** (all `package.json` files in the workspace):
+- Package name, current version spec (from `dependencies` and `devDependencies`)
+- Whether it's a workspace-internal dependency (check if it matches a workspace path from the root `package.json` `workspaces` field) — skip internals
+- Which workspace it was found in (path to the `package.json`)
+
+For **Rust** (all `Cargo.toml` files that are actual projects, not workspaces-only files):
+- Package name, current version spec (from `[dependencies]` and `[dev-dependencies]`)
+- Which workspace it was found in
+
+## Scope filtering
+
+Apply these filters in order:
+1. `{workflow.workspace_scope}` — only scan listed workspace directories. Empty = all.
+2. `{workflow.package_scope}` — only include these packages in the manifest. Empty = all.
+3. `{workflow.skip_packages}` — exclude these packages from the manifest.
+
+When CLI args are provided (`--workspace`, `--packages`, `--skip-packages`), those override the config defaults for this run.
+
+## Script-assisted discovery
+
+Run the prepass script for a compact JSON manifest:
+
+```
+python3 {skill-root}/scripts/discover-deps.py
+  [--workspace <path> ...]
+  [--packages <pkg> ...]
+  [--skip-packages <pkg> ...]
+```
+
+The script scans all files, resolves workspace membership, filters internal deps, applies scope filters, and emits the exact JSON schema below. Read the script's output as your manifest — no need to manually read raw config files.
+
+## Output
+
+Produce a structured manifest with three lists:
+
+```json
+{
+  "js_deps": [
+    { "name": "next", "current": "16.2.6", "workspaces": ["apps/webview-ui"] },
+    ...
+  ],
+  "rust_deps": [
+    { "name": "actix-web", "current": "4.13.0", "workspace": "apps/server" },
+    ...
+  ],
+  "workspace_paths": {
+    "js": ["apps/webview-ui", "packages/client", ...],
+    "rust": ["apps/server", "packages/benchmarks"]
+  }
+}
+```
+
+Note any deps that already have exact pinned versions vs range specifiers (`^`, `~`). The pinning stage needs this to know where pin-exact matters. Save the manifest — the next stage consumes it.

--- a/.claude/skills/deps-updater/references/report.md
+++ b/.claude/skills/deps-updater/references/report.md
@@ -1,0 +1,47 @@
+# Report
+
+Produce a summary of the entire dependency update run. Tailor presentation to the mode. Produce user-facing content in `{communication_language}`.
+
+## Headless
+
+Emit JSON:
+
+```json
+{
+  "status": "complete|blocked",
+  "date": "2026-06-16T12:00:00Z",
+  "scope": {
+    "workspaces": ["apps/webview-ui"],
+    "packages": ["next", "react"],
+    "skipped": []
+  },
+  "workspaces_affected": 5,
+  "updated_packages": [
+    { "name": "react", "from": "19.2.6", "to": "20.0.0", "workspaces": ["apps/webview-ui", "apps/docs"] }
+  ],
+  "codemods_run": [
+    { "package": "next", "codemod": "npx @next/codemod@latest ...", "status": "success|failed|skipped" }
+  ],
+  "breaking_changes": [
+    { "package": "next", "from": "16.2.6", "to": "17.0.0", "resolution": "approved|reverted|skipped" }
+  ],
+  "verification": {
+    "typecheck": "passed|failed",
+    "lint": "passed|failed",
+    "build": "passed|failed",
+    "test": "passed|failed"
+  },
+  "unresolved_issues": []
+}
+```
+
+## Interactive
+
+Present a Markdown summary in `{communication_language}` with:
+- **Summary table** — workspace, deps updated, codemods, verification status
+- **Breaking changes** — what was approved, reverted, or deferred
+- **Codemods** — what ran and whether they succeeded
+- **Verification results** — command by command
+- **Next steps** — any unresolved issues or manual migration steps the user needs to handle
+
+End with: "Are you satisfied with this update? (y/n)". If no, offer to roll back specific packages or revert the entire batch.

--- a/.claude/skills/deps-updater/references/resolve-and-pin.md
+++ b/.claude/skills/deps-updater/references/resolve-and-pin.md
@@ -42,7 +42,7 @@ After all JS and Rust updates are written to manifest files, install the new dep
 pnpm install --no-frozen-lockfile
 ```
 
-This ensures the lockfile (`pnpm-lock.yaml`, `Cargo.lock`) reflects the new versions before proceeding to verification.
+This ensures `pnpm-lock.yaml` reflects the new versions (the `Cargo.lock` was already updated by `cargo upgrade` in the Rust step).
 
 ## Diff
 

--- a/.claude/skills/deps-updater/references/resolve-and-pin.md
+++ b/.claude/skills/deps-updater/references/resolve-and-pin.md
@@ -1,0 +1,55 @@
+# Resolve and Pin
+
+Take the dependency manifest produced by the discovery stage and update every external dependency to its latest available version, pinned to an exact version.
+
+## JS/TypeScript
+
+For each JS workspace, run:
+
+```
+ncu --packageFile <path/to/package.json> --upgrade --target latest --removeRange
+```
+
+- `--upgrade` writes changes directly to `package.json` (non-interactive).
+- `--target latest` gets the absolute latest, including major bumps.
+- `--removeRange` strips `^` and `~` prefixes so all versions are pinned exact. In ncu v22+, this replaces the removed `--save-exact` flag.
+- If `ncu` is not available, install it with `npm install -g npm-check-updates` or use `pnpm dlx npm-check-updates`.
+
+After running `ncu`, verify EVERY dep has an exact version (no `^`, `~`, `>=` prefixes). `--removeRange` only strips ranges from packages that were actually updated — any pinned ranges on un-updated packages must be fixed manually. Scan for residual `^`/`~` in all updated `package.json` files and strip them.
+
+## Rust
+
+For each Rust workspace directory (containing `Cargo.toml`), run `cargo upgrade` from that directory:
+
+```
+cd apps/server && cargo upgrade
+cd packages/benchmarks && cargo upgrade
+```
+
+**Note**: `cargo upgrade` does NOT support `--workspace`. Run it per-workspace directory.
+
+From `cargo-edit` crate. If not installed: `cargo install cargo-edit`.
+
+Cargo already uses exact versions, so no pinning step is needed.
+
+For incompatible (major) bumps, re-run with `--incompatible allow` to see available major versions. Flag any that update for breaking change review.
+
+## Post-update install
+
+After all JS and Rust updates are written to manifest files, install the new deps and update lockfiles:
+
+```
+pnpm install --no-frozen-lockfile
+```
+
+This ensures the lockfile (`pnpm-lock.yaml`, `Cargo.lock`) reflects the new versions before proceeding to verification.
+
+## Diff
+
+After all updates, run `git diff` and note every dependency that changed:
+- Package name
+- From version → To version
+- Whether it's a major, minor, or patch bump
+- Which workspace file was modified
+
+This diff feeds into the codemod stage (runs per updated package) and breaking-change detection (identifies major bumps). Save it — you'll need it later.

--- a/.claude/skills/deps-updater/references/run-codemods.md
+++ b/.claude/skills/deps-updater/references/run-codemods.md
@@ -1,0 +1,35 @@
+# Run Codemods
+
+Codemods run BEFORE version bumps. Use the discovered manifest (current versions) to decide which codemods to run. The package's current code is still on the old version — codemods transform it to be compatible with the new one.
+
+## Workflow
+
+1. Walk the discovered manifest. For every dep that has a matching `code` in `{workflow.codemod_registry}`, run its registered migration.
+2. Run codemods regardless of bump size (patch, minor, or major). Even patch bumps can ship new APIs or deprecate old patterns that a codemod may want to fix.
+3. For each match:
+   - Resolve `<transform>` and `<path>` placeholders:
+     - `<transform>` — research what transforms/codemods are available for this version jump. Look at the package's release notes or changelog. For known tools like `@next/codemod`, check available transforms by running the tool with `--help` or `--list`.
+     - `<path>` — the workspace directory(s) where the package is used.
+   - Run the resolved command in the appropriate workspace directory.
+4. Only after all codemods complete, proceed to resolve and pin (version bumps).
+
+## Fan-out
+
+For 3+ codemods, delegate each to a subagent running in parallel. The parent waits for all to complete. Each subagent receives: the package name, the codemod command, the workspace path, and returns: success/failure + stdout tail.
+
+## Examples
+
+If `next` is in the manifest at 16.2.6:
+- Look up available next codemods (`npx @next/codemod@latest --help`)
+- Run each relevant transform: `npx @next/codemod@latest <transform> apps/webview-ui`
+- Then bump next to latest
+
+If `tailwindcss` is in the manifest:
+- Run `npx @tailwindcss/upgrade` in each workspace that uses it.
+- Then bump tailwindcss to latest
+
+## Error handling
+
+- If a codemod fails, log the failure as a warning (the project may still work fine without it).
+- If a codemod command contains `<transform>` but no transforms are available, skip it.
+- If a codemod doesn't exist yet for the new version, skip and note it in the report.

--- a/.claude/skills/deps-updater/references/verify-fixes.md
+++ b/.claude/skills/deps-updater/references/verify-fixes.md
@@ -1,0 +1,31 @@
+# Verify
+
+Run the project's verification suite to confirm nothing broke. Communicate with the user in `{communication_language}`.
+
+## Detection
+
+Determine the project's commands. Heuristics:
+- **typecheck:** Look for `tsc --noEmit`, `tsc -b`, or a `typecheck` script in root `package.json`.
+- **lint:** Look for a `lint` script, `biome check`, `eslint`, or `ruff` invocation.
+- **build:** Look for a `build` script in root `package.json` (Turborepo).
+- **test:** Look for a `test` script, `vitest`, `cargo test`, or `pnpm test`.
+
+If `{workflow.test_command}`, `{workflow.typecheck_command}`, `{workflow.build_command}`, or `{workflow.lint_command}` are non-empty, use them instead of auto-detecting.
+
+## Order
+
+Run in this order (fail early):
+1. Typecheck — catches type incompatibilities from new API surfaces
+2. Lint — catches formatting/style regressions from codemods
+3. Build — catches compilation failures
+4. Test — catches runtime regressions
+
+For monorepos, run at root via the workspace command (`pnpm -r`, `turbo run`, `cargo test --workspace`).
+
+## On failure
+
+- Report which command failed and what the error was.
+- In **interactive** mode: ask the user whether to fix, roll back, or ignore.
+- In **headless** mode: set status to `"blocked"` and include the failure details.
+
+Offer to fix: if a typecheck or lint failure has an obvious automated fix (e.g. `biome check --apply`, `tsc --noEmit` issues from new types), run it and re-verify before reporting failure.

--- a/.claude/skills/deps-updater/scripts/discover-deps.py
+++ b/.claude/skills/deps-updater/scripts/discover-deps.py
@@ -95,6 +95,9 @@ def scan_js_deps(ws_dirs, root_dir, scope_packages, skip_packages):
                         continue
                     if name in skip_packages:
                         continue
+                    # Skip workspace-protocol deps (pnpm workspace references)
+                    if isinstance(ver, str) and ver.startswith("workspace:"):
+                        continue
                     clean_ver, ranged = resolve_version(ver)
                     if name in seen:
                         idx = seen[name]
@@ -130,15 +133,19 @@ def scan_rust_deps(root_dir, ws_paths, workspace_members, scope_packages, skip_p
 
         # Simple TOML parsing for dependencies section (avoids external deps)
         in_deps = False
+        char_offset = 0
         for line in text.splitlines():
             stripped = line.strip()
             if stripped.startswith("[dependencies]") or stripped.startswith("[dev-dependencies]"):
                 in_deps = True
+                char_offset += len(line) + 1
                 continue
             if stripped.startswith("[") and in_deps:
                 in_deps = False
+                char_offset += len(line) + 1
                 continue
             if not in_deps:
+                char_offset += len(line) + 1
                 continue
             # Parse lines like: package = "1.0.0" or package = { version = "1.0.0", ... }
             match = re.match(r'^(\w[\w-]*)\s*=\s*"([^"]+)"', stripped)
@@ -149,11 +156,17 @@ def scan_rust_deps(root_dir, ws_paths, workspace_members, scope_packages, skip_p
                 match = re.match(r'^(\w[\w-]*)\s*=\s*\{', stripped)
                 if match:
                     name = match.group(1)
+                    # Skip path/workspace/git deps (not external registry deps)
+                    if re.search(r'\b(path|git|workspace)\s*=', stripped):
+                        char_offset += len(line) + 1
+                        continue
                     # Find version in inline table
-                    ver_match = re.search(r'version\s*=\s*"([^"]+)"', text[cargo_file.read_text().index(line):cargo_file.read_text().index(line)+200])
+                    ver_match = re.search(r'version\s*=\s*"([^"]+)"', text[char_offset:char_offset+200])
                     ver = ver_match.group(1) if ver_match else "unknown"
                 else:
+                    char_offset += len(line) + 1
                     continue
+            char_offset += len(line) + 1
 
             if scope_packages and name not in scope_packages:
                 continue
@@ -246,12 +259,6 @@ def main():
             ws for dep in rust_deps for ws in dep["workspaces"]
         )),
     }
-
-    # Remove workspace field from individual dep entries — redundant with ws_paths
-    for dep in js_deps:
-        del dep["workspaces"]
-    for dep in rust_deps:
-        del dep["workspaces"]
 
     manifest = {
         "js_deps": js_deps,

--- a/.claude/skills/deps-updater/scripts/discover-deps.py
+++ b/.claude/skills/deps-updater/scripts/discover-deps.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""
+Prepass script for deps-updater: scans the workspace and emits a compact JSON
+manifest of all external dependencies. Run from the project root or pass
+paths via --workspace.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+EXCLUDE_DIRS = {"node_modules", ".next", "target", ".git", "dist", ".turbo", "build", "__pycache__", ".cache", ".pnpm-store"}
+
+def find_package_json_files(workspace_dirs):
+    for d in workspace_dirs:
+        for p in Path(d).rglob("package.json"):
+            parts = p.parts
+            if any(excl in parts for excl in EXCLUDE_DIRS):
+                continue
+            yield p
+
+
+def find_cargo_toml_files(workspace_dirs):
+    for d in workspace_dirs:
+        for p in Path(d).rglob("Cargo.toml"):
+            parts = p.parts
+            if any(excl in parts for excl in EXCLUDE_DIRS):
+                continue
+            yield p
+
+
+def read_json(path):
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def parse_workspace_paths(root_pkg):
+    """Resolve workspace directories from root package.json workspaces field."""
+    ws = root_pkg.get("workspaces", [])
+    if isinstance(ws, dict):
+        ws = ws.get("packages", [])
+    return list(ws)
+
+
+def matches_glob(name, patterns):
+    """Check if name matches any glob pattern."""
+    import fnmatch
+    return any(fnmatch.fnmatch(name, p) for p in patterns)
+
+
+def is_internal_dep(name, ws_paths, root_dir):
+    """Check if name matches any workspace path pattern."""
+    # Workspace paths can be like "packages/*" or "apps/*"
+    return matches_glob(name, ws_paths)
+
+
+def resolve_version(version_str):
+    """Strip range prefix and return the raw version and whether it was ranged."""
+    version_str = version_str.strip()
+    ranged = bool(re.match(r'^[\^~>=<]', version_str))
+    clean = re.sub(r'^[\^~>=<]', '', version_str).strip()
+    # Handle >=1.0.0 or similar
+    clean = re.sub(r'^=', '', clean).strip()
+    return clean, ranged
+
+
+def scan_js_deps(ws_dirs, root_dir, scope_packages, skip_packages):
+    deps = []
+    seen = {}
+
+    for pkg_file in find_package_json_files(ws_dirs):
+            data = read_json(pkg_file)
+            if not data:
+                continue
+            # Skip root workspace package if it only has workspaces field
+            if pkg_file.parent == root_dir and "workspaces" in data and not data.get("dependencies") and not data.get("devDependencies"):
+                continue
+
+            rel_dir = str(pkg_file.parent.relative_to(root_dir)) if root_dir in pkg_file.parent.parents else "."
+
+            for section in ("dependencies", "devDependencies"):
+                pkg_data = data.get(section, {})
+                for name, ver in pkg_data.items():
+                    if scope_packages and name not in scope_packages:
+                        continue
+                    if name in skip_packages:
+                        continue
+                    clean_ver, ranged = resolve_version(ver)
+                    if name in seen:
+                        idx = seen[name]
+                        if rel_dir not in deps[idx]["workspaces"]:
+                            deps[idx]["workspaces"].append(rel_dir)
+                    else:
+                        seen[name] = len(deps)
+                        deps.append({
+                            "name": name,
+                            "current": clean_ver,
+                            "ranged": ranged,
+                            "workspaces": [rel_dir],
+                        })
+    return deps
+
+
+def scan_rust_deps(root_dir, ws_paths, workspace_members, scope_packages, skip_packages):
+    deps = []
+    seen = {}
+
+    # Resolve workspace member paths
+    member_paths = []
+    for member in workspace_members:
+        member_paths.append(root_dir / member)
+
+    # If no members defined, use cargo workspace roots
+    if not member_paths:
+        member_paths = list(ws_paths)
+
+    for cargo_file in find_cargo_toml_files(member_paths):
+        text = cargo_file.read_text()
+        rel_dir = str(cargo_file.parent.relative_to(root_dir))
+
+        # Simple TOML parsing for dependencies section (avoids external deps)
+        in_deps = False
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("[dependencies]") or stripped.startswith("[dev-dependencies]"):
+                in_deps = True
+                continue
+            if stripped.startswith("[") and in_deps:
+                in_deps = False
+                continue
+            if not in_deps:
+                continue
+            # Parse lines like: package = "1.0.0" or package = { version = "1.0.0", ... }
+            match = re.match(r'^(\w[\w-]*)\s*=\s*"([^"]+)"', stripped)
+            if match:
+                name = match.group(1)
+                ver = match.group(2)
+            else:
+                match = re.match(r'^(\w[\w-]*)\s*=\s*\{', stripped)
+                if match:
+                    name = match.group(1)
+                    # Find version in inline table
+                    ver_match = re.search(r'version\s*=\s*"([^"]+)"', text[cargo_file.read_text().index(line):cargo_file.read_text().index(line)+200])
+                    ver = ver_match.group(1) if ver_match else "unknown"
+                else:
+                    continue
+
+            if scope_packages and name not in scope_packages:
+                continue
+            if name in skip_packages:
+                continue
+            clean_ver, ranged = resolve_version(ver)
+
+            if name in seen:
+                idx = seen[name]
+                if rel_dir not in deps[idx]["workspaces"]:
+                    deps[idx]["workspaces"].append(rel_dir)
+            else:
+                seen[name] = len(deps)
+                deps.append({
+                    "name": name,
+                    "current": clean_ver,
+                    "ranged": ranged,
+                    "workspaces": [rel_dir],
+                })
+    return deps
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Discover deps in workspace")
+    parser.add_argument("--workspace", "-w", action="append", default=[], help="Workspace dirs to scan")
+    parser.add_argument("--packages", "-p", action="append", default=[], help="Only include these packages")
+    parser.add_argument("--skip-packages", "-s", action="append", default=[], help="Skip these packages")
+    parser.add_argument("--root", default=".", help="Project root directory")
+    parser.add_argument("--output", "-o", help="Output file (default: stdout)")
+    args = parser.parse_args()
+
+    root_dir = Path(args.root).resolve()
+    scope_packages = set(args.packages) if args.packages else set()
+    skip_packages = set(args.skip_packages) if args.skip_packages else set()
+    explicit_workspaces = args.workspace if args.workspace else None
+
+    root_pkg_file = root_dir / "package.json"
+    root_pkg = read_json(root_pkg_file) if root_pkg_file.exists() else {}
+
+    ws_patterns = parse_workspace_paths(root_pkg) if root_pkg else []
+    if explicit_workspaces:
+        ws_dirs = [root_dir / w for w in explicit_workspaces]
+    else:
+        ws_dirs = []
+        for pattern in ws_patterns:
+            expanded = sorted(root_dir.glob(pattern))
+            ws_dirs.extend(expanded)
+        if not ws_dirs:
+            ws_dirs = [root_dir]
+
+    # Filter to dirs that actually exist
+    ws_dirs = [d for d in ws_dirs if d.exists()]
+
+    # Rust workspace members
+    root_cargo = root_dir / "Cargo.toml"
+    workspace_members = []
+    if root_cargo.exists():
+        text = root_cargo.read_text()
+        in_workspace = False
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped == "[workspace]":
+                in_workspace = True
+                continue
+            if stripped.startswith("[") and in_workspace:
+                in_workspace = False
+                continue
+            if in_workspace:
+                match = re.match(r'^members\s*=\s*\[(.+)\]', stripped)
+                if match:
+                    members_raw = match.group(1)
+                    for m in re.findall(r'"([^"]+)"', members_raw):
+                        workspace_members.append(m)
+
+    # Scan
+    js_deps = scan_js_deps(ws_dirs, root_dir, scope_packages, skip_packages)
+    rust_deps = scan_rust_deps(
+        root_dir,
+        ws_dirs,
+        [root_dir / m for m in workspace_members],
+        scope_packages,
+        skip_packages,
+    )
+
+    ws_paths = {
+        "js": sorted(set(
+            ws for dep in js_deps for ws in dep["workspaces"]
+        )),
+        "rust": sorted(set(
+            ws for dep in rust_deps for ws in dep["workspaces"]
+        )),
+    }
+
+    # Remove workspace field from individual dep entries — redundant with ws_paths
+    for dep in js_deps:
+        del dep["workspaces"]
+    for dep in rust_deps:
+        del dep["workspaces"]
+
+    manifest = {
+        "js_deps": js_deps,
+        "rust_deps": rust_deps,
+        "workspace_paths": ws_paths,
+        "scope_filters": {
+            "packages": sorted(scope_packages),
+            "skip_packages": sorted(skip_packages),
+        },
+    }
+
+    output = json.dumps(manifest, indent=2)
+    if args.output:
+        Path(args.output).write_text(output)
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/deps-updater/scripts/tests/test-discover-deps.py
+++ b/.claude/skills/deps-updater/scripts/tests/test-discover-deps.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Tests for discover-deps.py."""
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parent.parent / "discover-deps.py"
+
+
+def test_script_exists():
+    assert SCRIPT.exists(), f"Script not found: {SCRIPT}"
+
+
+def test_parseable():
+    result = subprocess.run(
+        [sys.executable, "-c", f"import py_compile; py_compile.compile('{SCRIPT}', doraise=True)"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"Parse error: {result.stderr}"
+
+
+def test_help():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "--workspace" in result.stdout
+
+
+def test_empty_project():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "package.json").write_text('{"name":"test","private":true}')
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(tmp)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["js_deps"] == []
+        assert data["rust_deps"] == []
+
+
+def test_single_js_dep():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "package.json").write_text('{"name":"test","dependencies":{"left-pad":"1.3.0"}}')
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(tmp)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert len(data["js_deps"]) == 1
+        assert data["js_deps"][0]["name"] == "left-pad"
+        assert data["js_deps"][0]["current"] == "1.3.0"
+
+
+def test_skip_packages():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "package.json").write_text('{"name":"test","dependencies":{"foo":"1.0.0","bar":"2.0.0"}}')
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(tmp), "--skip-packages", "bar"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert len(data["js_deps"]) == 1
+        assert data["js_deps"][0]["name"] == "foo"
+
+
+def test_output_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "package.json").write_text('{"name":"test","private":true}')
+        out_file = tmp / "manifest.json"
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(tmp), "--output", str(out_file)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert out_file.exists()
+        data = json.loads(out_file.read_text())
+        assert "js_deps" in data
+
+
+if __name__ == "__main__":
+    test_script_exists()
+    test_parseable()
+    test_help()
+    test_empty_project()
+    test_single_js_dep()
+    test_skip_packages()
+    test_output_file()
+    print("All tests passed.")
+    sys.exit(0)

--- a/.claude/skills/deps-updater/scripts/tests/test-discover-deps.py
+++ b/.claude/skills/deps-updater/scripts/tests/test-discover-deps.py
@@ -94,6 +94,61 @@ def test_output_file():
         assert "js_deps" in data
 
 
+def test_rust_dep_extraction():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "package.json").write_text('{"name":"test","private":true}')
+        (tmp / "Cargo.toml").write_text(
+            '[package]\nname = "test"\n[workspace]\n[dependencies]\nserde = "1.0"\ntokio = { version = "1.35", features = ["full"] }\n')
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(tmp)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        dep_names = {d["name"] for d in data["rust_deps"]}
+        assert "serde" in dep_names, f"serde not found in {dep_names}"
+        assert "tokio" in dep_names, f"tokio not found in {dep_names}"
+
+
+def test_exclude_workspace_deps():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "package.json").write_text(
+            '{"name":"test","dependencies":{"left-pad":"1.3.0","@myapp/ui":"workspace:*","@myapp/utils":"workspace:^1.0.0"}}'
+        )
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(tmp)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        dep_names = {d["name"] for d in data["js_deps"]}
+        assert "left-pad" in dep_names, "external dep should be included"
+        assert "@myapp/ui" not in dep_names, "workspace:* dep should be excluded"
+        assert "@myapp/utils" not in dep_names, "workspace:^ dep should be excluded"
+
+
+def test_per_dep_workspace_paths():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "package.json").write_text('{"name":"test","workspaces":["packages/*"],"private":true}')
+        pkg_dir = tmp / "packages" / "a"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "package.json").write_text('{"name":"pkg-a","dependencies":{"left-pad":"1.3.0"}}')
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(tmp)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert len(data["js_deps"]) == 1
+        dep = data["js_deps"][0]
+        assert dep["name"] == "left-pad"
+        assert "workspaces" in dep, "per-dep workspaces field must be preserved"
+        assert "packages/a" in dep["workspaces"], f"expected packages/a in {dep['workspaces']}"
+
+
 if __name__ == "__main__":
     test_script_exists()
     test_parseable()
@@ -102,5 +157,8 @@ if __name__ == "__main__":
     test_single_js_dep()
     test_skip_packages()
     test_output_file()
+    test_rust_dep_extraction()
+    test_exclude_workspace_deps()
+    test_per_dep_workspace_paths()
     print("All tests passed.")
     sys.exit(0)


### PR DESCRIPTION
## Changes

Fixes identified during the first real run of the deps-updater skill:

### Stage ordering (SKILL.md)
- Codemods now run **before** version bumps, not after

### run-codemods.md
- Codemods run pre-bump for **any** version change (patch, minor, major)
- Input comes from the discovered manifest (current versions), not the diff

### resolve-and-pin.md
- `--save-exact` → `--removeRange` (ncu v22+ compat)
- Added residual range cleanup step (un-updated packages retain ^/~)
- `cargo upgrade --workspace` → `cargo upgrade` per directory
- Added `pnpm install --no-frozen-lockfile` post-update step

### detect-breaking.md
- Added known breaking-change catalog with sqlx 0.8→0.9 (`SqlSafeStr` → `AssertSqlSafe`), react 18→19, tailwindcss 3→4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a `deps-updater` workflow to discover, resolve, and pin dependency updates across JavaScript and Rust, with breaking-change detection and optional per-change approvals.
  * Added headless reporting with machine-readable JSON output and rollback guidance when verification fails.
  * Included scope controls to target workspace/package subsets and skip selected packages.

* **Documentation**
  * Added/expanded guides for dependency discovery, version resolution, codemods, breaking-change research, verification, and reporting, plus workflow customization settings.

* **Tests**
  * Added integration tests covering dependency discovery output, filtering, and workspace-path preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->