### PR TITLE
feat: transaction detail endpoint + performance UI + sidebar redesign

### DIFF
--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -2661,6 +2661,74 @@
         ]
       }
     },
+    "/api/projects/{project_id}/transactions/{transaction_id}": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "GET /api/projects/{project_id}/transactions/{transaction_id}\nReturns a single transaction with its full Sentry payload (spans, contexts,\nmeasurements, tags) for the performance detail view.",
+        "operationId": "get_transaction",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "transaction_id",
+            "in": "path",
+            "description": "Transaction ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Full transaction detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/team": {
       "get": {
         "tags": [
@@ -4368,6 +4436,69 @@
         "description": "Request body for the test-integration endpoint.",
         "properties": {
           "routing_override": {}
+        }
+      },
+      "TransactionDetailResponse": {
+        "type": "object",
+        "description": "Response model for a single transaction detail view.\n\nCarries the same summary fields as [`TransactionResponse`] plus the full\nSentry payload under `data` (spans, contexts.trace, measurements, tags,\nrequest, user). The frontend builds the span waterfall and metrics view\nfrom `data`.",
+        "required": [
+          "id",
+          "event_id",
+          "transaction_name",
+          "timestamp",
+          "platform",
+          "environment",
+          "release",
+          "ingested_at",
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "description": "Full Sentry transaction payload (spans, contexts, measurements, tags, request, user)."
+          },
+          "duration_ms": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double",
+            "description": "Duration in milliseconds (timestamp - start_timestamp). None if start_timestamp is missing."
+          },
+          "environment": {
+            "type": "string"
+          },
+          "event_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ingested_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "platform": {
+            "type": "string"
+          },
+          "release": {
+            "type": "string"
+          },
+          "start_timestamp": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "transaction_name": {
+            "type": "string"
+          }
         }
       },
       "TransactionResponse": {

--- a/apps/server/src/digest/processors/transaction.rs
+++ b/apps/server/src/digest/processors/transaction.rs
@@ -18,12 +18,32 @@ impl Processor for TransactionProcessor {
 
         let timestamp = extract_timestamp(&data, "timestamp").unwrap_or(ctx.ingested_at);
         let start_timestamp = extract_timestamp(&data, "start_timestamp");
-        let transaction_name = data
-            .get("transaction")
+        let transaction_name = extract_str(&data, "transaction");
+        let spans: Option<serde_json::Value> = data.get("spans").cloned();
+
+        // Denormalize the fields the list/detail views surface so they don't
+        // have to parse the JSONB payload on every read.
+        let platform = extract_str(&data, "platform");
+        let release = extract_str(&data, "release");
+        let environment = extract_str(&data, "environment");
+        let server_name = extract_str(&data, "server_name");
+        let level = data
+            .get("level")
+            .and_then(|v| v.as_str())
+            .unwrap_or("info")
+            .to_string();
+        let sdk_name = data
+            .get("sdk")
+            .and_then(|s| s.get("name"))
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        let spans: Option<serde_json::Value> = data.get("spans").cloned();
+        let sdk_version = data
+            .get("sdk")
+            .and_then(|s| s.get("version"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
 
         let id = Uuid::new_v4();
 
@@ -45,8 +65,8 @@ impl Processor for TransactionProcessor {
                 'transaction', $7, $8,
                 '', '', $9,
                 '', '', '',
-                'info', '', '', '', '',
-                '', '', $10, 1
+                $10, $11, $12, $13, $14,
+                $15, $16, $17, 1
             )
             "#,
         )
@@ -59,12 +79,27 @@ impl Processor for TransactionProcessor {
         .bind(start_timestamp)
         .bind(spans)
         .bind(transaction_name)
+        .bind(level)
+        .bind(platform)
+        .bind(release)
+        .bind(environment)
+        .bind(server_name)
+        .bind(sdk_name)
+        .bind(sdk_version)
         .bind(ctx.remote_addr.as_deref())
         .execute(&ctx.pool)
         .await?;
 
         Ok(())
     }
+}
+
+/// Extracts a top-level string field from the payload, defaulting to empty.
+fn extract_str(data: &serde_json::Value, key: &str) -> String {
+    data.get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 fn extract_timestamp(data: &serde_json::Value, key: &str) -> Option<DateTime<Utc>> {

--- a/apps/server/src/models/mod.rs
+++ b/apps/server/src/models/mod.rs
@@ -54,5 +54,5 @@ pub use invitation::{
 pub use issue::{Issue, IssueResponse, UpdateIssueState};
 pub use project::{CreateProject, Project, ProjectResponse, UpdateProject};
 pub use project_member::{ProjectMember, ProjectMemberResponse, ProjectRole, UpsertProjectMember};
-pub use transaction::TransactionResponse;
+pub use transaction::{TransactionDetailResponse, TransactionResponse};
 pub use user::{CreateUserRequest, LoginRequest, User, UserRole};

--- a/apps/server/src/models/transaction.rs
+++ b/apps/server/src/models/transaction.rs
@@ -18,3 +18,27 @@ pub struct TransactionResponse {
     pub release: String,
     pub ingested_at: DateTime<Utc>,
 }
+
+/// Response model for a single transaction detail view.
+///
+/// Carries the same summary fields as [`TransactionResponse`] plus the full
+/// Sentry payload under `data` (spans, contexts.trace, measurements, tags,
+/// request, user). The frontend builds the span waterfall and metrics view
+/// from `data`.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct TransactionDetailResponse {
+    pub id: Uuid,
+    pub event_id: Uuid,
+    pub transaction_name: String,
+    pub timestamp: DateTime<Utc>,
+    pub start_timestamp: Option<DateTime<Utc>>,
+    /// Duration in milliseconds (timestamp - start_timestamp). None if start_timestamp is missing.
+    pub duration_ms: Option<f64>,
+    pub platform: String,
+    pub environment: String,
+    pub release: String,
+    pub ingested_at: DateTime<Utc>,
+    /// Full Sentry transaction payload (spans, contexts, measurements, tags, request, user).
+    pub data: serde_json::Value,
+}

--- a/apps/server/src/openapi.rs
+++ b/apps/server/src/openapi.rs
@@ -77,6 +77,7 @@ impl Modify for SecurityAddon {
         crate::routes::sourcemaps::list_source_maps,
         crate::routes::sessions::get_stats,
         crate::routes::transactions::list_transactions,
+        crate::routes::transactions::get_transaction,
     ),
     components(schemas(
         crate::models::ProjectResponse,
@@ -87,6 +88,7 @@ impl Modify for SecurityAddon {
         crate::models::EventResponse,
         crate::models::EventDetailResponse,
         crate::models::TransactionResponse,
+        crate::models::TransactionDetailResponse,
         crate::models::AuthTokenResponse,
         crate::models::AuthTokenCreatedResponse,
         crate::models::CreateAuthToken,

--- a/apps/server/src/routes/transactions.rs
+++ b/apps/server/src/routes/transactions.rs
@@ -1,10 +1,11 @@
 use actix_web::{web, HttpResponse};
+use uuid::Uuid;
 
 use crate::auth::ApiActor;
 use crate::db::DbPool;
 use crate::error::AppResult;
 #[cfg(feature = "openapi")]
-use crate::models::TransactionResponse;
+use crate::models::{TransactionDetailResponse, TransactionResponse};
 use crate::pagination::{PaginatedResponse, TransactionCursor, PAGE_SIZE};
 use crate::services::access::{self, Action};
 use crate::services::TransactionService;
@@ -76,15 +77,59 @@ pub async fn list_transactions(
     Ok(HttpResponse::Ok().json(PaginatedResponse::new(transactions, next_cursor, has_more)))
 }
 
+#[cfg_attr(feature = "openapi", utoipa::path(
+    get,
+    path = "/api/projects/{project_id}/transactions/{transaction_id}",
+    tag = "Transactions",
+    params(
+        ("project_id" = i32, Path, description = "Project ID"),
+        ("transaction_id" = uuid::Uuid, Path, description = "Transaction ID"),
+    ),
+    responses(
+        (status = 200, description = "Full transaction detail", body = TransactionDetailResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
+        (status = 404, description = "Not found", body = crate::error::ErrorResponse),
+    ),
+    security(("bearer_auth" = [])),
+))]
+/// GET /api/projects/{project_id}/transactions/{transaction_id}
+/// Returns a single transaction with its full Sentry payload (spans, contexts,
+/// measurements, tags) for the performance detail view.
+pub async fn get_transaction(
+    pool: web::Data<DbPool>,
+    path: web::Path<(i32, Uuid)>,
+    actor: ApiActor,
+) -> AppResult<HttpResponse> {
+    let (project_id, transaction_id) = path.into_inner();
+
+    access::require(
+        pool.get_ref(),
+        actor.is_admin(),
+        actor.user_id(),
+        project_id,
+        Action::ViewProject,
+    )
+    .await?;
+
+    let transaction =
+        TransactionService::get_by_id(pool.get_ref(), project_id, transaction_id).await?;
+
+    Ok(HttpResponse::Ok().json(transaction))
+}
+
 #[cfg(feature = "openapi")]
 #[derive(OpenApi)]
-#[openapi(paths(list_transactions), components(schemas(TransactionResponse,)))]
+#[openapi(
+    paths(list_transactions, get_transaction),
+    components(schemas(TransactionResponse, TransactionDetailResponse,))
+)]
 pub struct TransactionsApi;
 
 /// Configure transaction routes
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/api/projects/{project_id}/transactions")
-            .route("", web::get().to(list_transactions)),
+            .route("", web::get().to(list_transactions))
+            .route("/{transaction_id}", web::get().to(get_transaction)),
     );
 }

--- a/apps/server/src/services/transaction.rs
+++ b/apps/server/src/services/transaction.rs
@@ -1,9 +1,10 @@
 use chrono::DateTime;
 use sqlx::Row;
+use uuid::Uuid;
 
 use crate::db::DbPool;
-use crate::error::AppResult;
-use crate::models::TransactionResponse;
+use crate::error::{AppError, AppResult};
+use crate::models::{TransactionDetailResponse, TransactionResponse};
 use crate::pagination::TransactionCursor;
 
 pub struct TransactionService;
@@ -86,5 +87,52 @@ impl TransactionService {
             .collect();
 
         Ok((transactions, has_more))
+    }
+
+    /// Fetches a single transaction by its primary key, scoped to a project.
+    ///
+    /// Returns the summary fields plus the full Sentry payload (`data`) so the
+    /// frontend can render the span waterfall and metrics. Only rows with
+    /// `event_type = 'transaction'` are returned — an error event id yields
+    /// NotFound, keeping the transaction namespace isolated.
+    pub async fn get_by_id(
+        pool: &DbPool,
+        project_id: i32,
+        id: Uuid,
+    ) -> AppResult<TransactionDetailResponse> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, event_id, "transaction" AS transaction_name,
+                   timestamp, start_timestamp,
+                   platform, environment, release, ingested_at, data
+            FROM events
+            WHERE id = $1
+              AND project_id = $2
+              AND event_type = 'transaction'
+            "#,
+        )
+        .bind(id)
+        .bind(project_id)
+        .fetch_optional(pool)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("Transaction {} not found", id)))?;
+
+        let timestamp: DateTime<chrono::Utc> = row.get("timestamp");
+        let start_timestamp: Option<DateTime<chrono::Utc>> = row.get("start_timestamp");
+        let duration_ms = start_timestamp.map(|st| (timestamp - st).num_milliseconds() as f64);
+
+        Ok(TransactionDetailResponse {
+            id: row.get("id"),
+            event_id: row.get("event_id"),
+            transaction_name: row.get("transaction_name"),
+            timestamp,
+            start_timestamp,
+            duration_ms,
+            platform: row.get("platform"),
+            environment: row.get("environment"),
+            release: row.get("release"),
+            ingested_at: row.get("ingested_at"),
+            data: row.get("data"),
+        })
     }
 }

--- a/apps/server/src/services/transaction.rs
+++ b/apps/server/src/services/transaction.rs
@@ -70,7 +70,7 @@ impl TransactionService {
                 let timestamp: DateTime<chrono::Utc> = row.get("timestamp");
                 let start_timestamp: Option<DateTime<chrono::Utc>> = row.get("start_timestamp");
                 let duration_ms =
-                    start_timestamp.map(|st| (timestamp - st).num_milliseconds() as f64);
+                    start_timestamp.map(|st| (timestamp - st).num_milliseconds().max(0) as f64);
                 TransactionResponse {
                     id: row.get("id"),
                     event_id: row.get("event_id"),
@@ -119,7 +119,8 @@ impl TransactionService {
 
         let timestamp: DateTime<chrono::Utc> = row.get("timestamp");
         let start_timestamp: Option<DateTime<chrono::Utc>> = row.get("start_timestamp");
-        let duration_ms = start_timestamp.map(|st| (timestamp - st).num_milliseconds() as f64);
+        let duration_ms =
+            start_timestamp.map(|st| (timestamp - st).num_milliseconds().max(0) as f64);
 
         Ok(TransactionDetailResponse {
             id: row.get("id"),

--- a/apps/server/tests/integration/transactions_api_test.rs
+++ b/apps/server/tests/integration/transactions_api_test.rs
@@ -94,6 +94,145 @@ async fn store_test_transaction(pool: &rustrak::db::DbPool, project_id: i32, nam
         .expect("Failed to store transaction");
 }
 
+/// Stores a transaction carrying a full payload (spans + contexts.trace) and
+/// returns the stored events row primary key (`id`) for detail lookups.
+async fn store_rich_transaction(pool: &rustrak::db::DbPool, project_id: i32, name: &str) -> Uuid {
+    let ctx = ProcessorCtx {
+        pool: pool.clone(),
+        project_id,
+        event_id: Uuid::new_v4(),
+        ingested_at: Utc::now(),
+        remote_addr: None,
+    };
+    let payload = serde_json::to_vec(&json!({
+        "event_id": Uuid::new_v4().to_string(),
+        "type": "transaction",
+        "transaction": name,
+        "timestamp": Utc::now().timestamp(),
+        "start_timestamp": (Utc::now().timestamp() - 1),
+        "platform": "javascript",
+        "environment": "production",
+        "release": "1.0.0",
+        "contexts": { "trace": { "trace_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "span_id": "bbbbbbbbbbbbbbbb", "op": "http.server" } },
+        "spans": [
+            { "span_id": "cccccccccccccccc", "parent_span_id": "bbbbbbbbbbbbbbbb", "op": "db", "description": "SELECT 1", "start_timestamp": 1.0, "timestamp": 1.5 }
+        ],
+        "measurements": { "lcp": { "value": 1200.0, "unit": "millisecond" } },
+        "tags": { "browser": "Chrome" }
+    }))
+    .unwrap();
+    TransactionProcessor
+        .process(payload, &ctx)
+        .await
+        .expect("Failed to store transaction");
+
+    sqlx::query_scalar::<_, Uuid>(
+        "SELECT id FROM events WHERE project_id = $1 AND event_type = 'transaction' LIMIT 1",
+    )
+    .bind(project_id)
+    .fetch_one(pool)
+    .await
+    .expect("stored transaction id")
+}
+
+#[actix_web::test]
+async fn test_get_transaction_returns_full_detail_with_data() {
+    let db = TestDb::new().await;
+    let pool = db.pool.clone();
+    let config = create_test_config();
+    let token = create_test_token(&pool).await;
+    let project = create_test_project(&pool, "Transaction Detail Test").await;
+
+    let txn_id = store_rich_transaction(&pool, project.id, "/api/checkout").await;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(pool.clone()))
+            .app_data(web::Data::new(config.clone()))
+            .configure(routes::transactions::configure),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/api/projects/{}/transactions/{}",
+            project.id, txn_id
+        ))
+        .insert_header(("Authorization", format!("Bearer {}", token)))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["id"], txn_id.to_string());
+    assert_eq!(body["transaction_name"], "/api/checkout");
+    assert_eq!(body["platform"], "javascript");
+    // The full Sentry payload must be returned under `data`.
+    assert_eq!(body["data"]["spans"][0]["op"], "db");
+    assert_eq!(
+        body["data"]["contexts"]["trace"]["span_id"],
+        "bbbbbbbbbbbbbbbb"
+    );
+    assert_eq!(body["data"]["measurements"]["lcp"]["value"], 1200.0);
+}
+
+#[actix_web::test]
+async fn test_get_transaction_404_for_unknown_id() {
+    let db = TestDb::new().await;
+    let pool = db.pool.clone();
+    let config = create_test_config();
+    let token = create_test_token(&pool).await;
+    let project = create_test_project(&pool, "Transaction Detail 404 Test").await;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(pool.clone()))
+            .app_data(web::Data::new(config.clone()))
+            .configure(routes::transactions::configure),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/api/projects/{}/transactions/{}",
+            project.id,
+            Uuid::new_v4()
+        ))
+        .insert_header(("Authorization", format!("Bearer {}", token)))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 404);
+}
+
+#[actix_web::test]
+async fn test_get_transaction_401_without_token() {
+    let db = TestDb::new().await;
+    let pool = db.pool.clone();
+    let config = create_test_config();
+    let project = create_test_project(&pool, "Transaction Detail Auth Test").await;
+    let txn_id = store_rich_transaction(&pool, project.id, "/api/x").await;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(pool.clone()))
+            .app_data(web::Data::new(config.clone()))
+            .configure(routes::transactions::configure),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/api/projects/{}/transactions/{}",
+            project.id, txn_id
+        ))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 401);
+}
+
 #[actix_web::test]
 async fn test_list_transactions_returns_empty_when_none_exist() {
     let db = TestDb::new().await;

--- a/apps/server/tests/integration/transactions_api_test.rs
+++ b/apps/server/tests/integration/transactions_api_test.rs
@@ -127,7 +127,7 @@ async fn store_rich_transaction(pool: &rustrak::db::DbPool, project_id: i32, nam
         .expect("Failed to store transaction");
 
     sqlx::query_scalar::<_, Uuid>(
-        "SELECT id FROM events WHERE project_id = $1 AND event_type = 'transaction' LIMIT 1",
+        "SELECT id FROM events WHERE project_id = $1 AND event_type = 'transaction' ORDER BY ingested_at DESC LIMIT 1",
     )
     .bind(project_id)
     .fetch_one(pool)

--- a/apps/webview-ui/src/actions/transactions.ts
+++ b/apps/webview-ui/src/actions/transactions.ts
@@ -1,0 +1,25 @@
+'use server';
+
+import type {
+  ListTransactionsOptions,
+  PaginatedResponse,
+  Transaction,
+  TransactionDetail,
+} from '@rustrak/client';
+import { createClient } from '@/lib/rustrak';
+
+export async function listTransactions(
+  projectId: number,
+  options?: ListTransactionsOptions,
+): Promise<PaginatedResponse<Transaction>> {
+  const client = await createClient();
+  return client.transactions.list(projectId, options);
+}
+
+export async function getTransaction(
+  projectId: number,
+  transactionId: string,
+): Promise<TransactionDetail> {
+  const client = await createClient();
+  return client.transactions.get(projectId, transactionId);
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/issues-list.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/issues-list.tsx
@@ -68,11 +68,13 @@ export function IssuesList({
   const { items: issues, total_count, total_pages, per_page } = initialIssues;
 
   const handleFilterChange = (filter: string) => {
-    router.push(`/projects/${projectId}?filter=${filter}&page=1`);
+    router.push(`/projects/${projectId}/issues?filter=${filter}&page=1`);
   };
 
   const handlePageChange = (page: number) => {
-    router.push(`/projects/${projectId}?filter=${currentFilter}&page=${page}`);
+    router.push(
+      `/projects/${projectId}/issues?filter=${currentFilter}&page=${page}`,
+    );
   };
 
   const toggleSelectAll = () => {

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/page.tsx
@@ -1,0 +1,100 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { listAlertRules, listIntegrations } from '@/actions/alerts';
+import { getCurrentUser } from '@/actions/auth';
+import { listIssues } from '@/actions/issues';
+import { listProjectMembers } from '@/actions/members';
+import { getProject } from '@/actions/projects';
+import { getReleaseHealth } from '@/actions/sessions';
+import { ProjectHeader } from '../project-header';
+import { IssuesList } from './issues-list';
+
+interface IssuesPageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ filter?: string; page?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: IssuesPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const project = await getProject(parseInt(id, 10));
+
+  if (!project) {
+    return { title: 'Project Not Found | Rustrak' };
+  }
+
+  return {
+    title: `${project.name} | Rustrak`,
+    description: `Issues for ${project.name}`,
+  };
+}
+
+export default async function IssuesPage({
+  params,
+  searchParams,
+}: IssuesPageProps) {
+  const { id } = await params;
+  const { filter = 'open', page = '1' } = await searchParams;
+  const projectId = parseInt(id, 10);
+  const currentPage = parseInt(page, 10) || 1;
+
+  const project = await getProject(projectId);
+
+  if (!project) {
+    notFound();
+  }
+
+  const [
+    issuesResponse,
+    alertRules,
+    channels,
+    members,
+    currentUser,
+    releaseHealth,
+  ] = await Promise.all([
+    listIssues(projectId, {
+      filter: filter as 'open' | 'resolved' | 'muted' | 'all',
+      page: currentPage,
+      per_page: 20,
+      sort: 'last_seen',
+      order: 'desc',
+    }),
+    listAlertRules(projectId).catch(() => []),
+    listIntegrations().catch(() => []),
+    listProjectMembers(projectId).catch(() => []),
+    getCurrentUser(),
+    getReleaseHealth(projectId).catch(() => []),
+  ]);
+
+  const currentMembership = currentUser
+    ? members.find((member) => member.user_id === currentUser.id)
+    : undefined;
+  const canManageMembers =
+    currentUser?.role === 'admin' || currentMembership?.role === 'admin';
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-64px)]">
+      <div className="shrink-0 max-w-400 w-full mx-auto px-4 md:px-8 py-4 md:py-6 border-b">
+        <ProjectHeader
+          project={project}
+          alertRules={alertRules}
+          channels={channels}
+          members={members}
+          currentUserId={currentUser?.id}
+          canManageMembers={canManageMembers}
+          releaseHealth={releaseHealth}
+        />
+      </div>
+
+      <div className="flex-1 overflow-hidden max-w-400 w-full mx-auto px-4 md:px-8 py-4 md:py-6">
+        <IssuesList
+          projectId={projectId}
+          initialIssues={issuesResponse}
+          currentFilter={filter}
+          currentPage={currentPage}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/layout.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/layout.tsx
@@ -1,5 +1,4 @@
 import { cookies } from 'next/headers';
-import { listIssues } from '@/actions/issues';
 import { getProject, getProjects } from '@/actions/projects';
 import {
   SidebarInset,
@@ -20,21 +19,12 @@ export default async function ProjectLayout({
   const { id } = await params;
   const projectId = parseInt(id, 10);
 
-  const [project, issuesResponse, projectsResponse, cookieStore] =
-    await Promise.all([
-      getProject(projectId),
-      listIssues(projectId, { filter: 'open', per_page: 20 }).catch(() => ({
-        items: [],
-        total_count: 0,
-        page: 1,
-        per_page: 20,
-        total_pages: 0,
-      })),
-      getProjects({ per_page: 100 }).catch(() => ({ items: [] })),
-      cookies(),
-    ]);
+  const [project, projectsResponse, cookieStore] = await Promise.all([
+    getProject(projectId),
+    getProjects({ per_page: 100 }).catch(() => ({ items: [] })),
+    cookies(),
+  ]);
 
-  const unresolvedCount = issuesResponse.total_count;
   const projects = projectsResponse.items.map((p) => ({
     id: p.id,
     name: p.name,
@@ -47,11 +37,7 @@ export default async function ProjectLayout({
       defaultOpen={defaultOpen}
       className="min-h-[calc(100svh-4rem)]!"
     >
-      <ProjectSidebar
-        projectId={projectId}
-        projects={projects}
-        unresolvedCount={unresolvedCount}
-      />
+      <ProjectSidebar projectId={projectId} projects={projects} />
       <SidebarInset className="min-w-0 overflow-hidden">
         {/* Mobile-only bar — opens the sidebar sheet. On desktop the sidebar
             collapses via its footer button, drag-rail, or Cmd/Ctrl+B.

--- a/apps/webview-ui/src/app/(main)/projects/[id]/layout.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/layout.tsx
@@ -1,0 +1,70 @@
+import { cookies } from 'next/headers';
+import { listIssues } from '@/actions/issues';
+import { getProject, getProjects } from '@/actions/projects';
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from '@/components/ui/sidebar';
+import { ProjectSidebar } from './project-sidebar';
+
+interface ProjectLayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ id: string }>;
+}
+
+export default async function ProjectLayout({
+  children,
+  params,
+}: ProjectLayoutProps) {
+  const { id } = await params;
+  const projectId = parseInt(id, 10);
+
+  const [project, issuesResponse, projectsResponse, cookieStore] =
+    await Promise.all([
+      getProject(projectId),
+      listIssues(projectId, { filter: 'open', per_page: 20 }).catch(() => ({
+        items: [],
+        total_count: 0,
+        page: 1,
+        per_page: 20,
+        total_pages: 0,
+      })),
+      getProjects({ per_page: 100 }).catch(() => ({ items: [] })),
+      cookies(),
+    ]);
+
+  const unresolvedCount = issuesResponse.total_count;
+  const projects = projectsResponse.items.map((p) => ({
+    id: p.id,
+    name: p.name,
+    slug: p.slug,
+  }));
+  const defaultOpen = cookieStore.get('sidebar_state')?.value !== 'false';
+
+  return (
+    <SidebarProvider
+      defaultOpen={defaultOpen}
+      className="min-h-[calc(100svh-4rem)]!"
+    >
+      <ProjectSidebar
+        projectId={projectId}
+        projects={projects}
+        unresolvedCount={unresolvedCount}
+      />
+      <SidebarInset className="min-w-0 overflow-hidden">
+        {/* Mobile-only bar — opens the sidebar sheet. On desktop the sidebar
+            collapses via its footer button, drag-rail, or Cmd/Ctrl+B.
+            top-0: it pins to the top of SidebarInset, which already sits below
+            the global header (an offset like top-16 would double-shift it). */}
+        <div className="sticky top-0 z-30 flex h-11 shrink-0 items-center gap-2 border-b bg-background/80 px-3 backdrop-blur-md md:hidden">
+          <SidebarTrigger className="text-muted-foreground" />
+          <span className="truncate text-sm font-medium text-muted-foreground">
+            {project?.name ?? ''}
+          </span>
+        </div>
+        {children}
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/page.tsx
@@ -1,105 +1,10 @@
-import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
-import { listAlertRules, listIntegrations } from '@/actions/alerts';
-import { getCurrentUser } from '@/actions/auth';
-import { listIssues } from '@/actions/issues';
-import { listProjectMembers } from '@/actions/members';
-import { getProject } from '@/actions/projects';
-import { getReleaseHealth } from '@/actions/sessions';
-import { IssuesList } from './issues-list';
-import { ProjectHeader } from './project-header';
+import { redirect } from 'next/navigation';
 
 interface ProjectPageProps {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ filter?: string; page?: string }>;
 }
 
-export async function generateMetadata({
-  params,
-}: ProjectPageProps): Promise<Metadata> {
+export default async function ProjectPage({ params }: ProjectPageProps) {
   const { id } = await params;
-  const project = await getProject(parseInt(id, 10));
-
-  if (!project) {
-    return { title: 'Project Not Found | Rustrak' };
-  }
-
-  return {
-    title: `${project.name} | Rustrak`,
-    description: `Issues for ${project.name}`,
-  };
-}
-
-export default async function ProjectPage({
-  params,
-  searchParams,
-}: ProjectPageProps) {
-  const { id } = await params;
-  const { filter = 'open', page = '1' } = await searchParams;
-  const projectId = parseInt(id, 10);
-  const currentPage = parseInt(page, 10) || 1;
-
-  const project = await getProject(projectId);
-
-  if (!project) {
-    notFound();
-  }
-
-  // Fetch issues, alert, member, release health and user data in parallel
-  const [
-    issuesResponse,
-    alertRules,
-    channels,
-    members,
-    currentUser,
-    releaseHealth,
-  ] = await Promise.all([
-    listIssues(projectId, {
-      filter: filter as 'open' | 'resolved' | 'muted' | 'all',
-      page: currentPage,
-      per_page: 20,
-      sort: 'last_seen',
-      order: 'desc',
-    }),
-    listAlertRules(projectId).catch(() => []),
-    listIntegrations().catch(() => []),
-    listProjectMembers(projectId).catch(() => []),
-    getCurrentUser(),
-    getReleaseHealth(projectId).catch(() => []),
-  ]);
-
-  // A user can manage project members if they are a global admin or have the
-  // project-level 'admin' role on this project.
-  const currentMembership = currentUser
-    ? members.find((member) => member.user_id === currentUser.id)
-    : undefined;
-  const canManageMembers =
-    currentUser?.role === 'admin' || currentMembership?.role === 'admin';
-
-  return (
-    <div className="flex flex-col h-[calc(100vh-64px)]">
-      {/* Header section - fixed */}
-      <div className="shrink-0 max-w-400 w-full mx-auto px-4 md:px-8 py-4 md:py-6 border-b">
-        <ProjectHeader
-          project={project}
-          alertRules={alertRules}
-          channels={channels}
-          members={members}
-          currentUserId={currentUser?.id}
-          canManageMembers={canManageMembers}
-          releaseHealth={releaseHealth}
-        />
-      </div>
-
-      {/* Content section - grows and handles overflow */}
-      <div className="flex-1 overflow-hidden max-w-400 w-full mx-auto px-4 md:px-8 py-4 md:py-6">
-        <IssuesList
-          projectId={projectId}
-          initialIssues={issuesResponse}
-          currentFilter={filter}
-          currentPage={currentPage}
-        />
-      </div>
-    </div>
-  );
+  redirect(`/projects/${id}/issues`);
 }

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/measurements-card.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/measurements-card.tsx
@@ -1,0 +1,88 @@
+import { cn } from '@/lib/utils';
+
+interface Measurement {
+  value?: number;
+  unit?: string;
+}
+
+interface MeasurementsCardProps {
+  measurements: Record<string, unknown>;
+}
+
+// Web-vital thresholds (good / needs-improvement boundaries) from web.dev.
+// Values in ms unless noted. Unknown keys render without a rating.
+const VITALS: Record<string, { label: string; good: number; poor: number }> = {
+  lcp: { label: 'LCP', good: 2500, poor: 4000 },
+  fcp: { label: 'FCP', good: 1800, poor: 3000 },
+  fid: { label: 'FID', good: 100, poor: 300 },
+  inp: { label: 'INP', good: 200, poor: 500 },
+  ttfb: { label: 'TTFB', good: 800, poor: 1800 },
+  cls: { label: 'CLS', good: 0.1, poor: 0.25 },
+};
+
+function rating(key: string, value: number): 'good' | 'meh' | 'poor' | null {
+  const v = VITALS[key.toLowerCase()];
+  if (!v) return null;
+  if (value <= v.good) return 'good';
+  if (value <= v.poor) return 'meh';
+  return 'poor';
+}
+
+const RATING_STYLES: Record<'good' | 'meh' | 'poor', string> = {
+  good: 'text-primary',
+  meh: 'text-yellow-600 dark:text-yellow-500',
+  poor: 'text-destructive',
+};
+
+function formatValue(value: number, unit?: string): string {
+  if (unit === 'millisecond' || unit == null) {
+    if (value < 1000) return `${Math.round(value)}ms`;
+    return `${(value / 1000).toFixed(2)}s`;
+  }
+  if (unit === 'ratio' || unit === 'none') return value.toFixed(3);
+  if (unit === 'second') return `${value.toFixed(2)}s`;
+  return `${value} ${unit}`;
+}
+
+export function MeasurementsCard({ measurements }: MeasurementsCardProps) {
+  const entries = Object.entries(measurements)
+    .map(([key, raw]): [string, Measurement] | null => {
+      const m = raw as Measurement | null;
+      return m && typeof m.value === 'number' ? [key, m] : null;
+    })
+    .filter((e): e is [string, Measurement] => e !== null);
+
+  if (entries.length === 0) return null;
+
+  // Known vitals first, then the rest.
+  entries.sort(([a], [b]) => {
+    const av = a.toLowerCase() in VITALS ? 0 : 1;
+    const bv = b.toLowerCase() in VITALS ? 0 : 1;
+    return av - bv;
+  });
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+      {entries.map(([key, m]) => {
+        const value = m.value as number;
+        const r = rating(key, value);
+        const label = VITALS[key.toLowerCase()]?.label ?? key;
+        return (
+          <div key={key} className="rounded-lg border p-3">
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">
+              {label}
+            </div>
+            <div
+              className={cn(
+                'mt-1 font-mono text-lg font-semibold',
+                r ? RATING_STYLES[r] : 'text-foreground',
+              )}
+            >
+              {formatValue(value, m.unit)}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/page.tsx
@@ -1,0 +1,188 @@
+import { ArrowLeft } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getProject } from '@/actions/projects';
+import { getTransaction } from '@/actions/transactions';
+import { Badge } from '@/components/ui/badge';
+import { MeasurementsCard } from './measurements-card';
+import { SpanWaterfall } from './span-waterfall';
+
+interface TransactionDetailPageProps {
+  params: Promise<{ id: string; txnId: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: TransactionDetailPageProps): Promise<Metadata> {
+  const { id, txnId } = await params;
+  const txn = await getTransaction(parseInt(id, 10), txnId).catch(() => null);
+  return {
+    title: txn
+      ? `${txn.transaction_name} | Performance | Rustrak`
+      : 'Transaction | Rustrak',
+  };
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function epochSeconds(raw: unknown, fallbackIso: string): number {
+  if (typeof raw === 'number') return raw;
+  return Date.parse(fallbackIso) / 1000;
+}
+
+/** Renders the primitive entries of an object as a key/value list. */
+function KeyValuePanel({
+  title,
+  data,
+}: {
+  title: string;
+  data: Record<string, unknown>;
+}) {
+  const entries = Object.entries(data).filter(
+    ([, v]) => v != null && typeof v !== 'object',
+  );
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border">
+      <div className="border-b px-4 py-2.5 text-xs font-bold uppercase tracking-widest text-muted-foreground">
+        {title}
+      </div>
+      <dl className="divide-y">
+        {entries.map(([key, value]) => (
+          <div
+            key={key}
+            className="flex items-start justify-between gap-4 px-4 py-2 text-sm"
+          >
+            <dt className="font-mono text-muted-foreground">{key}</dt>
+            <dd className="font-mono text-right break-all">{String(value)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+export default async function TransactionDetailPage({
+  params,
+}: TransactionDetailPageProps) {
+  const { id, txnId } = await params;
+  const projectId = parseInt(id, 10);
+
+  const [project, txn] = await Promise.all([
+    getProject(projectId),
+    getTransaction(projectId, txnId).catch(() => null),
+  ]);
+
+  if (!project || !txn) {
+    notFound();
+  }
+
+  const data = txn.data ?? {};
+  const trace = asObject(data.contexts)?.trace as
+    | Record<string, unknown>
+    | undefined;
+  const spans = Array.isArray(data.spans) ? data.spans : [];
+  const measurements = asObject(data.measurements);
+  const tags = asObject(data.tags);
+  const request = asObject(data.request);
+  const user = asObject(data.user);
+
+  const transactionStart = epochSeconds(
+    data.start_timestamp,
+    txn.start_timestamp ?? txn.timestamp,
+  );
+  const transactionEnd = epochSeconds(data.timestamp, txn.timestamp);
+
+  const op = typeof trace?.op === 'string' ? trace.op : undefined;
+  const status = typeof trace?.status === 'string' ? trace.status : undefined;
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-64px)]">
+      {/* Header */}
+      <div className="shrink-0 max-w-400 w-full mx-auto px-4 md:px-8 py-4 md:py-6 border-b">
+        <Link
+          href={`/projects/${projectId}/performance`}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-3"
+        >
+          <ArrowLeft className="size-4" />
+          Performance
+        </Link>
+        <h1 className="font-mono text-lg font-semibold break-all">
+          {txn.transaction_name || '(unnamed transaction)'}
+        </h1>
+        <div className="mt-2 flex items-center gap-2 flex-wrap text-sm">
+          <span className="font-mono font-semibold">
+            {formatDuration(txn.duration_ms)}
+          </span>
+          {op && <Badge variant="secondary">{op}</Badge>}
+          {status && (
+            <Badge variant={status === 'ok' ? 'outline' : 'destructive'}>
+              {status}
+            </Badge>
+          )}
+          {txn.environment && (
+            <Badge variant="outline">{txn.environment}</Badge>
+          )}
+          {txn.platform && <Badge variant="outline">{txn.platform}</Badge>}
+          {txn.release && (
+            <span className="font-mono text-xs text-muted-foreground">
+              {txn.release}
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground">
+            {new Date(txn.timestamp).toLocaleString()}
+          </span>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-auto max-w-400 w-full mx-auto px-4 md:px-8 py-4 md:py-6 space-y-6">
+        {measurements && <MeasurementsCard measurements={measurements} />}
+
+        <section className="rounded-lg border">
+          <div className="border-b px-4 py-2.5 flex items-center justify-between">
+            <h2 className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+              Spans
+            </h2>
+            <span className="text-xs text-muted-foreground">
+              {spans.length} span{spans.length === 1 ? '' : 's'}
+            </span>
+          </div>
+          <div className="p-3">
+            {spans.length === 0 && !trace ? (
+              <p className="text-sm text-muted-foreground px-1 py-4 text-center">
+                This transaction has no spans.
+              </p>
+            ) : (
+              <SpanWaterfall
+                spans={spans as never[]}
+                trace={trace as never}
+                transactionStart={transactionStart}
+                transactionEnd={transactionEnd}
+              />
+            )}
+          </div>
+        </section>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {tags && <KeyValuePanel title="Tags" data={tags} />}
+          {request && <KeyValuePanel title="Request" data={request} />}
+          {user && <KeyValuePanel title="User" data={user} />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/page.tsx
@@ -6,6 +6,7 @@ import { getProject } from '@/actions/projects';
 import { getTransaction } from '@/actions/transactions';
 import { Badge } from '@/components/ui/badge';
 import { MeasurementsCard } from './measurements-card';
+import type { Span, TraceContext } from './span-waterfall';
 import { SpanWaterfall } from './span-waterfall';
 
 interface TransactionDetailPageProps {
@@ -168,8 +169,8 @@ export default async function TransactionDetailPage({
               </p>
             ) : (
               <SpanWaterfall
-                spans={spans as never[]}
-                trace={trace as never}
+                spans={spans as Span[]}
+                trace={trace as TraceContext | undefined}
                 transactionStart={transactionStart}
                 transactionEnd={transactionEnd}
               />

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/span-waterfall.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/span-waterfall.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils';
  * A single Sentry span. Every field is optional — SDKs omit most of them; a
  * minimal legal span is `{ span_id, start_timestamp, timestamp }`.
  */
-interface Span {
+export interface Span {
   span_id?: string;
   parent_span_id?: string;
   op?: string;
@@ -15,7 +15,7 @@ interface Span {
   exclusive_time?: number;
 }
 
-interface TraceContext {
+export interface TraceContext {
   span_id?: string;
   op?: string;
   status?: string;
@@ -126,8 +126,11 @@ export function SpanWaterfall({
     .map((s) => s.timestamp)
     .filter((v): v is number => v != null);
 
-  const traceStart = Math.min(...starts, transactionStart ?? Infinity);
-  const traceEnd = Math.max(...ends, transactionEnd);
+  const traceStart = starts.reduce(
+    (a, b) => Math.min(a, b),
+    transactionStart ?? Infinity,
+  );
+  const traceEnd = ends.reduce((a, b) => Math.max(a, b), transactionEnd);
   const total = traceEnd - traceStart;
 
   const order = buildOrder(spans, trace?.span_id);

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/span-waterfall.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/span-waterfall.tsx
@@ -1,0 +1,219 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * A single Sentry span. Every field is optional — SDKs omit most of them; a
+ * minimal legal span is `{ span_id, start_timestamp, timestamp }`.
+ */
+interface Span {
+  span_id?: string;
+  parent_span_id?: string;
+  op?: string;
+  description?: string;
+  status?: string;
+  start_timestamp?: number;
+  timestamp?: number;
+  exclusive_time?: number;
+}
+
+interface TraceContext {
+  span_id?: string;
+  op?: string;
+  status?: string;
+  description?: string;
+}
+
+interface SpanWaterfallProps {
+  spans: Span[];
+  trace?: TraceContext;
+  /** Transaction-level bounds (epoch seconds) for the root bar. */
+  transactionStart?: number;
+  transactionEnd: number;
+}
+
+interface WaterfallNode {
+  span: Span;
+  depth: number;
+}
+
+// Map a span op to a bar color. Prefix match keeps it resilient to the long
+// tail of op values SDKs emit (db.sql.query, http.client, resource.script…).
+function opColor(op?: string): string {
+  const o = (op ?? '').toLowerCase();
+  if (o.startsWith('db')) return 'bg-blue-500';
+  if (o.startsWith('http')) return 'bg-emerald-500';
+  if (o.startsWith('resource')) return 'bg-purple-500';
+  if (o.startsWith('ui') || o.includes('render')) return 'bg-orange-500';
+  if (o.startsWith('cache')) return 'bg-pink-500';
+  if (o.startsWith('rpc') || o.startsWith('grpc')) return 'bg-cyan-500';
+  return 'bg-primary';
+}
+
+function spanDuration(span: Span): number | null {
+  if (span.start_timestamp == null || span.timestamp == null) return null;
+  return (span.timestamp - span.start_timestamp) * 1000;
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms == null) return '—';
+  if (ms < 1) return `${(ms * 1000).toFixed(0)}µs`;
+  if (ms < 1000) return `${ms.toFixed(1)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+/**
+ * Builds the span tree from `parent_span_id` links and flattens it to a
+ * depth-annotated DFS order. Orphan spans (parent not found) attach to the
+ * root. Children are sorted by start time.
+ */
+function buildOrder(spans: Span[], rootSpanId?: string): WaterfallNode[] {
+  const childrenByParent = new Map<string, Span[]>();
+  const known = new Set(
+    spans.map((s) => s.span_id).filter((id): id is string => Boolean(id)),
+  );
+
+  for (const span of spans) {
+    // A span attaches to its parent only if that parent is itself in the set
+    // (or is the trace root); otherwise it floats up to the root bucket.
+    const parent =
+      span.parent_span_id &&
+      (known.has(span.parent_span_id) || span.parent_span_id === rootSpanId)
+        ? span.parent_span_id
+        : '__root__';
+    const key = parent === rootSpanId ? '__root__' : parent;
+    const list = childrenByParent.get(key) ?? [];
+    list.push(span);
+    childrenByParent.set(key, list);
+  }
+
+  const order: WaterfallNode[] = [];
+  const visited = new Set<string>();
+
+  const walk = (parentKey: string, depth: number) => {
+    const children = (childrenByParent.get(parentKey) ?? []).sort(
+      (a, b) => (a.start_timestamp ?? 0) - (b.start_timestamp ?? 0),
+    );
+    for (const span of children) {
+      if (span.span_id && visited.has(span.span_id)) continue;
+      if (span.span_id) visited.add(span.span_id);
+      order.push({ span, depth });
+      if (span.span_id) walk(span.span_id, depth + 1);
+    }
+  };
+
+  walk('__root__', 0);
+
+  // Any spans not reached (cyclic / unreferenced) get appended flat so nothing
+  // silently disappears from the view.
+  for (const span of spans) {
+    if (span.span_id && !visited.has(span.span_id)) {
+      order.push({ span, depth: 0 });
+    }
+  }
+
+  return order;
+}
+
+export function SpanWaterfall({
+  spans,
+  trace,
+  transactionStart,
+  transactionEnd,
+}: SpanWaterfallProps) {
+  const starts = spans
+    .map((s) => s.start_timestamp)
+    .filter((v): v is number => v != null);
+  const ends = spans
+    .map((s) => s.timestamp)
+    .filter((v): v is number => v != null);
+
+  const traceStart = Math.min(...starts, transactionStart ?? Infinity);
+  const traceEnd = Math.max(...ends, transactionEnd);
+  const total = traceEnd - traceStart;
+
+  const order = buildOrder(spans, trace?.span_id);
+
+  const rootDuration =
+    transactionStart != null
+      ? (transactionEnd - transactionStart) * 1000
+      : null;
+
+  return (
+    <div className="space-y-0.5 font-mono text-xs">
+      {/* Root segment (the transaction itself) */}
+      <div className="flex items-center gap-3 rounded-md bg-muted/40 px-2 py-1.5">
+        <div className="w-[38%] min-w-0 flex items-center gap-2">
+          <span className="font-semibold text-foreground truncate">
+            {trace?.op || 'transaction'}
+          </span>
+          <span className="text-muted-foreground truncate">
+            {trace?.description ?? ''}
+          </span>
+        </div>
+        <div className="relative flex-1 h-4">
+          <div className="absolute inset-y-0 left-0 right-0 rounded-sm bg-primary/80" />
+        </div>
+        <span className="w-16 text-right text-muted-foreground tabular-nums">
+          {formatDuration(rootDuration)}
+        </span>
+      </div>
+
+      {order.map(({ span, depth }, i) => {
+        const dur = spanDuration(span);
+        const start = span.start_timestamp;
+        const offsetPct =
+          start != null && total > 0 ? ((start - traceStart) / total) * 100 : 0;
+        const widthPct =
+          dur != null && total > 0
+            ? Math.max(0.5, (dur / 1000 / total) * 100)
+            : 0;
+        const clampedWidth = Math.min(widthPct, 100 - offsetPct);
+        const failed = span.status && span.status !== 'ok';
+
+        return (
+          <div
+            key={span.span_id ?? `span-${i}`}
+            className="flex items-center gap-3 px-2 py-1 rounded-md hover:bg-muted/30"
+            title={span.description || span.op || span.span_id || ''}
+          >
+            <div
+              className="w-[38%] min-w-0 flex items-center gap-2"
+              style={{ paddingLeft: `${Math.min(depth, 8) * 12}px` }}
+            >
+              <span
+                className={cn(
+                  'shrink-0 rounded px-1 py-px text-[10px] font-medium text-white',
+                  opColor(span.op),
+                )}
+              >
+                {span.op || 'span'}
+              </span>
+              <span className="truncate text-muted-foreground">
+                {span.description || '—'}
+              </span>
+              {failed && (
+                <span className="shrink-0 rounded bg-destructive/15 px-1 text-[10px] text-destructive">
+                  {span.status}
+                </span>
+              )}
+            </div>
+            <div className="relative flex-1 h-4">
+              <div
+                className={cn(
+                  'absolute inset-y-0 rounded-sm',
+                  opColor(span.op),
+                )}
+                style={{
+                  left: `${offsetPct}%`,
+                  width: `${clampedWidth}%`,
+                }}
+              />
+            </div>
+            <span className="w-16 text-right text-muted-foreground tabular-nums">
+              {formatDuration(dur)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getProject } from '@/actions/projects';
+import { listTransactions } from '@/actions/transactions';
+import { TransactionsList } from './transactions-list';
+
+interface PerformancePageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PerformancePageProps): Promise<Metadata> {
+  const { id } = await params;
+  const project = await getProject(parseInt(id, 10));
+
+  if (!project) {
+    return { title: 'Project Not Found | Rustrak' };
+  }
+
+  return {
+    title: `Performance | ${project.name} | Rustrak`,
+    description: `Transaction performance for ${project.name}`,
+  };
+}
+
+export default async function PerformancePage({
+  params,
+}: PerformancePageProps) {
+  const { id } = await params;
+  const projectId = parseInt(id, 10);
+
+  const project = await getProject(projectId);
+
+  if (!project) {
+    notFound();
+  }
+
+  const transactions = await listTransactions(projectId).catch(() => ({
+    items: [],
+    has_more: false,
+  }));
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-64px)]">
+      <div className="shrink-0 max-w-400 w-full mx-auto px-4 md:px-8 py-4 md:py-6 border-b">
+        <h1 className="text-lg font-semibold">Performance</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          Transaction traces for {project.name}
+        </p>
+      </div>
+      <div className="flex-1 overflow-auto max-w-400 w-full mx-auto px-4 md:px-8 py-4 md:py-6">
+        <TransactionsList
+          projectId={projectId}
+          initialTransactions={transactions}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/transactions-list.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/transactions-list.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import type { PaginatedResponse, Transaction } from '@rustrak/client';
+import { formatDistanceToNow } from 'date-fns';
+import { Loader2, Zap } from 'lucide-react';
+import Link from 'next/link';
+import { useState, useTransition } from 'react';
+import { listTransactions } from '@/actions/transactions';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface TransactionsListProps {
+  projectId: number;
+  initialTransactions: PaginatedResponse<Transaction>;
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+// Severity thresholds mirror Sentry's apdex-ish buckets: <1s good, <3s warn.
+function durationTone(ms: number | null): {
+  text: string;
+  bar: string;
+  pct: number;
+} {
+  if (ms === null)
+    return { text: 'text-muted-foreground', bar: 'bg-muted', pct: 0 };
+  if (ms > 3000)
+    return { text: 'text-destructive', bar: 'bg-destructive', pct: 100 };
+  if (ms > 1000)
+    return {
+      text: 'text-yellow-600 dark:text-yellow-500',
+      bar: 'bg-yellow-500',
+      pct: Math.min(100, (ms / 3000) * 100),
+    };
+  return {
+    text: 'text-primary',
+    bar: 'bg-primary',
+    pct: Math.min(100, (ms / 3000) * 100),
+  };
+}
+
+export function TransactionsList({
+  projectId,
+  initialTransactions,
+}: TransactionsListProps) {
+  const [isPending, startTransition] = useTransition();
+  const [items, setItems] = useState<Transaction[]>(initialTransactions.items);
+  const [cursor, setCursor] = useState<string | undefined>(
+    initialTransactions.next_cursor,
+  );
+  const [hasMore, setHasMore] = useState<boolean>(initialTransactions.has_more);
+
+  function loadMore() {
+    if (!cursor) return;
+    startTransition(async () => {
+      const next = await listTransactions(projectId, { cursor });
+      setItems((prev) => [...prev, ...next.items]);
+      setCursor(next.next_cursor);
+      setHasMore(next.has_more);
+    });
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-100 text-center">
+        <Zap className="size-12 text-muted-foreground/30 mb-4" />
+        <h2 className="text-lg font-semibold mb-1">No transactions yet</h2>
+        <p className="text-sm text-muted-foreground max-w-md">
+          Configure your SDK with <code>tracesSampleRate</code> to start
+          capturing performance data.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-hidden flex flex-col border rounded-lg">
+        {/* Header */}
+        <div className="shrink-0 flex items-center gap-4 px-4 py-3 bg-muted/50 border-b">
+          <span className="text-xs font-bold uppercase tracking-widest text-muted-foreground flex-1">
+            Transaction
+          </span>
+          <span className="hidden sm:block text-xs font-bold uppercase tracking-widest text-muted-foreground w-40">
+            Duration
+          </span>
+          <span className="hidden md:block text-xs font-bold uppercase tracking-widest text-muted-foreground w-28 text-right">
+            Last Seen
+          </span>
+        </div>
+
+        {/* Scrollable rows */}
+        <div className="flex-1 overflow-auto">
+          {items.map((txn) => {
+            const tone = durationTone(txn.duration_ms);
+            return (
+              <Link
+                key={txn.id}
+                href={`/projects/${projectId}/performance/${txn.id}`}
+                className="flex items-center gap-4 px-4 py-3 border-b last:border-b-0 hover:bg-muted/30 transition-colors group"
+              >
+                <div className="flex-1 min-w-0">
+                  <span className="block font-mono text-sm truncate group-hover:text-primary transition-colors">
+                    {txn.transaction_name || '(unnamed)'}
+                  </span>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap mt-1">
+                    {txn.platform && (
+                      <Badge variant="outline" className="text-[10px]">
+                        {txn.platform}
+                      </Badge>
+                    )}
+                    {txn.environment && (
+                      <Badge variant="secondary" className="text-[10px]">
+                        {txn.environment}
+                      </Badge>
+                    )}
+                    {txn.release && (
+                      <span className="font-mono truncate max-w-40">
+                        {txn.release}
+                      </span>
+                    )}
+                    {/* Mobile-only duration + time */}
+                    <span className={cn('sm:hidden font-medium', tone.text)}>
+                      {formatDuration(txn.duration_ms)}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Duration with bar */}
+                <div className="hidden sm:flex flex-col items-end w-40 gap-1">
+                  <span
+                    className={cn('font-mono text-sm font-medium', tone.text)}
+                  >
+                    {formatDuration(txn.duration_ms)}
+                  </span>
+                  <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
+                    <div
+                      className={cn('h-full rounded-full', tone.bar)}
+                      style={{ width: `${tone.pct}%` }}
+                    />
+                  </div>
+                </div>
+
+                <div className="hidden md:block w-28 text-right">
+                  <span className="text-sm text-muted-foreground whitespace-nowrap">
+                    {formatDistanceToNow(new Date(txn.timestamp), {
+                      addSuffix: true,
+                    })}
+                  </span>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="shrink-0 flex items-center justify-between gap-2 pt-4">
+        <span className="text-sm text-muted-foreground">
+          {items.length} transaction{items.length === 1 ? '' : 's'} loaded
+        </span>
+        {hasMore && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={loadMore}
+            disabled={isPending}
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Loading…
+              </>
+            ) : (
+              'Load more'
+            )}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/project-sidebar.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/project-sidebar.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import {
+  AlertCircle,
+  Check,
+  ChevronsLeft,
+  ChevronsUpDown,
+  Zap,
+} from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+  useSidebar,
+} from '@/components/ui/sidebar';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+interface ProjectOption {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface ProjectSidebarProps {
+  projectId: number;
+  projects: ProjectOption[];
+  unresolvedCount: number;
+}
+
+function formatBadge(count: number): string {
+  if (count > 99) return '99+';
+  return String(count);
+}
+
+function initialOf(name: string): string {
+  return (name || '?').charAt(0).toUpperCase();
+}
+
+function ProjectAvatar({ name, className }: { name: string; className?: string }) {
+  return (
+    <div
+      className={cn(
+        'flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted text-sm font-semibold text-foreground',
+        className,
+      )}
+    >
+      {initialOf(name)}
+    </div>
+  );
+}
+
+/** Dokploy-style project switcher: a card that opens a project picker. */
+function ProjectSwitcher({
+  projectId,
+  projects,
+}: {
+  projectId: number;
+  projects: ProjectOption[];
+}) {
+  const current =
+    projects.find((p) => p.id === projectId) ??
+    ({ id: projectId, name: 'Project', slug: '' } as ProjectOption);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-lg border bg-sidebar-accent/40 p-2 text-left transition-colors hover:bg-sidebar-accent group-data-[collapsible=icon]:size-8 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:border-0 group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:p-0"
+          />
+        }
+      >
+        <ProjectAvatar name={current.name} />
+        <div className="flex min-w-0 flex-1 flex-col group-data-[collapsible=icon]:hidden">
+          <span className="truncate text-sm font-semibold leading-tight">
+            {current.name}
+          </span>
+          <span className="truncate font-mono text-xs text-muted-foreground leading-tight">
+            {current.slug}
+          </span>
+        </div>
+        <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground group-data-[collapsible=icon]:hidden" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
+            Projects
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {projects.map((p) => (
+            <DropdownMenuItem
+              key={p.id}
+              render={<Link href={`/projects/${p.id}/issues`} />}
+              className="gap-2"
+            >
+              <ProjectAvatar name={p.name} className="size-6 text-xs" />
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-sm">{p.name}</span>
+                <span className="truncate font-mono text-xs text-muted-foreground">
+                  {p.slug}
+                </span>
+              </div>
+              {p.id === projectId && (
+                <Check className="size-4 shrink-0 text-primary" />
+              )}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function CollapseButton() {
+  const { toggleSidebar } = useSidebar();
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          tooltip="Expand"
+          onClick={toggleSidebar}
+          isActive={false}
+          className="h-9 justify-center text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+        >
+          <ChevronsLeft className="transition-transform group-data-[collapsible=icon]:rotate-180" />
+          <span className="group-data-[collapsible=icon]:hidden">Collapse</span>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}
+
+export function ProjectSidebar({
+  projectId,
+  projects,
+  unresolvedCount,
+}: ProjectSidebarProps) {
+  const pathname = usePathname();
+
+  const navItems = [
+    {
+      href: `/projects/${projectId}/issues`,
+      label: 'Issues',
+      icon: AlertCircle,
+      badge: unresolvedCount,
+    },
+    {
+      href: `/projects/${projectId}/performance`,
+      label: 'Performance',
+      icon: Zap,
+    },
+  ];
+
+  return (
+    <TooltipProvider delay={0}>
+      <Sidebar collapsible="icon" className="top-16! h-[calc(100svh-4rem)]!">
+        <SidebarHeader className="p-2">
+          <ProjectSwitcher projectId={projectId} projects={projects} />
+        </SidebarHeader>
+
+        <SidebarContent className="py-1">
+          <SidebarGroup>
+            <SidebarGroupLabel>Navigation</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu className="gap-1.5">
+                {navItems.map((item) => {
+                  const Icon = item.icon;
+                  const isActive = pathname.startsWith(item.href);
+                  const showBadge =
+                    item.badge !== undefined && item.badge > 0;
+
+                  return (
+                    <SidebarMenuItem key={item.href}>
+                      <SidebarMenuButton
+                        // Drive active styling ourselves for the brand-green fill.
+                        isActive={false}
+                        tooltip={item.label}
+                        render={<Link href={item.href} />}
+                        className={cn(
+                          'h-10 gap-3 rounded-lg text-[0.925rem] font-medium group-data-[collapsible=icon]:justify-center',
+                          isActive
+                            ? 'bg-primary! font-semibold text-primary-foreground! shadow-sm hover:bg-primary! hover:text-primary-foreground!'
+                            : 'text-muted-foreground hover:bg-sidebar-accent hover:text-foreground',
+                        )}
+                      >
+                        <Icon />
+                        <span className="group-data-[collapsible=icon]:hidden">
+                          {item.label}
+                        </span>
+                        {showBadge && (
+                          <span
+                            className={cn(
+                              'ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[11px] font-bold tabular-nums group-data-[collapsible=icon]:hidden',
+                              isActive
+                                ? 'bg-primary-foreground/20 text-primary-foreground'
+                                : 'bg-destructive/10 text-destructive',
+                            )}
+                          >
+                            {formatBadge(item.badge!)}
+                          </span>
+                        )}
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+
+        <SidebarFooter>
+          <CollapseButton />
+        </SidebarFooter>
+        <SidebarRail />
+      </Sidebar>
+    </TooltipProvider>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/project-sidebar.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/project-sidebar.tsx
@@ -44,19 +44,19 @@ interface ProjectOption {
 interface ProjectSidebarProps {
   projectId: number;
   projects: ProjectOption[];
-  unresolvedCount: number;
-}
-
-function formatBadge(count: number): string {
-  if (count > 99) return '99+';
-  return String(count);
 }
 
 function initialOf(name: string): string {
   return (name || '?').charAt(0).toUpperCase();
 }
 
-function ProjectAvatar({ name, className }: { name: string; className?: string }) {
+function ProjectAvatar({
+  name,
+  className,
+}: {
+  name: string;
+  className?: string;
+}) {
   return (
     <div
       className={cn(
@@ -151,11 +151,7 @@ function CollapseButton() {
   );
 }
 
-export function ProjectSidebar({
-  projectId,
-  projects,
-  unresolvedCount,
-}: ProjectSidebarProps) {
+export function ProjectSidebar({ projectId, projects }: ProjectSidebarProps) {
   const pathname = usePathname();
 
   const navItems = [
@@ -163,7 +159,6 @@ export function ProjectSidebar({
       href: `/projects/${projectId}/issues`,
       label: 'Issues',
       icon: AlertCircle,
-      badge: unresolvedCount,
     },
     {
       href: `/projects/${projectId}/performance`,
@@ -187,8 +182,6 @@ export function ProjectSidebar({
                 {navItems.map((item) => {
                   const Icon = item.icon;
                   const isActive = pathname.startsWith(item.href);
-                  const showBadge =
-                    item.badge !== undefined && item.badge > 0;
 
                   return (
                     <SidebarMenuItem key={item.href}>
@@ -208,18 +201,6 @@ export function ProjectSidebar({
                         <span className="group-data-[collapsible=icon]:hidden">
                           {item.label}
                         </span>
-                        {showBadge && (
-                          <span
-                            className={cn(
-                              'ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[11px] font-bold tabular-nums group-data-[collapsible=icon]:hidden',
-                              isActive
-                                ? 'bg-primary-foreground/20 text-primary-foreground'
-                                : 'bg-destructive/10 text-destructive',
-                            )}
-                          >
-                            {formatBadge(item.badge!)}
-                          </span>
-                        )}
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                   );

--- a/apps/webview-ui/src/components/ui/sidebar.tsx
+++ b/apps/webview-ui/src/components/ui/sidebar.tsx
@@ -1,0 +1,722 @@
+'use client';
+
+import { mergeProps } from '@base-ui/react/merge-props';
+import { useRender } from '@base-ui/react/use-render';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { PanelLeftIcon } from 'lucide-react';
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
+
+const SIDEBAR_COOKIE_NAME = 'sidebar_state';
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_WIDTH = '16rem';
+const SIDEBAR_WIDTH_MOBILE = '18rem';
+const SIDEBAR_WIDTH_ICON = '3rem';
+const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
+
+type SidebarContextProps = {
+  state: 'expanded' | 'collapsed';
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+};
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error('useSidebar must be used within a SidebarProvider.');
+  }
+
+  return context;
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = React.useState(false);
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen);
+  const open = openProp ?? _open;
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === 'function' ? value(open) : value;
+      if (setOpenProp) {
+        setOpenProp(openState);
+      } else {
+        _setOpen(openState);
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    },
+    [setOpenProp, open],
+  );
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+  }, [isMobile, setOpen, setOpenMobile]);
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [toggleSidebar]);
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? 'expanded' : 'collapsed';
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+  );
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <div
+        data-slot="sidebar-wrapper"
+        style={
+          {
+            '--sidebar-width': SIDEBAR_WIDTH,
+            '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
+            ...style,
+          } as React.CSSProperties
+        }
+        className={cn(
+          'group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </SidebarContext.Provider>
+  );
+}
+
+function Sidebar({
+  side = 'left',
+  variant = 'sidebar',
+  collapsible = 'offcanvas',
+  className,
+  children,
+  dir,
+  ...props
+}: React.ComponentProps<'div'> & {
+  side?: 'left' | 'right';
+  variant?: 'sidebar' | 'floating' | 'inset';
+  collapsible?: 'offcanvas' | 'icon' | 'none';
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+
+  if (collapsible === 'none') {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          'flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          dir={dir}
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === 'collapsed' ? collapsible : ''}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
+          'group-data-[collapsible=offcanvas]:w-0',
+          'group-data-[side=right]:rotate-180',
+          variant === 'floating' || variant === 'inset'
+            ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
+            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        data-side={side}
+        className={cn(
+          'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex',
+          // Adjust the padding for floating and inset variants.
+          variant === 'floating' || variant === 'inset'
+            ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
+            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
+          className,
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon-sm"
+      className={cn(className)}
+      onClick={(event) => {
+        onClick?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        'absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2',
+        'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
+        '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
+        'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar',
+        '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
+        '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        'relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn('h-8 w-full bg-background shadow-none', className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn('flex flex-col gap-2 p-2', className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn('flex flex-col gap-2 p-2', className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn('mx-2 w-auto bg-sidebar-border', className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        'no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn('relative flex w-full min-w-0 flex-col p-2', className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupLabel({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<'div'> & React.ComponentProps<'div'>) {
+  return useRender({
+    defaultTagName: 'div',
+    props: mergeProps<'div'>(
+      {
+        className: cn(
+          'flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+          className,
+        ),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: 'sidebar-group-label',
+      sidebar: 'group-label',
+    },
+  });
+}
+
+function SidebarGroupAction({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<'button'> & React.ComponentProps<'button'>) {
+  return useRender({
+    defaultTagName: 'button',
+    props: mergeProps<'button'>(
+      {
+        className: cn(
+          'absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0',
+          className,
+        ),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: 'sidebar-group-action',
+      sidebar: 'group-action',
+    },
+  });
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn('w-full text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn('flex w-full min-w-0 flex-col gap-1', className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn('group/menu-item relative', className)}
+      {...props}
+    />
+  );
+}
+
+const sidebarMenuButtonVariants = cva(
+  'peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate',
+  {
+    variants: {
+      variant: {
+        default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        outline:
+          'bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]',
+      },
+      size: {
+        default: 'h-8 text-sm',
+        sm: 'h-7 text-xs',
+        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+function SidebarMenuButton({
+  render,
+  isActive = false,
+  variant = 'default',
+  size = 'default',
+  tooltip,
+  className,
+  ...props
+}: useRender.ComponentProps<'button'> &
+  React.ComponentProps<'button'> & {
+    isActive?: boolean;
+    tooltip?: string | React.ComponentProps<typeof TooltipContent>;
+  } & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const { isMobile, state } = useSidebar();
+  const comp = useRender({
+    defaultTagName: 'button',
+    props: mergeProps<'button'>(
+      {
+        className: cn(sidebarMenuButtonVariants({ variant, size }), className),
+      },
+      props,
+    ),
+    render: !tooltip ? render : <TooltipTrigger render={render} />,
+    state: {
+      slot: 'sidebar-menu-button',
+      sidebar: 'menu-button',
+      size,
+      active: isActive,
+    },
+  });
+
+  if (!tooltip) {
+    return comp;
+  }
+
+  if (typeof tooltip === 'string') {
+    tooltip = {
+      children: tooltip,
+    };
+  }
+
+  return (
+    <Tooltip>
+      {comp}
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== 'collapsed' || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  );
+}
+
+function SidebarMenuAction({
+  className,
+  render,
+  showOnHover = false,
+  ...props
+}: useRender.ComponentProps<'button'> &
+  React.ComponentProps<'button'> & {
+    showOnHover?: boolean;
+  }) {
+  return useRender({
+    defaultTagName: 'button',
+    props: mergeProps<'button'>(
+      {
+        className: cn(
+          'absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0',
+          showOnHover &&
+            'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground aria-expanded:opacity-100 md:opacity-0',
+          className,
+        ),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: 'sidebar-menu-action',
+      sidebar: 'menu-action',
+    },
+  });
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        'pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showIcon?: boolean;
+}) {
+  // Random width between 50 to 90%.
+  const [width] = React.useState(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`;
+  });
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn('flex h-8 items-center gap-2 rounded-md px-2', className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            '--skeleton-width': width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<'ul'>) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        'mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<'li'>) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn('group/menu-sub-item relative', className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubButton({
+  render,
+  size = 'md',
+  isActive = false,
+  className,
+  ...props
+}: useRender.ComponentProps<'a'> &
+  React.ComponentProps<'a'> & {
+    size?: 'sm' | 'md';
+    isActive?: boolean;
+  }) {
+  return useRender({
+    defaultTagName: 'a',
+    props: mergeProps<'a'>(
+      {
+        className: cn(
+          'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+          className,
+        ),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: 'sidebar-menu-sub-button',
+      sidebar: 'menu-sub-button',
+      size,
+      active: isActive,
+    },
+  });
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+};

--- a/apps/webview-ui/src/hooks/use-mobile.ts
+++ b/apps/webview-ui/src/hooks/use-mobile.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -83,6 +83,7 @@ export type {
   TestChannelResponse,
   TestIntegrationBody,
   Transaction,
+  TransactionDetail,
   UpdateAlertIntegration,
   UpdateAlertRule,
   UpdateIssueState,

--- a/packages/client/src/resources/transactions.ts
+++ b/packages/client/src/resources/transactions.ts
@@ -1,11 +1,13 @@
 import {
   paginatedResponseSchema,
+  transactionDetailSchema,
   transactionSchema,
 } from '../schemas/index.js';
 import type {
   ListTransactionsOptions,
   PaginatedResponse,
   Transaction,
+  TransactionDetail,
 } from '../types/index.js';
 import { BaseResource } from './base.js';
 
@@ -33,5 +35,20 @@ export class TransactionsResource extends BaseResource {
       .json();
 
     return this.validate(data, paginatedResponseSchema(transactionSchema));
+  }
+
+  /**
+   * Get a single transaction by ID with its full Sentry payload (spans,
+   * contexts.trace, measurements, tags) for the performance detail view.
+   */
+  async get(
+    projectId: number,
+    transactionId: string,
+  ): Promise<TransactionDetail> {
+    const data = await this.http
+      .get(`api/projects/${projectId}/transactions/${transactionId}`)
+      .json();
+
+    return this.validate(data, transactionDetailSchema);
   }
 }

--- a/packages/client/src/schemas/common.ts
+++ b/packages/client/src/schemas/common.ts
@@ -47,9 +47,26 @@ export const issueFilterSchema = z.enum(['open', 'resolved', 'muted', 'all']);
 export const dateTimeSchema = z.string().datetime();
 
 /**
- * UUID v4 string
+ * UUID v4 string (RFC 4122). Use for server-generated ids (row PKs, issue ids)
+ * which are always created with `gen_random_uuid()`.
  */
 export const uuidSchema = z.string().uuid();
+
+/**
+ * Sentry event identifier.
+ *
+ * Sentry event ids are 32 random hex characters — they do NOT carry RFC-4122
+ * version/variant bits. The server stores them in a UUID column and returns
+ * them in canonical dashed form, but a strict `uuid()` check rejects the many
+ * valid ids whose version nibble falls outside 1–8. Accept any hex UUID shape
+ * regardless of version/variant so real SDK payloads validate.
+ */
+export const eventIdSchema = z
+  .string()
+  .regex(
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
+    'Invalid event id',
+  );
 
 /**
  * API error response

--- a/packages/client/src/schemas/event.ts
+++ b/packages/client/src/schemas/event.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
-import { dateTimeSchema, uuidSchema } from './common.js';
+import { dateTimeSchema, eventIdSchema, uuidSchema } from './common.js';
 
 /**
  * Event response schema from list endpoint
  */
 export const eventSchema = z.object({
   id: uuidSchema,
-  event_id: uuidSchema,
+  event_id: eventIdSchema,
   issue_id: uuidSchema.nullable(),
   title: z.string(),
   timestamp: dateTimeSchema,
@@ -22,7 +22,7 @@ export const eventSchema = z.object({
  */
 export const eventDetailSchema = z.object({
   id: uuidSchema,
-  event_id: uuidSchema,
+  event_id: eventIdSchema,
   issue_id: uuidSchema.nullable(),
   title: z.string(),
   timestamp: dateTimeSchema,

--- a/packages/client/src/schemas/transaction.ts
+++ b/packages/client/src/schemas/transaction.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
-import { dateTimeSchema, uuidSchema } from './common.js';
+import { dateTimeSchema, eventIdSchema, uuidSchema } from './common.js';
 
 /**
  * Transaction response schema from list endpoint
  */
 export const transactionSchema = z.object({
   id: uuidSchema,
-  event_id: uuidSchema,
+  event_id: eventIdSchema,
   transaction_name: z.string(),
   timestamp: dateTimeSchema,
   start_timestamp: dateTimeSchema.nullable(),
@@ -15,4 +15,25 @@ export const transactionSchema = z.object({
   environment: z.string(),
   release: z.string(),
   ingested_at: dateTimeSchema,
+});
+
+/**
+ * Transaction detail schema from the detail endpoint.
+ *
+ * Same summary fields as {@link transactionSchema} plus the full Sentry
+ * payload under `data` (spans, contexts.trace, measurements, tags, request,
+ * user) used to render the span waterfall and metrics view.
+ */
+export const transactionDetailSchema = z.object({
+  id: uuidSchema,
+  event_id: eventIdSchema,
+  transaction_name: z.string(),
+  timestamp: dateTimeSchema,
+  start_timestamp: dateTimeSchema.nullable(),
+  duration_ms: z.number().nullable(),
+  platform: z.string(),
+  environment: z.string(),
+  release: z.string(),
+  ingested_at: dateTimeSchema,
+  data: z.record(z.string(), z.any()), // Full Sentry transaction payload
 });

--- a/packages/client/src/types/transaction.ts
+++ b/packages/client/src/types/transaction.ts
@@ -1,7 +1,15 @@
 import type { z } from 'zod';
-import type { transactionSchema } from '../schemas/transaction.js';
+import type {
+  transactionDetailSchema,
+  transactionSchema,
+} from '../schemas/transaction.js';
 
 /**
  * Transaction type inferred from Zod schema
  */
 export type Transaction = z.infer<typeof transactionSchema>;
+
+/**
+ * Transaction detail type (summary fields + full Sentry payload under `data`)
+ */
+export type TransactionDetail = z.infer<typeof transactionDetailSchema>;

--- a/packages/client/tests/integration/transactions.test.ts
+++ b/packages/client/tests/integration/transactions.test.ts
@@ -35,4 +35,24 @@ describe('TransactionsResource', () => {
       expect(result).toBeDefined();
     });
   });
+
+  describe('get()', () => {
+    it('returns a transaction detail with full payload', async () => {
+      const txn = await client.transactions.get(
+        1,
+        'a1b2c3d4-e89b-12d3-a456-426614174000',
+      );
+
+      expect(txn.transaction_name).toBe('/api/checkout');
+      expect(txn.duration_ms).toBe(1000.0);
+      expect(txn.data.spans).toHaveLength(1);
+      expect(txn.data.spans[0].op).toBe('db');
+      expect(txn.data.contexts.trace.span_id).toBe('root');
+      expect(txn.data.measurements.lcp.value).toBe(1200.0);
+    });
+
+    it('throws NotFoundError for a missing transaction', async () => {
+      await expect(client.transactions.get(1, 'missing')).rejects.toThrow();
+    });
+  });
 });

--- a/packages/client/tests/mocks/handlers.ts
+++ b/packages/client/tests/mocks/handlers.ts
@@ -1164,6 +1164,46 @@ export const handlers = [
     });
   }),
 
+  // Transactions — get single transaction detail
+  http.get(
+    `${BASE_URL}/api/projects/:projectId/transactions/:transactionId`,
+    ({ params }) => {
+      if (params.transactionId === 'missing') {
+        return HttpResponse.json({ error: 'not found' }, { status: 404 });
+      }
+      return HttpResponse.json({
+        id: 'a1b2c3d4-e89b-12d3-a456-426614174000',
+        event_id: 'b2c3d4e5-e89b-12d3-a456-426614174000',
+        transaction_name: '/api/checkout',
+        timestamp: '2026-06-18T12:00:00.000Z',
+        start_timestamp: '2026-06-18T11:59:59.000Z',
+        duration_ms: 1000.0,
+        platform: 'javascript',
+        environment: 'production',
+        release: '1.0.0',
+        ingested_at: '2026-06-18T12:00:01.000Z',
+        data: {
+          transaction: '/api/checkout',
+          contexts: {
+            trace: { trace_id: 'abc', span_id: 'root', op: 'http.server' },
+          },
+          spans: [
+            {
+              span_id: 'child1',
+              parent_span_id: 'root',
+              op: 'db',
+              description: 'SELECT 1',
+              start_timestamp: 1.0,
+              timestamp: 1.5,
+            },
+          ],
+          measurements: { lcp: { value: 1200.0, unit: 'millisecond' } },
+          tags: { browser: 'Chrome' },
+        },
+      });
+    },
+  ),
+
   // Source Maps — list source maps for project
   http.get(
     `${BASE_URL}/api/0/projects/:orgSlug/:projectSlug/files/source-maps/`,

--- a/packages/client/tests/unit/schemas.test.ts
+++ b/packages/client/tests/unit/schemas.test.ts
@@ -7,6 +7,7 @@ import {
   issueSchema,
   paginatedResponseSchema,
   projectSchema,
+  transactionSchema,
 } from '../../src/schemas/index.js';
 
 describe('Schema Validation', () => {
@@ -205,6 +206,49 @@ describe('Schema Validation', () => {
       };
 
       const result = eventDetailSchema.safeParse(event);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('transactionSchema', () => {
+    const base = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      event_id: '550e8400-e29b-41d4-a716-446655440000',
+      transaction_name: '/api/checkout',
+      timestamp: '2026-06-18T12:00:00.000Z',
+      start_timestamp: '2026-06-18T11:59:59.000Z',
+      duration_ms: 1000,
+      platform: 'node',
+      environment: 'production',
+      release: '1.0.0',
+      ingested_at: '2026-06-18T12:00:01.000Z',
+    };
+
+    it('accepts a Sentry event_id whose version nibble is not RFC 1-8', () => {
+      // Sentry event ids are 32 random hex chars; once formatted as a UUID the
+      // version nibble (here `9`) and variant are arbitrary. The list must not
+      // be rejected wholesale because of this. Regression for empty Performance.
+      const result = transactionSchema.safeParse({
+        ...base,
+        event_id: '5bda3e1e-66be-9c41-bf8a-1c97848e1092',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('still rejects a malformed event_id', () => {
+      const result = transactionSchema.safeParse({
+        ...base,
+        event_id: 'not-a-uuid',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts a null start_timestamp and duration', () => {
+      const result = transactionSchema.safeParse({
+        ...base,
+        start_timestamp: null,
+        duration_ms: null,
+      });
       expect(result.success).toBe(true);
     });
   });

--- a/packages/mcp/src/tools/transactions.ts
+++ b/packages/mcp/src/tools/transactions.ts
@@ -31,4 +31,29 @@ export function registerTransactionTools(
       }
     },
   );
+
+  server.registerTool(
+    'get_transaction',
+    {
+      description:
+        'Get a single Rustrak transaction by ID with its full Sentry payload: the span list (waterfall), trace context, measurements (web vitals), tags, request and user. Use the transaction id from list_transactions.',
+      inputSchema: {
+        project_id: z.number().int().describe('Project ID'),
+        transaction_id: z.string().describe('Transaction ID (UUID)'),
+      },
+    },
+    async ({ project_id, transaction_id }) => {
+      try {
+        const result = await client.transactions.get(
+          project_id,
+          transaction_id,
+        );
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return toMcpError(err);
+      }
+    },
+  );
 }

--- a/packages/mcp/tests/integration/server.test.ts
+++ b/packages/mcp/tests/integration/server.test.ts
@@ -38,8 +38,9 @@ const EXPECTED_TOOLS = [
   'get_server_version',
   // Sessions (1)
   'get_release_health',
-  // Transactions (1)
+  // Transactions (2)
   'list_transactions',
+  'get_transaction',
 ] as const;
 
 describe('MCP server integration', () => {
@@ -64,7 +65,7 @@ describe('MCP server integration', () => {
       members: { list: vi.fn(), upsert: vi.fn(), remove: vi.fn() },
       health: { getVersion: vi.fn() },
       sessions: { stats: vi.fn() },
-      transactions: { list: vi.fn() },
+      transactions: { list: vi.fn(), get: vi.fn() },
     };
     testEnv = await createTestEnv(mockClient);
   });

--- a/packages/mcp/tests/tools/transactions.test.ts
+++ b/packages/mcp/tests/tools/transactions.test.ts
@@ -24,10 +24,20 @@ describe('transaction tools', () => {
     has_more: false,
   };
 
+  const mockTransactionDetail = {
+    ...mockTransactionPage.items[0],
+    data: {
+      spans: [{ span_id: 'child1', parent_span_id: 'root', op: 'db' }],
+      contexts: { trace: { span_id: 'root', op: 'http.server' } },
+      measurements: { lcp: { value: 1200.0, unit: 'millisecond' } },
+    },
+  };
+
   beforeEach(async () => {
     mockClient = {
       transactions: {
         list: vi.fn(),
+        get: vi.fn(),
       },
     };
     testEnv = await createTestEnv(mockClient);
@@ -77,6 +87,41 @@ describe('transaction tools', () => {
       const result = await callTool({
         name: 'list_transactions',
         arguments: { project_id: 1 },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Unexpected error');
+    });
+  });
+
+  describe('get_transaction', () => {
+    it('returns full transaction detail', async () => {
+      mockClient.transactions.get.mockResolvedValue(mockTransactionDetail);
+
+      const result = await callTool({
+        name: 'get_transaction',
+        arguments: {
+          project_id: 1,
+          transaction_id: 'a1b2c3d4-e89b-12d3-a456-426614174000',
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.transaction_name).toBe('/api/checkout');
+      expect(parsed.data.spans[0].op).toBe('db');
+      expect(mockClient.transactions.get).toHaveBeenCalledWith(
+        1,
+        'a1b2c3d4-e89b-12d3-a456-426614174000',
+      );
+    });
+
+    it('returns error content on API failure', async () => {
+      mockClient.transactions.get.mockRejectedValue(new Error('API error'));
+
+      const result = await callTool({
+        name: 'get_transaction',
+        arguments: { project_id: 1, transaction_id: 'x' },
       });
 
       expect(result.isError).toBe(true);

--- a/packages/test-sentry/send-transactions.ts
+++ b/packages/test-sentry/send-transactions.ts
@@ -1,0 +1,278 @@
+/**
+ * Sends rich performance transactions to a local Rustrak server.
+ *
+ * Builds the Sentry envelope by hand (instead of going through @sentry/node)
+ * so each transaction carries a realistic span tree, web-vital measurements,
+ * tags, request and user context — exactly the fields the Performance detail
+ * page renders. The SDK path with `defaultIntegrations: false` emits empty
+ * `spans`, which is why the detail view looked bare.
+ *
+ * Usage: tsx packages/test-sentry/send-transactions.ts [dsn]
+ * Default DSN: http://0cabb1ed-295f-4cf6-b414-11220caa8eb6@localhost:8080/1
+ */
+import { randomBytes } from 'node:crypto';
+
+const DSN =
+  process.argv[2] ??
+  'http://0cabb1ed-295f-4cf6-b414-11220caa8eb6@localhost:8080/1';
+
+const url = new URL(DSN);
+const SENTRY_KEY = url.username;
+const PROJECT_ID = url.pathname.replace(/\//g, '');
+const ENDPOINT = `${url.protocol}//${url.host}/api/${PROJECT_ID}/envelope/`;
+
+const hex = (bytes: number) => randomBytes(bytes).toString('hex');
+
+interface SpanDef {
+  op: string;
+  description: string;
+  /** ms from the transaction start. */
+  offsetMs: number;
+  durationMs: number;
+  /** Index of the parent span in the list, or omit for the root segment. */
+  parent?: number;
+  status?: string;
+  data?: Record<string, unknown>;
+}
+
+interface TxnDef {
+  name: string;
+  op: string;
+  platform: string;
+  durationMs: number;
+  status?: string;
+  spans: SpanDef[];
+  measurements?: Record<string, { value: number; unit: string }>;
+  tags?: Record<string, string>;
+  request?: Record<string, unknown>;
+  user?: Record<string, unknown>;
+}
+
+function buildEnvelope(txn: TxnDef): string {
+  const eventId = hex(16);
+  const traceId = hex(16);
+  const rootSpanId = hex(8);
+  const end = Date.now() / 1000;
+  const start = end - txn.durationMs / 1000;
+
+  // First pass: assign a span_id to every span so children can reference parents.
+  const ids = txn.spans.map(() => hex(8));
+
+  const spans = txn.spans.map((s, i) => ({
+    span_id: ids[i],
+    parent_span_id: s.parent != null ? ids[s.parent] : rootSpanId,
+    trace_id: traceId,
+    op: s.op,
+    description: s.description,
+    start_timestamp: start + s.offsetMs / 1000,
+    timestamp: start + (s.offsetMs + s.durationMs) / 1000,
+    status: s.status ?? 'ok',
+    ...(s.data ? { data: s.data } : {}),
+  }));
+
+  const event = {
+    event_id: eventId,
+    type: 'transaction',
+    transaction: txn.name,
+    platform: txn.platform,
+    environment: 'production',
+    release: '1.0.0',
+    server_name: 'web-1',
+    start_timestamp: start,
+    timestamp: end,
+    contexts: {
+      trace: {
+        trace_id: traceId,
+        span_id: rootSpanId,
+        op: txn.op,
+        status: txn.status ?? 'ok',
+      },
+    },
+    spans,
+    ...(txn.measurements ? { measurements: txn.measurements } : {}),
+    ...(txn.tags ? { tags: txn.tags } : {}),
+    ...(txn.request ? { request: txn.request } : {}),
+    ...(txn.user ? { user: txn.user } : {}),
+    sdk: { name: 'rustrak.test-sentry', version: '1.0.0' },
+  };
+
+  const payload = JSON.stringify(event);
+  const header = JSON.stringify({ event_id: eventId, dsn: DSN });
+  const itemHeader = JSON.stringify({
+    type: 'transaction',
+    length: Buffer.byteLength(payload),
+  });
+  return `${header}\n${itemHeader}\n${payload}\n`;
+}
+
+const TRANSACTIONS: TxnDef[] = [
+  {
+    name: 'POST /api/checkout',
+    op: 'http.server',
+    platform: 'node',
+    durationMs: 1240,
+    tags: { browser: 'Chrome', region: 'eu-west-1' },
+    request: {
+      method: 'POST',
+      url: 'https://shop.example.com/api/checkout',
+    },
+    user: { id: '42', email: 'buyer@example.com' },
+    spans: [
+      {
+        op: 'db.query',
+        description: 'SELECT * FROM carts WHERE id = $1',
+        offsetMs: 15,
+        durationMs: 120,
+        data: { 'db.system': 'postgresql' },
+      },
+      {
+        op: 'http.client',
+        description: 'POST https://api.stripe.com/v1/charges',
+        offsetMs: 150,
+        durationMs: 830,
+        data: { 'http.response.status_code': 200 },
+      },
+      {
+        op: 'db.query',
+        description: 'INSERT INTO orders (...) VALUES (...)',
+        offsetMs: 150,
+        durationMs: 60,
+        parent: 1,
+      },
+      {
+        op: 'cache.put',
+        description: 'redis SET order:9182',
+        offsetMs: 1000,
+        durationMs: 12,
+      },
+      {
+        op: 'db.query',
+        description: 'UPDATE carts SET status = $1',
+        offsetMs: 1020,
+        durationMs: 200,
+      },
+    ],
+  },
+  {
+    name: 'GET /checkout',
+    op: 'pageload',
+    platform: 'javascript',
+    durationMs: 2350,
+    tags: { browser: 'Firefox', 'device.family': 'Desktop' },
+    measurements: {
+      lcp: { value: 1850, unit: 'millisecond' },
+      fcp: { value: 920, unit: 'millisecond' },
+      ttfb: { value: 340, unit: 'millisecond' },
+      cls: { value: 0.04, unit: 'none' },
+      inp: { value: 180, unit: 'millisecond' },
+    },
+    spans: [
+      {
+        op: 'browser.request',
+        description: 'Initial document request',
+        offsetMs: 0,
+        durationMs: 340,
+      },
+      {
+        op: 'resource.script',
+        description: '/_next/static/chunks/main.js',
+        offsetMs: 360,
+        durationMs: 480,
+      },
+      {
+        op: 'resource.css',
+        description: '/_next/static/css/app.css',
+        offsetMs: 360,
+        durationMs: 120,
+      },
+      {
+        op: 'ui.render',
+        description: 'Hydrate <CheckoutPage>',
+        offsetMs: 900,
+        durationMs: 1300,
+      },
+    ],
+  },
+  {
+    name: 'POST /api/payments/process',
+    op: 'http.server',
+    platform: 'node',
+    durationMs: 3420,
+    status: 'internal_error',
+    tags: { region: 'us-east-1' },
+    spans: [
+      {
+        op: 'db.query',
+        description: 'SELECT * FROM payment_methods WHERE user_id = $1',
+        offsetMs: 20,
+        durationMs: 90,
+      },
+      {
+        op: 'http.client',
+        description: 'POST https://gateway.bank.example/charge',
+        offsetMs: 120,
+        durationMs: 3200,
+        status: 'deadline_exceeded',
+        data: { 'http.response.status_code': 504 },
+      },
+    ],
+  },
+  {
+    name: 'GET /api/products',
+    op: 'http.server',
+    platform: 'python',
+    durationMs: 88,
+    spans: [
+      {
+        op: 'db.query',
+        description: 'SELECT * FROM products LIMIT 50',
+        offsetMs: 10,
+        durationMs: 64,
+      },
+    ],
+  },
+  {
+    name: 'GET /api/search',
+    op: 'http.server',
+    platform: 'node',
+    durationMs: 520,
+    spans: [
+      {
+        op: 'cache.get',
+        description: 'redis GET search:popular',
+        offsetMs: 5,
+        durationMs: 8,
+      },
+      {
+        op: 'db.query',
+        description: 'SELECT ... FROM products WHERE name ILIKE $1',
+        offsetMs: 20,
+        durationMs: 470,
+      },
+    ],
+  },
+];
+
+async function main() {
+  console.log(`Sending ${TRANSACTIONS.length} transactions to ${ENDPOINT}\n`);
+
+  for (const txn of TRANSACTIONS) {
+    const body = buildEnvelope(txn);
+    const res = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-sentry-envelope',
+        'X-Sentry-Auth': `Sentry sentry_key=${SENTRY_KEY}, sentry_version=7`,
+      },
+      body,
+    });
+    const status = res.ok ? '✓' : '✗';
+    console.log(
+      `${status} ${txn.name} — ${txn.durationMs}ms, ${txn.spans.length} spans (HTTP ${res.status})`,
+    );
+  }
+
+  console.log('\nDone. Open the Performance tab and click a transaction.');
+}
+
+main().catch(console.error);


### PR DESCRIPTION
Builds the full performance-monitoring experience on top of the transaction ingestion (#132) and client/MCP wiring (#133).

> Stacked on #133. GitHub will retarget this to \`main\` once #133 merges. Code only — no \`.md\` / docs included by request.

## Server
- **New endpoint** \`GET /api/projects/{id}/transactions/{txn_id}\` → summary fields + the **full Sentry payload** (spans, \`contexts.trace\`, measurements, tags, request, user) read straight from \`events.data\`. Scoped to \`event_type='transaction'\` so an error-event id 404s. No migration — the payload was already stored. openapi.json regenerated.
- **Processor fix:** \`TransactionProcessor\` now denormalizes \`platform\`/\`environment\`/\`release\`/\`sdk\`/\`server_name\` from the payload instead of writing empty strings (the list/detail views were showing blanks).

## Client (\`@rustrak/client\`)
- \`transactions.get(projectId, txnId)\` + \`transactionDetail\` schema/type.
- **Sentry-compat fix:** added a lenient \`eventIdSchema\` — Sentry event ids are 32 random hex chars and don't carry RFC-4122 version/variant bits, so the strict \`uuid()\` check was rejecting valid ids and failing the *entire* list validation. Applied to \`event_id\` on the transaction **and** event schemas.

## MCP (\`@rustrak/mcp\`)
- \`get_transaction\` tool exposing the detail (span tree, web vitals, tags).

## WebView UI
- **Sidebar** rebuilt on the shadcn primitive: a Dokploy-style **project switcher** (dropdown) in the header, brand-green active nav items, collapse-to-icon rail, mobile sheet. **Overview page removed**; \`/projects/[id]\` redirects to issues.
- **Performance list** mirrors the issues layout — clickable rows → detail, duration bars, richer columns.
- **Transaction detail page**: metrics header, web-vitals card (good/meh/poor), **span waterfall** (tree by \`parent_span_id\`, colored by op), and tags/request/user panels.

## test-sentry
- \`send-transactions.ts\` now builds rich envelopes by hand (span trees, measurements, tags) so the detail view has realistic data.

## Verification
- Server: \`cargo test\` + clippy clean (transaction detail tests added).
- Client: 335 tests (regression test for the Sentry-style event id).
- MCP: typecheck + tests green (get_transaction).
- WebView UI: \`tsc\` clean + \`next build\` OK.