### PR TITLE
fix(mcp): emit package declarations

### DIFF
--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   format: ['esm'],
   target: 'node18',
   shims: true,
-  dts: false,
+  dts: true,
   clean: true,
   splitting: false,
   sourcemap: false,


### PR DESCRIPTION
## Summary
- enable declaration generation for the `@rustrak/mcp` tsup build
- add a patch changeset for the package metadata fix

## Why
`@rustrak/mcp` publishes `types` and export metadata pointing to `./dist/index.d.ts`, but the current packed package only includes `dist/index.js`. TypeScript consumers that import the package report TS7016 because the advertised declaration file is missing.

## Validation
- `corepack pnpm --filter @rustrak/mcp... build`
- `corepack pnpm --filter @rustrak/mcp typecheck`
- `corepack pnpm --filter @rustrak/mcp test`
- `git diff --check`
- packed `packages/mcp` and installed the tarball in a clean project; `npx tsc index.ts --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --skipLibCheck` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enabled TypeScript declaration file generation for the MCP package to ensure type definitions are properly included in distributions.

**Chores**
- Added release notes for upcoming patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->