### PR TITLE
feat: make release health period optional with UI period selector

### DIFF
--- a/apps/server/src/routes/sessions.rs
+++ b/apps/server/src/routes/sessions.rs
@@ -19,9 +19,8 @@ pub struct StatsQuery {
 }
 
 impl StatsQuery {
-    pub fn period_hours(&self) -> i64 {
-        let parsed = self
-            .period
+    pub fn period_hours(&self) -> Option<i64> {
+        self.period
             .as_deref()
             .and_then(|p| {
                 // Accept "24h", "48h", "7d", or bare integers (treated as hours).
@@ -33,9 +32,8 @@ impl StatsQuery {
                     p.parse::<i64>().ok()
                 }
             })
-            .unwrap_or(24);
-        // Clamp to 1 hour – 90 days to prevent negative intervals and table scans
-        parsed.clamp(1, 90 * 24)
+            // Clamp to 1 hour – 90 days to prevent negative intervals and table scans
+            .map(|h| h.clamp(1, 90 * 24))
     }
 }
 

--- a/apps/server/src/services/session.rs
+++ b/apps/server/src/services/session.rs
@@ -8,11 +8,12 @@ type PgHealthRow = (String, String, i64, i64, i64, i64, Option<f64>, Option<f64>
 pub struct SessionService;
 
 impl SessionService {
-    /// Query per-release health stats for a project over the given period (hours).
+    /// Query per-release health stats for a project.
+    /// If `period_hours` is `None`, all data is returned (no time filter).
     pub async fn release_health(
         pool: &DbPool,
         project_id: i32,
-        period_hours: i64,
+        period_hours: Option<i64>,
     ) -> AppResult<Vec<ReleaseHealthRow>> {
         let rows = query_release_health(pool, project_id, period_hours).await?;
         Ok(rows)
@@ -22,11 +23,20 @@ impl SessionService {
 async fn query_release_health(
     pool: &DbPool,
     project_id: i32,
-    period_hours: i64,
+    period_hours: Option<i64>,
 ) -> Result<Vec<ReleaseHealthRow>, sqlx::Error> {
     #[cfg(feature = "postgres")]
     {
-        let rows: Vec<PgHealthRow> = sqlx::query_as(
+        let (time_filter_sc, time_filter_su) = if let Some(hours) = period_hours {
+            (
+                format!("AND sc.bucket >= NOW() - '{} hours'::interval", hours),
+                format!("AND su.day >= (NOW() - '{} hours'::interval)::date", hours),
+            )
+        } else {
+            (String::new(), String::new())
+        };
+
+        let sql = format!(
             r#"
                 SELECT
                     sc.release,
@@ -47,17 +57,19 @@ async fn query_release_health(
                     ON su.project_id = sc.project_id
                    AND su.release    = sc.release
                    AND su.environment = sc.environment
-                   AND su.day >= (NOW() - ($2::text || ' hours')::interval)::date
+                   {}
                 WHERE sc.project_id = $1
-                  AND sc.bucket >= NOW() - ($2::text || ' hours')::interval
+                  {}
                 GROUP BY sc.release, sc.environment
                 ORDER BY SUM(sc.total) DESC
                 "#,
-        )
-        .bind(project_id)
-        .bind(period_hours)
-        .fetch_all(pool)
-        .await?;
+            time_filter_su, time_filter_sc
+        );
+
+        let rows: Vec<PgHealthRow> = sqlx::query_as(sqlx::AssertSqlSafe(&*sql))
+            .bind(project_id)
+            .fetch_all(pool)
+            .await?;
 
         Ok(rows
             .into_iter()
@@ -82,8 +94,22 @@ async fn query_release_health(
 
     #[cfg(not(feature = "postgres"))]
     {
-        // SQLite: datetime arithmetic via strftime
-        let rows: Vec<(String, String, i64, i64, i64, i64)> = sqlx::query_as(
+        let time_filter_sc = if let Some(hours) = period_hours {
+            format!(
+                "AND bucket >= datetime('now', '-' || '{}' || ' hours')",
+                hours
+            )
+        } else {
+            String::new()
+        };
+
+        let time_filter_su = if let Some(hours) = period_hours {
+            format!("AND day >= date('now', '-' || '{}' || ' hours')", hours)
+        } else {
+            String::new()
+        };
+
+        let sql = format!(
             r#"
             SELECT
                 release,
@@ -94,20 +120,22 @@ async fn query_release_health(
                 SUM(abnormal) AS abnormal
             FROM session_counts
             WHERE project_id = ?1
-              AND bucket >= datetime('now', '-' || ?2 || ' hours')
+              {}
             GROUP BY release, environment
             ORDER BY SUM(total) DESC
             "#,
-        )
-        .bind(project_id)
-        .bind(period_hours)
-        .fetch_all(pool)
-        .await?;
+            time_filter_sc
+        );
+
+        let rows: Vec<(String, String, i64, i64, i64, i64)> =
+            sqlx::query_as(sqlx::AssertSqlSafe(&*sql))
+                .bind(project_id)
+                .fetch_all(pool)
+                .await?;
 
         let mut result = Vec::with_capacity(rows.len());
         for (release, environment, total, errored, crashed, abnormal) in rows {
-            // For crash-free-users we need a second query per release in SQLite
-            let (total_users, crashed_users): (i64, i64) = sqlx::query_as(
+            let user_sql = format!(
                 r#"
                 SELECT
                     COUNT(DISTINCT did),
@@ -116,15 +144,18 @@ async fn query_release_health(
                 WHERE project_id = ?1
                   AND release = ?2
                   AND environment = ?3
-                  AND day >= date('now', '-' || ?4 || ' hours')
+                  {}
                 "#,
-            )
-            .bind(project_id)
-            .bind(&release)
-            .bind(&environment)
-            .bind(period_hours)
-            .fetch_one(pool)
-            .await?;
+                time_filter_su
+            );
+
+            let (total_users, crashed_users): (i64, i64) =
+                sqlx::query_as(sqlx::AssertSqlSafe(&*user_sql))
+                    .bind(project_id)
+                    .bind(&release)
+                    .bind(&environment)
+                    .fetch_one(pool)
+                    .await?;
 
             let crash_free_sessions_rate = if total > 0 {
                 Some(1.0 - crashed as f64 / total as f64)

--- a/apps/server/tests/integration/sessions_api_test.rs
+++ b/apps/server/tests/integration/sessions_api_test.rs
@@ -137,7 +137,7 @@ async fn test_release_health_empty_returns_empty() {
     let db = TestDb::new().await;
     let project_id = create_project(&db.pool, "Empty Project").await;
 
-    let rows = SessionService::release_health(&db.pool, project_id, 24)
+    let rows = SessionService::release_health(&db.pool, project_id, Some(24))
         .await
         .expect("query failed");
 
@@ -165,7 +165,7 @@ async fn test_release_health_sums_across_buckets() {
     )
     .await;
 
-    let rows = SessionService::release_health(&db.pool, project_id, 24)
+    let rows = SessionService::release_health(&db.pool, project_id, Some(24))
         .await
         .expect("query failed");
 
@@ -187,7 +187,7 @@ async fn test_release_health_healthy_is_total_minus_unhealthy() {
     // total=100, errored=5, crashed=3, abnormal=2 → healthy=90
     seed_count(&db.pool, project_id, "2.0.0", "staging", 1, 100, 5, 3, 2).await;
 
-    let rows = SessionService::release_health(&db.pool, project_id, 24)
+    let rows = SessionService::release_health(&db.pool, project_id, Some(24))
         .await
         .expect("query failed");
 
@@ -216,12 +216,47 @@ async fn test_release_health_excludes_buckets_outside_window() {
     )
     .await;
 
-    let rows = SessionService::release_health(&db.pool, project_id, 24)
+    let rows = SessionService::release_health(&db.pool, project_id, Some(24))
         .await
         .expect("query failed");
 
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].total, 50, "old bucket must not contribute to total");
+}
+
+#[actix_web::test]
+async fn test_release_health_no_period_returns_all_buckets() {
+    let db = TestDb::new().await;
+    let project_id = create_project(&db.pool, "No Period Project").await;
+
+    // 1h ago
+    seed_count(&db.pool, project_id, "4.0.0", "production", 1, 10, 0, 0, 0).await;
+    // 48h ago
+    seed_count(&db.pool, project_id, "4.0.0", "production", 48, 20, 0, 0, 0).await;
+    // 240h ago (10 days)
+    seed_count(
+        &db.pool,
+        project_id,
+        "4.0.0",
+        "production",
+        240,
+        30,
+        0,
+        0,
+        0,
+    )
+    .await;
+
+    // No period filter → all buckets should be included
+    let rows = SessionService::release_health(&db.pool, project_id, None)
+        .await
+        .expect("query failed");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].total, 60,
+        "all buckets must contribute when no period is set"
+    );
 }
 
 #[actix_web::test]
@@ -233,7 +268,7 @@ async fn test_release_health_excludes_other_projects() {
     seed_count(&db.pool, project_a, "1.0.0", "prod", 1, 10, 0, 0, 0).await;
     seed_count(&db.pool, project_b, "1.0.0", "prod", 1, 999, 0, 0, 0).await;
 
-    let rows = SessionService::release_health(&db.pool, project_a, 24)
+    let rows = SessionService::release_health(&db.pool, project_a, Some(24))
         .await
         .expect("query failed");
 
@@ -253,7 +288,7 @@ async fn test_release_health_orders_by_total_desc() {
     seed_count(&db.pool, project_id, "large", "prod", 1, 500, 0, 0, 0).await;
     seed_count(&db.pool, project_id, "medium", "prod", 1, 100, 0, 0, 0).await;
 
-    let rows = SessionService::release_health(&db.pool, project_id, 24)
+    let rows = SessionService::release_health(&db.pool, project_id, Some(24))
         .await
         .expect("query failed");
 
@@ -271,7 +306,7 @@ async fn test_release_health_crash_free_sessions_rate() {
     // 100 total, 10 crashed → crash_free_sessions_rate = 0.90
     seed_count(&db.pool, project_id, "1.0.0", "prod", 1, 100, 0, 10, 0).await;
 
-    let rows = SessionService::release_health(&db.pool, project_id, 24)
+    let rows = SessionService::release_health(&db.pool, project_id, Some(24))
         .await
         .expect("query failed");
 
@@ -290,7 +325,7 @@ async fn test_release_health_crash_free_sessions_rate_is_none_when_no_sessions()
     // 0 total → rate must be None (CASE WHEN total > 0)
     seed_count(&db.pool, project_id, "1.0.0", "prod", 1, 0, 0, 0, 0).await;
 
-    let rows = SessionService::release_health(&db.pool, project_id, 24)
+    let rows = SessionService::release_health(&db.pool, project_id, Some(24))
         .await
         .expect("query failed");
 
@@ -319,7 +354,7 @@ async fn test_release_health_crash_free_users_rate() {
     seed_user(&db.pool, project_id, "1.0.0", "prod", "user-3", true).await;
     seed_user(&db.pool, project_id, "1.0.0", "prod", "user-4", true).await;
 
-    let rows = SessionService::release_health(&db.pool, project_id, 24)
+    let rows = SessionService::release_health(&db.pool, project_id, Some(24))
         .await
         .expect("query failed");
 
@@ -338,7 +373,7 @@ async fn test_release_health_multiple_releases_independent() {
     seed_count(&db.pool, project_id, "1.0.0", "prod", 1, 100, 5, 10, 2).await;
     seed_count(&db.pool, project_id, "2.0.0", "prod", 1, 50, 1, 0, 0).await;
 
-    let rows = SessionService::release_health(&db.pool, project_id, 24)
+    let rows = SessionService::release_health(&db.pool, project_id, Some(24))
         .await
         .expect("query failed");
 

--- a/apps/webview-ui/src/app/(main)/projects/[id]/project-header.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/project-header.tsx
@@ -52,7 +52,10 @@ export function ProjectHeader({
           </p>
         </div>
 
-        <ReleaseHealthSheet health={releaseHealth} />
+        <ReleaseHealthSheet
+          projectId={project.id}
+          initialHealth={releaseHealth}
+        />
         <ProjectAlertsDialog
           project={project}
           alertRules={alertRules}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/release-health-sheet.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/release-health-sheet.tsx
@@ -2,6 +2,8 @@
 
 import type { ReleaseHealth } from '@rustrak/client';
 import { Activity } from 'lucide-react';
+import { useCallback, useState, useTransition } from 'react';
+import { getReleaseHealth } from '@/actions/sessions';
 import { Button } from '@/components/ui/button';
 import {
   Sheet,
@@ -12,8 +14,17 @@ import {
 } from '@/components/ui/sheet';
 
 interface ReleaseHealthSheetProps {
-  health: ReleaseHealth;
+  projectId: number;
+  initialHealth: ReleaseHealth;
 }
+
+const PERIODS = [
+  { label: 'All', value: undefined as string | undefined },
+  { label: '24h', value: '24h' as const },
+  { label: '7d', value: '7d' as const },
+  { label: '14d', value: '14d' as const },
+  { label: '30d', value: '30d' as const },
+] as const;
 
 function pct(rate: number | null): string {
   if (rate === null) return '—';
@@ -27,8 +38,24 @@ function crashFreeClass(rate: number | null): string {
   return 'text-red-600 dark:text-red-400';
 }
 
-export function ReleaseHealthSheet({ health }: ReleaseHealthSheetProps) {
-  if (health.length === 0) return null;
+export function ReleaseHealthSheet({
+  projectId,
+  initialHealth,
+}: ReleaseHealthSheetProps) {
+  const [health, setHealth] = useState(initialHealth);
+  const [period, setPeriod] = useState<string | undefined>(undefined);
+  const [isPending, startTransition] = useTransition();
+
+  const handlePeriodChange = useCallback(
+    (newPeriod: string | undefined) => {
+      setPeriod(newPeriod);
+      startTransition(async () => {
+        const data = await getReleaseHealth(projectId, newPeriod);
+        setHealth(data);
+      });
+    },
+    [projectId],
+  );
 
   return (
     <Sheet>
@@ -46,56 +73,85 @@ export function ReleaseHealthSheet({ health }: ReleaseHealthSheetProps) {
           <SheetTitle>Release Health</SheetTitle>
         </SheetHeader>
 
-        <div className="flex-1 overflow-y-auto px-4 pb-4 space-y-2">
-          <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground mb-3">
-            Releases
-          </p>
-          {health.map((row) => (
-            <div
-              key={`${row.release}-${row.environment}`}
-              className="rounded-lg border bg-card p-3 space-y-2"
+        <div className="flex gap-1 px-4 py-2 border-b shrink-0">
+          {PERIODS.map((p) => (
+            <button
+              key={p.label}
+              onClick={() => handlePeriodChange(p.value)}
+              disabled={isPending}
+              className={`px-2 py-1 text-xs rounded-md font-medium transition-colors ${
+                period === p.value
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80'
+              }`}
             >
-              <div className="flex items-center justify-between gap-2">
-                <p className="font-mono text-xs truncate text-foreground">
-                  {row.release}
-                </p>
-                <span className="text-[10px] font-medium text-muted-foreground bg-muted rounded px-1.5 py-0.5 shrink-0">
-                  {row.environment}
-                </span>
-              </div>
-              <div className="grid grid-cols-4 gap-2">
-                <div>
-                  <p className="text-[10px] text-muted-foreground">Sessions</p>
-                  <p className="text-sm font-semibold">{row.total}</p>
-                </div>
-                <div>
-                  <p className="text-[10px] text-muted-foreground">
-                    Crash-free
-                  </p>
-                  <p
-                    className={`text-sm font-semibold ${crashFreeClass(row.crash_free_sessions_rate)}`}
-                  >
-                    {pct(row.crash_free_sessions_rate)}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-[10px] text-muted-foreground">Users</p>
-                  <p className="text-sm font-semibold">
-                    {pct(row.crash_free_users_rate)}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-[10px] text-muted-foreground">Crashed</p>
-                  <p
-                    className={`text-sm font-semibold ${row.crashed > 0 ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground'}`}
-                  >
-                    {row.crashed > 0 ? row.crashed : '—'}
-                  </p>
-                </div>
-              </div>
-            </div>
+              {p.label}
+            </button>
           ))}
         </div>
+
+        {health.length === 0 ? (
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-sm text-muted-foreground">
+              {isPending
+                ? 'Loading...'
+                : 'No release health data for this period'}
+            </p>
+          </div>
+        ) : (
+          <div className="flex-1 overflow-y-auto px-4 pb-4 space-y-2 pt-3">
+            <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground mb-3">
+              Releases
+            </p>
+            {health.map((row) => (
+              <div
+                key={`${row.release}-${row.environment}`}
+                className="rounded-lg border bg-card p-3 space-y-2"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <p className="font-mono text-xs truncate text-foreground">
+                    {row.release}
+                  </p>
+                  <span className="text-[10px] font-medium text-muted-foreground bg-muted rounded px-1.5 py-0.5 shrink-0">
+                    {row.environment}
+                  </span>
+                </div>
+                <div className="grid grid-cols-4 gap-2">
+                  <div>
+                    <p className="text-[10px] text-muted-foreground">
+                      Sessions
+                    </p>
+                    <p className="text-sm font-semibold">{row.total}</p>
+                  </div>
+                  <div>
+                    <p className="text-[10px] text-muted-foreground">
+                      Crash-free
+                    </p>
+                    <p
+                      className={`text-sm font-semibold ${crashFreeClass(row.crash_free_sessions_rate)}`}
+                    >
+                      {pct(row.crash_free_sessions_rate)}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-[10px] text-muted-foreground">Users</p>
+                    <p className="text-sm font-semibold">
+                      {pct(row.crash_free_users_rate)}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-[10px] text-muted-foreground">Crashed</p>
+                    <p
+                      className={`text-sm font-semibold ${row.crashed > 0 ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground'}`}
+                    >
+                      {row.crashed > 0 ? row.crashed : '—'}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/apps/webview-ui/src/app/(main)/projects/[id]/release-health-sheet.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/release-health-sheet.tsx
@@ -2,7 +2,7 @@
 
 import type { ReleaseHealth } from '@rustrak/client';
 import { Activity } from 'lucide-react';
-import { useCallback, useState, useTransition } from 'react';
+import { useCallback, useRef, useState, useTransition } from 'react';
 import { getReleaseHealth } from '@/actions/sessions';
 import { Button } from '@/components/ui/button';
 import {
@@ -45,13 +45,17 @@ export function ReleaseHealthSheet({
   const [health, setHealth] = useState(initialHealth);
   const [period, setPeriod] = useState<string | undefined>(undefined);
   const [isPending, startTransition] = useTransition();
+  const latestPeriod = useRef<string | undefined>(undefined);
 
   const handlePeriodChange = useCallback(
     (newPeriod: string | undefined) => {
+      latestPeriod.current = newPeriod;
       setPeriod(newPeriod);
       startTransition(async () => {
         const data = await getReleaseHealth(projectId, newPeriod);
-        setHealth(data);
+        if (latestPeriod.current === newPeriod) {
+          setHealth(data);
+        }
       });
     },
     [projectId],
@@ -99,7 +103,9 @@ export function ReleaseHealthSheet({
             </p>
           </div>
         ) : (
-          <div className="flex-1 overflow-y-auto px-4 pb-4 space-y-2 pt-3">
+          <div
+            className={`flex-1 overflow-y-auto px-4 pb-4 space-y-2 pt-3 transition-opacity ${isPending ? 'opacity-50 pointer-events-none' : ''}`}
+          >
             <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground mb-3">
               Releases
             </p>


### PR DESCRIPTION
**Cambios:**

- **Servidor**: `period_hours` ahora es `Option<i64>` — si es `None`, no filtra por tiempo (devuelve todo el histórico)
- **SQL dinámico**: se construye con `format!` + `AssertSqlSafe`, sin cláusula de tiempo cuando no hay periodo
- **Frontend**: selector de periodo en el sheet (All, 24h, 7d, 14d, 30d) que refetch data vía server action
- **Tests**: nuevo test `test_release_health_no_period_returns_all_buckets` + actualizados a `Option<i64>`
- `openapi.json` sin cambios (el schema de query params no varió)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added period selector to release health view, allowing users to filter health metrics by time window (1 hour–90 days) or view all data without time filtering.
  * Dynamic data fetching now updates health metrics when users change the selected period.

* **Bug Fixes**
  * Improved handling of optional time-period parameters in health metric queries.

* **Tests**
  * Added test coverage for period-less health data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->