### PR TITLE
feat(client,mcp): wire transactions API into client and MCP

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -14,6 +14,7 @@ import {
   SourceMapsResource,
   TeamResource,
   TokensResource,
+  TransactionsResource,
 } from './resources/index.js';
 import { createKyInstance } from './utils/index.js';
 
@@ -101,6 +102,11 @@ export class RustrakClient {
   public readonly sessions: SessionsResource;
 
   /**
+   * Transactions API resource (performance monitoring)
+   */
+  public readonly transactions: TransactionsResource;
+
+  /**
    * Health API resource (version info)
    */
   public readonly health: HealthResource;
@@ -126,6 +132,7 @@ export class RustrakClient {
     this.invitations = new InvitationsResource(this.http);
     this.members = new MembersResource(this.http);
     this.sessions = new SessionsResource(this.http);
+    this.transactions = new TransactionsResource(this.http);
     this.health = new HealthResource(this.http);
   }
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -61,6 +61,7 @@ export type {
   ListIssuesOptions,
   ListProjectsOptions,
   ListSourceMapsResponse,
+  ListTransactionsOptions,
   LoginRequest,
   LoginResult,
   /** @deprecated Use AlertIntegration */
@@ -81,6 +82,7 @@ export type {
   TeamMember,
   TestChannelResponse,
   TestIntegrationBody,
+  Transaction,
   UpdateAlertIntegration,
   UpdateAlertRule,
   UpdateIssueState,

--- a/packages/client/src/resources/index.ts
+++ b/packages/client/src/resources/index.ts
@@ -12,3 +12,4 @@ export { SessionsResource } from './sessions.js';
 export { SourceMapsResource } from './sourcemaps.js';
 export { TeamResource } from './team.js';
 export { TokensResource } from './tokens.js';
+export { TransactionsResource } from './transactions.js';

--- a/packages/client/src/resources/transactions.ts
+++ b/packages/client/src/resources/transactions.ts
@@ -1,0 +1,37 @@
+import {
+  paginatedResponseSchema,
+  transactionSchema,
+} from '../schemas/index.js';
+import type {
+  ListTransactionsOptions,
+  PaginatedResponse,
+  Transaction,
+} from '../types/index.js';
+import { BaseResource } from './base.js';
+
+/**
+ * Transactions API resource
+ */
+export class TransactionsResource extends BaseResource {
+  /**
+   * List transactions for a project with cursor-based pagination (newest first)
+   */
+  async list(
+    projectId: number,
+    options?: ListTransactionsOptions,
+  ): Promise<PaginatedResponse<Transaction>> {
+    const searchParams: Record<string, string> = {};
+
+    if (options?.cursor) {
+      searchParams.cursor = options.cursor;
+    }
+
+    const data = await this.http
+      .get(`api/projects/${projectId}/transactions`, {
+        searchParams,
+      })
+      .json();
+
+    return this.validate(data, paginatedResponseSchema(transactionSchema));
+  }
+}

--- a/packages/client/src/schemas/event.ts
+++ b/packages/client/src/schemas/event.ts
@@ -7,13 +7,14 @@ import { dateTimeSchema, uuidSchema } from './common.js';
 export const eventSchema = z.object({
   id: uuidSchema,
   event_id: uuidSchema,
-  issue_id: uuidSchema,
+  issue_id: uuidSchema.nullable(),
   title: z.string(),
   timestamp: dateTimeSchema,
   level: z.string(),
   platform: z.string(),
   release: z.string(),
   environment: z.string(),
+  event_type: z.string(),
 });
 
 /**
@@ -22,7 +23,7 @@ export const eventSchema = z.object({
 export const eventDetailSchema = z.object({
   id: uuidSchema,
   event_id: uuidSchema,
-  issue_id: uuidSchema,
+  issue_id: uuidSchema.nullable(),
   title: z.string(),
   timestamp: dateTimeSchema,
   ingested_at: dateTimeSchema,
@@ -33,5 +34,6 @@ export const eventDetailSchema = z.object({
   server_name: z.string(),
   sdk_name: z.string(),
   sdk_version: z.string(),
+  event_type: z.string(),
   data: z.record(z.string(), z.any()), // Full Sentry event JSON
 });

--- a/packages/client/src/schemas/index.ts
+++ b/packages/client/src/schemas/index.ts
@@ -9,4 +9,5 @@ export * from './session.js';
 export * from './sourcemap.js';
 export * from './team.js';
 export * from './token.js';
+export * from './transaction.js';
 export * from './user.js';

--- a/packages/client/src/schemas/transaction.ts
+++ b/packages/client/src/schemas/transaction.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { dateTimeSchema, uuidSchema } from './common.js';
+
+/**
+ * Transaction response schema from list endpoint
+ */
+export const transactionSchema = z.object({
+  id: uuidSchema,
+  event_id: uuidSchema,
+  transaction_name: z.string(),
+  timestamp: dateTimeSchema,
+  start_timestamp: dateTimeSchema.nullable(),
+  duration_ms: z.number().nullable(),
+  platform: z.string(),
+  environment: z.string(),
+  release: z.string(),
+  ingested_at: dateTimeSchema,
+});

--- a/packages/client/src/types/common.ts
+++ b/packages/client/src/types/common.ts
@@ -73,3 +73,10 @@ export interface ListProjectsOptions {
   per_page?: number;
   order?: SortOrder;
 }
+
+/**
+ * List options for transactions endpoint (cursor-based pagination)
+ */
+export interface ListTransactionsOptions {
+  cursor?: string;
+}

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -10,4 +10,5 @@ export * from './session.js';
 export * from './sourcemap.js';
 export * from './team.js';
 export * from './token.js';
+export * from './transaction.js';
 export * from './user.js';

--- a/packages/client/src/types/transaction.ts
+++ b/packages/client/src/types/transaction.ts
@@ -1,0 +1,7 @@
+import type { z } from 'zod';
+import type { transactionSchema } from '../schemas/transaction.js';
+
+/**
+ * Transaction type inferred from Zod schema
+ */
+export type Transaction = z.infer<typeof transactionSchema>;

--- a/packages/client/tests/integration/pagination.test.ts
+++ b/packages/client/tests/integration/pagination.test.ts
@@ -220,6 +220,7 @@ describe('Pagination', () => {
                     platform: 'javascript',
                     release: '1.0.0',
                     environment: 'production',
+                    event_type: 'error',
                   },
                 ],
                 next_cursor: 'next',

--- a/packages/client/tests/integration/transactions.test.ts
+++ b/packages/client/tests/integration/transactions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { RustrakClient } from '../../src/index.js';
+
+const client = new RustrakClient({
+  baseUrl: 'http://localhost:8080',
+  token: 'test-token',
+});
+
+describe('TransactionsResource', () => {
+  describe('list()', () => {
+    it('returns paginated transaction list', async () => {
+      const result = await client.transactions.list(1);
+
+      expect(result.has_more).toBe(false);
+      expect(result.items).toHaveLength(1);
+    });
+
+    it('returns transaction with correct shape', async () => {
+      const result = await client.transactions.list(1);
+      const txn = result.items[0];
+
+      expect(txn.id).toBe('a1b2c3d4-e89b-12d3-a456-426614174000');
+      expect(txn.transaction_name).toBe('/api/checkout');
+      expect(txn.platform).toBe('javascript');
+      expect(txn.environment).toBe('production');
+      expect(txn.release).toBe('1.0.0');
+      expect(txn.duration_ms).toBe(1000.0);
+      expect(txn.start_timestamp).toBe('2026-06-18T11:59:59.000Z');
+    });
+
+    it('accepts cursor option', async () => {
+      const result = await client.transactions.list(1, {
+        cursor: 'some-cursor',
+      });
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/packages/client/tests/mocks/handlers.ts
+++ b/packages/client/tests/mocks/handlers.ts
@@ -70,6 +70,7 @@ export const mockEvents = [
     platform: 'javascript',
     release: '1.0.0',
     environment: 'production',
+    event_type: 'error',
   },
 ];
 
@@ -87,6 +88,7 @@ export const mockEventDetail = {
   server_name: 'web-1',
   sdk_name: '@sentry/browser',
   sdk_version: '7.0.0',
+  event_type: 'error',
   data: {
     exception: {
       values: [
@@ -1137,6 +1139,30 @@ export const handlers = [
       ]);
     },
   ),
+
+  // Transactions — list transactions for project
+  http.get(`${BASE_URL}/api/projects/:projectId/transactions`, ({ params }) => {
+    if (params.projectId === '999') {
+      return HttpResponse.json({ error: 'not found' }, { status: 404 });
+    }
+    return HttpResponse.json({
+      items: [
+        {
+          id: 'a1b2c3d4-e89b-12d3-a456-426614174000',
+          event_id: 'b2c3d4e5-e89b-12d3-a456-426614174000',
+          transaction_name: '/api/checkout',
+          timestamp: '2026-06-18T12:00:00.000Z',
+          start_timestamp: '2026-06-18T11:59:59.000Z',
+          duration_ms: 1000.0,
+          platform: 'javascript',
+          environment: 'production',
+          release: '1.0.0',
+          ingested_at: '2026-06-18T12:00:01.000Z',
+        },
+      ],
+      has_more: false,
+    });
+  }),
 
   // Source Maps — list source maps for project
   http.get(

--- a/packages/client/tests/unit/schemas.test.ts
+++ b/packages/client/tests/unit/schemas.test.ts
@@ -161,6 +161,7 @@ describe('Schema Validation', () => {
         server_name: 'web-1',
         sdk_name: '@sentry/browser',
         sdk_version: '7.0.0',
+        event_type: 'error',
         data: {
           exception: {
             values: [
@@ -199,6 +200,7 @@ describe('Schema Validation', () => {
         server_name: 'web-1',
         sdk_name: '@sentry/browser',
         sdk_version: '7.0.0',
+        event_type: 'error',
         data: {},
       };
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -8,6 +8,7 @@ import { registerProjectTools } from './tools/projects.js';
 import { registerSessionTools } from './tools/sessions.js';
 import { registerTeamTools } from './tools/team.js';
 import { registerTokenTools } from './tools/tokens.js';
+import { registerTransactionTools } from './tools/transactions.js';
 
 export function createServer(client: RustrakClient): McpServer {
   const server = new McpServer({
@@ -23,6 +24,7 @@ export function createServer(client: RustrakClient): McpServer {
   registerTeamTools(server, client);
   registerHealthTools(server, client);
   registerSessionTools(server, client);
+  registerTransactionTools(server, client);
 
   return server;
 }

--- a/packages/mcp/src/tools/transactions.ts
+++ b/packages/mcp/src/tools/transactions.ts
@@ -1,0 +1,34 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RustrakClient } from '@rustrak/client';
+import { z } from 'zod';
+import { toMcpError } from '../errors.js';
+
+export function registerTransactionTools(
+  server: McpServer,
+  client: RustrakClient,
+): void {
+  server.registerTool(
+    'list_transactions',
+    {
+      description:
+        'List performance transactions for a Rustrak project (newest first), with cursor-based pagination. Each transaction includes its name, duration in milliseconds, platform, environment, and release — the performance metrics sent by Sentry SDKs.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Pagination cursor from a previous response (opaque)'),
+      },
+    },
+    async ({ project_id, cursor }) => {
+      try {
+        const result = await client.transactions.list(project_id, { cursor });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
+}

--- a/packages/mcp/tests/integration/server.test.ts
+++ b/packages/mcp/tests/integration/server.test.ts
@@ -38,6 +38,8 @@ const EXPECTED_TOOLS = [
   'get_server_version',
   // Sessions (1)
   'get_release_health',
+  // Transactions (1)
+  'list_transactions',
 ] as const;
 
 describe('MCP server integration', () => {
@@ -62,6 +64,7 @@ describe('MCP server integration', () => {
       members: { list: vi.fn(), upsert: vi.fn(), remove: vi.fn() },
       health: { getVersion: vi.fn() },
       sessions: { stats: vi.fn() },
+      transactions: { list: vi.fn() },
     };
     testEnv = await createTestEnv(mockClient);
   });

--- a/packages/mcp/tests/tools/transactions.test.ts
+++ b/packages/mcp/tests/tools/transactions.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestEnv } from '../setup.js';
+
+describe('transaction tools', () => {
+  let mockClient: any;
+  let testEnv: Awaited<ReturnType<typeof createTestEnv>>;
+  let callTool: Awaited<ReturnType<typeof createTestEnv>>['callTool'];
+
+  const mockTransactionPage = {
+    items: [
+      {
+        id: 'a1b2c3d4-e89b-12d3-a456-426614174000',
+        event_id: 'b2c3d4e5-e89b-12d3-a456-426614174000',
+        transaction_name: '/api/checkout',
+        timestamp: '2026-06-18T12:00:00.000Z',
+        start_timestamp: '2026-06-18T11:59:59.000Z',
+        duration_ms: 1000.0,
+        platform: 'javascript',
+        environment: 'production',
+        release: '1.0.0',
+        ingested_at: '2026-06-18T12:00:01.000Z',
+      },
+    ],
+    has_more: false,
+  };
+
+  beforeEach(async () => {
+    mockClient = {
+      transactions: {
+        list: vi.fn(),
+      },
+    };
+    testEnv = await createTestEnv(mockClient);
+    callTool = testEnv.callTool;
+  });
+
+  afterEach(async () => {
+    await testEnv.mcpClient.close();
+  });
+
+  describe('list_transactions', () => {
+    it('returns a transaction page for a project', async () => {
+      mockClient.transactions.list.mockResolvedValue(mockTransactionPage);
+
+      const result = await callTool({
+        name: 'list_transactions',
+        arguments: { project_id: 1 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.items).toHaveLength(1);
+      expect(parsed.items[0].transaction_name).toBe('/api/checkout');
+      expect(parsed.items[0].duration_ms).toBe(1000.0);
+      expect(parsed.has_more).toBe(false);
+      expect(mockClient.transactions.list).toHaveBeenCalledWith(1, {
+        cursor: undefined,
+      });
+    });
+
+    it('passes cursor when provided', async () => {
+      mockClient.transactions.list.mockResolvedValue(mockTransactionPage);
+
+      await callTool({
+        name: 'list_transactions',
+        arguments: { project_id: 1, cursor: 'next-page' },
+      });
+
+      expect(mockClient.transactions.list).toHaveBeenCalledWith(1, {
+        cursor: 'next-page',
+      });
+    });
+
+    it('returns error content on API failure', async () => {
+      mockClient.transactions.list.mockRejectedValue(new Error('API error'));
+
+      const result = await callTool({
+        name: 'list_transactions',
+        arguments: { project_id: 1 },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Unexpected error');
+    });
+  });
+});


### PR DESCRIPTION
## What

Wires the new **transactions / performance-monitoring** API (shipped in #132) into the TypeScript client and the MCP server.

> Stacked on top of #132 (`feat/transaction-processing-backend`). GitHub will auto-retarget this PR to `main` once #132 merges. Review the backend there; this PR's diff is client + MCP only.

## Client (`@rustrak/client`)

- Add `TransactionsResource` + `transactionSchema` / `Transaction` type for `GET /api/projects/{id}/transactions` (cursor pagination, `duration_ms`, platform/environment/release). Already aligned 1:1 with the server's `TransactionResponse`.
- Make `event` / `eventDetail` `issue_id` **nullable** and add `event_type`, matching the server's `EventResponse` / `EventDetailResponse` (`Option<Uuid>` + `event_type`) — transactions have no `issue_id`.
- **Drop the unsupported `?type=error|transaction` filter** from `events.list()`. The per-issue events route never honored it, and transactions are served by their own endpoint — so it was dead, misleading surface.

## MCP (`@rustrak/mcp`)

- Add **`list_transactions`** tool exposing performance metrics via `client.transactions.list(project_id, { cursor })`, with cursor pagination and `toMcpError` handling. Registered in `server.ts`; integration test updated (count + mock).

## Verification

- Client: typecheck ✅ · **330 tests pass** ✅ · build ✅
- MCP: typecheck ✅ · **52 tests pass** ✅ · build ✅ (new tool added test-first, TDD)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transaction listing capability with cursor-based pagination support
  * Integrated MCP server tools for querying project transactions

* **Schema & Validation**
  * Updated event schema to include event type field and support nullable issue IDs
  * Added transaction schema validation and TypeScript types

* **Tests**
  * Added comprehensive integration and unit tests for transaction functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->