### PR TITLE
feat: replace cursor-based pagination with offset-based pagination

### DIFF
--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3240,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -2518,7 +2518,7 @@
         "tags": [
           "Transactions"
         ],
-        "summary": "GET /api/projects/{project_id}/transactions\nLists transactions for a project with cursor-based pagination (newest first).",
+        "summary": "GET /api/projects/{project_id}/transactions\nLists transactions for a project with offset-based pagination (newest first).",
         "operationId": "list_transactions",
         "parameters": [
           {
@@ -2532,15 +2532,26 @@
             }
           },
           {
-            "name": "cursor",
+            "name": "page",
             "in": "query",
-            "description": "Pagination cursor (opaque, from previous response)",
+            "description": "Page number (1-indexed, default: 1)",
             "required": false,
             "schema": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "Items per page (default: 20, max: 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "maximum": 100,
+              "minimum": 1
             }
           }
         ],
@@ -2551,15 +2562,15 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "description": "Paginated response wrapper (cursor-based)",
+                  "description": "Offset-based paginated response wrapper",
                   "required": [
                     "items",
-                    "has_more"
+                    "total_count",
+                    "page",
+                    "per_page",
+                    "total_pages"
                   ],
                   "properties": {
-                    "has_more": {
-                      "type": "boolean"
-                    },
                     "items": {
                       "type": "array",
                       "items": {
@@ -2622,11 +2633,21 @@
                         }
                       }
                     },
-                    "next_cursor": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                    "page": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "per_page": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "total_count": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "total_pages": {
+                      "type": "integer",
+                      "format": "int64"
                     }
                   }
                 }

--- a/apps/server/src/pagination/mod.rs
+++ b/apps/server/src/pagination/mod.rs
@@ -162,6 +162,21 @@ pub enum IssueFilter {
     All,
 }
 
+/// Query parameters for listing transactions (offset-based)
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::IntoParams))]
+pub struct ListTransactionsQuery {
+    /// Page number (1-indexed, default: 1)
+    #[serde(default = "default_page")]
+    #[cfg_attr(feature = "openapi", param(minimum = 1))]
+    pub page: i64,
+
+    /// Items per page (default: 20, max: 100)
+    #[serde(default = "default_per_page")]
+    #[cfg_attr(feature = "openapi", param(minimum = 1, maximum = 100))]
+    pub per_page: i64,
+}
+
 /// Query parameters for listing events
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::IntoParams))]

--- a/apps/server/src/routes/transactions.rs
+++ b/apps/server/src/routes/transactions.rs
@@ -47,15 +47,17 @@ pub async fn list_transactions(
     )
     .await?;
 
+    let page = query.page.max(1);
+    let per_page = query.per_page.clamp(1, 100);
+
     let (transactions, total_count) =
-        TransactionService::list_offset(pool.get_ref(), project_id, query.page, query.per_page)
-            .await?;
+        TransactionService::list_offset(pool.get_ref(), project_id, page, per_page).await?;
 
     Ok(HttpResponse::Ok().json(OffsetPaginatedResponse::new(
         transactions,
         total_count,
-        query.page,
-        query.per_page,
+        page,
+        per_page,
     )))
 }
 

--- a/apps/server/src/routes/transactions.rs
+++ b/apps/server/src/routes/transactions.rs
@@ -6,20 +6,12 @@ use crate::db::DbPool;
 use crate::error::AppResult;
 #[cfg(feature = "openapi")]
 use crate::models::{TransactionDetailResponse, TransactionResponse};
-use crate::pagination::{PaginatedResponse, TransactionCursor, PAGE_SIZE};
+use crate::pagination::{ListTransactionsQuery, OffsetPaginatedResponse};
 use crate::services::access::{self, Action};
 use crate::services::TransactionService;
 
 #[cfg(feature = "openapi")]
 use utoipa::OpenApi;
-
-/// Query parameters for listing transactions
-#[derive(Debug, serde::Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::IntoParams))]
-pub struct ListTransactionsQuery {
-    /// Pagination cursor (opaque, from previous response)
-    pub cursor: Option<String>,
-}
 
 #[cfg_attr(feature = "openapi", utoipa::path(
     get,
@@ -30,14 +22,14 @@ pub struct ListTransactionsQuery {
         ListTransactionsQuery,
     ),
     responses(
-        (status = 200, description = "Paginated transaction list", body = inline(crate::pagination::PaginatedResponse<TransactionResponse>)),
+        (status = 200, description = "Paginated transaction list", body = inline(crate::pagination::OffsetPaginatedResponse<TransactionResponse>)),
         (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
         (status = 404, description = "Not found", body = crate::error::ErrorResponse),
     ),
     security(("bearer_auth" = [])),
 ))]
 /// GET /api/projects/{project_id}/transactions
-/// Lists transactions for a project with cursor-based pagination (newest first).
+/// Lists transactions for a project with offset-based pagination (newest first).
 pub async fn list_transactions(
     pool: web::Data<DbPool>,
     path: web::Path<i32>,
@@ -55,26 +47,16 @@ pub async fn list_transactions(
     )
     .await?;
 
-    let cursor = query
-        .cursor
-        .as_ref()
-        .map(|c| TransactionCursor::decode(c))
-        .transpose()?;
-
-    let (transactions, has_more) =
-        TransactionService::list_paginated(pool.get_ref(), project_id, cursor.as_ref(), PAGE_SIZE)
+    let (transactions, total_count) =
+        TransactionService::list_offset(pool.get_ref(), project_id, query.page, query.per_page)
             .await?;
 
-    let next_cursor = if has_more {
-        transactions
-            .last()
-            .map(|last| TransactionCursor::new(last.ingested_at, last.id).encode())
-            .transpose()?
-    } else {
-        None
-    };
-
-    Ok(HttpResponse::Ok().json(PaginatedResponse::new(transactions, next_cursor, has_more)))
+    Ok(HttpResponse::Ok().json(OffsetPaginatedResponse::new(
+        transactions,
+        total_count,
+        query.page,
+        query.per_page,
+    )))
 }
 
 #[cfg_attr(feature = "openapi", utoipa::path(

--- a/apps/server/src/services/transaction.rs
+++ b/apps/server/src/services/transaction.rs
@@ -5,64 +5,51 @@ use uuid::Uuid;
 use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
 use crate::models::{TransactionDetailResponse, TransactionResponse};
-use crate::pagination::TransactionCursor;
 
 pub struct TransactionService;
 
 impl TransactionService {
-    /// Lists transactions for a project with cursor-based pagination (newest first).
+    /// Lists transactions for a project with offset-based pagination (newest first).
     ///
     /// Transactions are events with event_type = 'transaction'. They have no issue_id.
-    /// Ordered by ingested_at DESC; cursor encodes the last ingested_at boundary.
-    pub async fn list_paginated(
+    /// Ordered by ingested_at DESC.
+    /// Returns (transactions, total_count).
+    pub async fn list_offset(
         pool: &DbPool,
         project_id: i32,
-        cursor: Option<&TransactionCursor>,
-        limit: i64,
-    ) -> AppResult<(Vec<TransactionResponse>, bool)> {
-        let fetch_limit = limit + 1;
+        page: i64,
+        per_page: i64,
+    ) -> AppResult<(Vec<TransactionResponse>, i64)> {
+        let offset = (page - 1) * per_page;
 
-        let rows = if let Some(c) = cursor {
-            sqlx::query(
-                r#"
-                SELECT id, event_id, "transaction" AS transaction_name,
-                       timestamp, start_timestamp,
-                       platform, environment, release, ingested_at
-                FROM events
-                WHERE project_id = $1
-                  AND event_type = 'transaction'
-                  AND (ingested_at < $3 OR (ingested_at = $3 AND id < $4))
-                ORDER BY ingested_at DESC, id DESC
-                LIMIT $2
-                "#,
-            )
-            .bind(project_id)
-            .bind(fetch_limit)
-            .bind(c.last_ingested_at)
-            .bind(c.last_id)
-            .fetch_all(pool)
-            .await?
-        } else {
-            sqlx::query(
-                r#"
-                SELECT id, event_id, "transaction" AS transaction_name,
-                       timestamp, start_timestamp,
-                       platform, environment, release, ingested_at
-                FROM events
-                WHERE project_id = $1
-                  AND event_type = 'transaction'
-                ORDER BY ingested_at DESC, id DESC
-                LIMIT $2
-                "#,
-            )
-            .bind(project_id)
-            .bind(fetch_limit)
-            .fetch_all(pool)
-            .await?
-        };
+        let total_count: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*) FROM events
+            WHERE project_id = $1
+              AND event_type = 'transaction'
+            "#,
+        )
+        .bind(project_id)
+        .fetch_one(pool)
+        .await?;
 
-        let has_more = rows.len() > limit as usize;
-        let rows: Vec<_> = rows.into_iter().take(limit as usize).collect();
+        let rows = sqlx::query(
+            r#"
+            SELECT id, event_id, "transaction" AS transaction_name,
+                   timestamp, start_timestamp,
+                   platform, environment, release, ingested_at
+            FROM events
+            WHERE project_id = $1
+              AND event_type = 'transaction'
+            ORDER BY ingested_at DESC, id DESC
+            LIMIT $2 OFFSET $3
+            "#,
+        )
+        .bind(project_id)
+        .bind(per_page)
+        .bind(offset)
+        .fetch_all(pool)
+        .await?;
 
         let transactions: Vec<TransactionResponse> = rows
             .iter()
@@ -86,7 +73,7 @@ impl TransactionService {
             })
             .collect();
 
-        Ok((transactions, has_more))
+        Ok((transactions, total_count.0))
     }
 
     /// Fetches a single transaction by its primary key, scoped to a project.

--- a/apps/server/src/services/transaction.rs
+++ b/apps/server/src/services/transaction.rs
@@ -20,6 +20,7 @@ impl TransactionService {
         page: i64,
         per_page: i64,
     ) -> AppResult<(Vec<TransactionResponse>, i64)> {
+        let per_page = per_page.clamp(1, 100);
         let offset = (page - 1) * per_page;
 
         let total_count: (i64,) = sqlx::query_as(

--- a/apps/server/tests/integration/transactions_api_test.rs
+++ b/apps/server/tests/integration/transactions_api_test.rs
@@ -259,7 +259,9 @@ async fn test_list_transactions_returns_empty_when_none_exist() {
 
     let body: Value = test::read_body_json(resp).await;
     assert_eq!(body["items"], json!([]));
-    assert_eq!(body["has_more"], false);
+    assert_eq!(body["total_count"], 0);
+    assert_eq!(body["page"], 1);
+    assert_eq!(body["total_pages"], 0);
 }
 
 #[actix_web::test]
@@ -290,7 +292,8 @@ async fn test_list_transactions_returns_stored_transactions() {
     assert_eq!(resp.status(), 200);
 
     let body: Value = test::read_body_json(resp).await;
-    assert_eq!(body["has_more"], false);
+    assert_eq!(body["total_count"], 2);
+    assert_eq!(body["total_pages"], 1);
     let items = body["items"].as_array().expect("items is array");
     assert_eq!(items.len(), 2);
     // Newest first

--- a/apps/server/tests/unit/transaction_processor_test.rs
+++ b/apps/server/tests/unit/transaction_processor_test.rs
@@ -155,7 +155,6 @@ mod level2 {
 
     #[tokio::test]
     async fn test_transaction_pagination_no_skip_on_equal_timestamps() {
-        use rustrak::pagination::TransactionCursor;
         use rustrak::services::TransactionService;
 
         let db = TestDb::new().await;
@@ -187,15 +186,12 @@ mod level2 {
             TransactionProcessor.process(payload, &ctx).await.unwrap();
         }
 
-        let (page1, has_more) = TransactionService::list_paginated(&db.pool, project.id, None, 2)
+        let (page1, _) = TransactionService::list_offset(&db.pool, project.id, 1, 2)
             .await
             .unwrap();
         assert_eq!(page1.len(), 2);
-        assert!(has_more);
 
-        let last = page1.last().unwrap();
-        let cursor = TransactionCursor::new(last.ingested_at, last.id);
-        let (page2, _) = TransactionService::list_paginated(&db.pool, project.id, Some(&cursor), 2)
+        let (page2, _) = TransactionService::list_offset(&db.pool, project.id, 2, 2)
             .await
             .unwrap();
 

--- a/apps/webview-ui/src/actions/transactions.ts
+++ b/apps/webview-ui/src/actions/transactions.ts
@@ -2,7 +2,7 @@
 
 import type {
   ListTransactionsOptions,
-  PaginatedResponse,
+  OffsetPaginatedResponse,
   Transaction,
   TransactionDetail,
 } from '@rustrak/client';
@@ -11,7 +11,7 @@ import { createClient } from '@/lib/rustrak';
 export async function listTransactions(
   projectId: number,
   options?: ListTransactionsOptions,
-): Promise<PaginatedResponse<Transaction>> {
+): Promise<OffsetPaginatedResponse<Transaction>> {
   const client = await createClient();
   return client.transactions.list(projectId, options);
 }

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/page.tsx
@@ -32,7 +32,7 @@ export default async function PerformancePage({
   const { id } = await params;
   const { page = '1' } = await searchParams;
   const projectId = parseInt(id, 10);
-  const currentPage = parseInt(page, 10) || 1;
+  const currentPage = Math.max(1, parseInt(page, 10) || 1);
 
   const project = await getProject(projectId);
 

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/page.tsx
@@ -6,6 +6,7 @@ import { TransactionsList } from './transactions-list';
 
 interface PerformancePageProps {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ page?: string }>;
 }
 
 export async function generateMetadata({
@@ -26,9 +27,12 @@ export async function generateMetadata({
 
 export default async function PerformancePage({
   params,
+  searchParams,
 }: PerformancePageProps) {
   const { id } = await params;
+  const { page = '1' } = await searchParams;
   const projectId = parseInt(id, 10);
+  const currentPage = parseInt(page, 10) || 1;
 
   const project = await getProject(projectId);
 
@@ -36,9 +40,15 @@ export default async function PerformancePage({
     notFound();
   }
 
-  const transactions = await listTransactions(projectId).catch(() => ({
+  const transactions = await listTransactions(projectId, {
+    page: currentPage,
+    per_page: 20,
+  }).catch(() => ({
     items: [],
-    has_more: false,
+    total_count: 0,
+    page: 1,
+    per_page: 20,
+    total_pages: 0,
   }));
 
   return (
@@ -49,10 +59,11 @@ export default async function PerformancePage({
           Transaction traces for {project.name}
         </p>
       </div>
-      <div className="flex-1 overflow-auto max-w-400 w-full mx-auto px-4 md:px-8 py-4 md:py-6">
+      <div className="flex-1 overflow-hidden max-w-400 w-full mx-auto px-4 md:px-8 py-4 md:py-6">
         <TransactionsList
           projectId={projectId}
           initialTransactions={transactions}
+          currentPage={currentPage}
         />
       </div>
     </div>

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/transactions-list.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/transactions-list.tsx
@@ -60,7 +60,9 @@ export function TransactionsList({
   } = initialTransactions;
 
   const handlePageChange = (page: number) => {
-    router.push(`/projects/${projectId}/performance?page=${page}`);
+    startTransition(() => {
+      router.push(`/projects/${projectId}/performance?page=${page}`);
+    });
   };
 
   const startIndex = (currentPage - 1) * per_page + 1;
@@ -168,10 +170,11 @@ export function TransactionsList({
             <Button
               variant="outline"
               size="sm"
+              aria-label="Go to previous page"
               onClick={() => handlePageChange(currentPage - 1)}
               disabled={currentPage <= 1 || isPending}
             >
-              <ChevronLeft className="size-4" />
+              <ChevronLeft className="size-4" aria-hidden="true" />
             </Button>
 
             <span className="text-sm px-2">
@@ -181,10 +184,11 @@ export function TransactionsList({
             <Button
               variant="outline"
               size="sm"
+              aria-label="Go to next page"
               onClick={() => handlePageChange(currentPage + 1)}
               disabled={currentPage >= total_pages || isPending}
             >
-              <ChevronRight className="size-4" />
+              <ChevronRight className="size-4" aria-hidden="true" />
             </Button>
           </div>
         </div>

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/transactions-list.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/transactions-list.tsx
@@ -1,18 +1,19 @@
 'use client';
 
-import type { PaginatedResponse, Transaction } from '@rustrak/client';
+import type { OffsetPaginatedResponse, Transaction } from '@rustrak/client';
 import { formatDistanceToNow } from 'date-fns';
-import { Loader2, Zap } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Zap } from 'lucide-react';
 import Link from 'next/link';
-import { useState, useTransition } from 'react';
-import { listTransactions } from '@/actions/transactions';
+import { useRouter } from 'next/navigation';
+import { useTransition } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 interface TransactionsListProps {
   projectId: number;
-  initialTransactions: PaginatedResponse<Transaction>;
+  initialTransactions: OffsetPaginatedResponse<Transaction>;
+  currentPage: number;
 }
 
 function formatDuration(ms: number | null): string {
@@ -21,7 +22,6 @@ function formatDuration(ms: number | null): string {
   return `${(ms / 1000).toFixed(2)}s`;
 }
 
-// Severity thresholds mirror Sentry's apdex-ish buckets: <1s good, <3s warn.
 function durationTone(ms: number | null): {
   text: string;
   bar: string;
@@ -47,25 +47,26 @@ function durationTone(ms: number | null): {
 export function TransactionsList({
   projectId,
   initialTransactions,
+  currentPage,
 }: TransactionsListProps) {
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const [items, setItems] = useState<Transaction[]>(initialTransactions.items);
-  const [cursor, setCursor] = useState<string | undefined>(
-    initialTransactions.next_cursor,
-  );
-  const [hasMore, setHasMore] = useState<boolean>(initialTransactions.has_more);
 
-  function loadMore() {
-    if (!cursor) return;
-    startTransition(async () => {
-      const next = await listTransactions(projectId, { cursor });
-      setItems((prev) => [...prev, ...next.items]);
-      setCursor(next.next_cursor);
-      setHasMore(next.has_more);
-    });
-  }
+  const {
+    items: transactions,
+    total_count,
+    total_pages,
+    per_page,
+  } = initialTransactions;
 
-  if (items.length === 0) {
+  const handlePageChange = (page: number) => {
+    router.push(`/projects/${projectId}/performance?page=${page}`);
+  };
+
+  const startIndex = (currentPage - 1) * per_page + 1;
+  const endIndex = Math.min(currentPage * per_page, total_count);
+
+  if (transactions.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center min-h-100 text-center">
         <Zap className="size-12 text-muted-foreground/30 mb-4" />
@@ -81,7 +82,6 @@ export function TransactionsList({
   return (
     <div className="flex flex-col h-full">
       <div className="flex-1 overflow-hidden flex flex-col border rounded-lg">
-        {/* Header */}
         <div className="shrink-0 flex items-center gap-4 px-4 py-3 bg-muted/50 border-b">
           <span className="text-xs font-bold uppercase tracking-widest text-muted-foreground flex-1">
             Transaction
@@ -94,9 +94,8 @@ export function TransactionsList({
           </span>
         </div>
 
-        {/* Scrollable rows */}
         <div className="flex-1 overflow-auto">
-          {items.map((txn) => {
+          {transactions.map((txn) => {
             const tone = durationTone(txn.duration_ms);
             return (
               <Link
@@ -124,14 +123,12 @@ export function TransactionsList({
                         {txn.release}
                       </span>
                     )}
-                    {/* Mobile-only duration + time */}
                     <span className={cn('sm:hidden font-medium', tone.text)}>
                       {formatDuration(txn.duration_ms)}
                     </span>
                   </div>
                 </div>
 
-                {/* Duration with bar */}
                 <div className="hidden sm:flex flex-col items-end w-40 gap-1">
                   <span
                     className={cn('font-mono text-sm font-medium', tone.text)}
@@ -159,29 +156,39 @@ export function TransactionsList({
         </div>
       </div>
 
-      {/* Footer */}
-      <div className="shrink-0 flex items-center justify-between gap-2 pt-4">
-        <span className="text-sm text-muted-foreground">
-          {items.length} transaction{items.length === 1 ? '' : 's'} loaded
-        </span>
-        {hasMore && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={loadMore}
-            disabled={isPending}
-          >
-            {isPending ? (
-              <>
-                <Loader2 className="mr-2 size-4 animate-spin" />
-                Loading…
-              </>
-            ) : (
-              'Load more'
-            )}
-          </Button>
-        )}
-      </div>
+      {total_pages > 0 && (
+        <div className="shrink-0 flex flex-col sm:flex-row items-center justify-between gap-2 pt-4">
+          <span className="text-sm text-muted-foreground">
+            {total_count > 0
+              ? `Showing ${startIndex}-${endIndex} of ${total_count}`
+              : 'No results'}
+          </span>
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage <= 1 || isPending}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+
+            <span className="text-sm px-2">
+              Page {currentPage} of {total_pages}
+            </span>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage >= total_pages || isPending}
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/resources/transactions.ts
+++ b/packages/client/src/resources/transactions.ts
@@ -1,11 +1,11 @@
 import {
-  paginatedResponseSchema,
+  offsetPaginatedResponseSchema,
   transactionDetailSchema,
   transactionSchema,
 } from '../schemas/index.js';
 import type {
   ListTransactionsOptions,
-  PaginatedResponse,
+  OffsetPaginatedResponse,
   Transaction,
   TransactionDetail,
 } from '../types/index.js';
@@ -16,16 +16,19 @@ import { BaseResource } from './base.js';
  */
 export class TransactionsResource extends BaseResource {
   /**
-   * List transactions for a project with cursor-based pagination (newest first)
+   * List transactions for a project with offset-based pagination (newest first)
    */
   async list(
     projectId: number,
     options?: ListTransactionsOptions,
-  ): Promise<PaginatedResponse<Transaction>> {
+  ): Promise<OffsetPaginatedResponse<Transaction>> {
     const searchParams: Record<string, string> = {};
 
-    if (options?.cursor) {
-      searchParams.cursor = options.cursor;
+    if (options?.page) {
+      searchParams.page = String(options.page);
+    }
+    if (options?.per_page) {
+      searchParams.per_page = String(options.per_page);
     }
 
     const data = await this.http
@@ -34,7 +37,10 @@ export class TransactionsResource extends BaseResource {
       })
       .json();
 
-    return this.validate(data, paginatedResponseSchema(transactionSchema));
+    return this.validate(
+      data,
+      offsetPaginatedResponseSchema(transactionSchema),
+    );
   }
 
   /**

--- a/packages/client/src/types/common.ts
+++ b/packages/client/src/types/common.ts
@@ -75,8 +75,9 @@ export interface ListProjectsOptions {
 }
 
 /**
- * List options for transactions endpoint (cursor-based pagination)
+ * List options for transactions endpoint (offset-based pagination)
  */
 export interface ListTransactionsOptions {
-  cursor?: string;
+  page?: number;
+  per_page?: number;
 }

--- a/packages/client/tests/integration/transactions.test.ts
+++ b/packages/client/tests/integration/transactions.test.ts
@@ -11,8 +11,9 @@ describe('TransactionsResource', () => {
     it('returns paginated transaction list', async () => {
       const result = await client.transactions.list(1);
 
-      expect(result.has_more).toBe(false);
+      expect(result.total_count).toBe(1);
       expect(result.items).toHaveLength(1);
+      expect(result.total_pages).toBe(1);
     });
 
     it('returns transaction with correct shape', async () => {
@@ -28,9 +29,10 @@ describe('TransactionsResource', () => {
       expect(txn.start_timestamp).toBe('2026-06-18T11:59:59.000Z');
     });
 
-    it('accepts cursor option', async () => {
+    it('accepts pagination options', async () => {
       const result = await client.transactions.list(1, {
-        cursor: 'some-cursor',
+        page: 1,
+        per_page: 10,
       });
       expect(result).toBeDefined();
     });

--- a/packages/client/tests/mocks/handlers.ts
+++ b/packages/client/tests/mocks/handlers.ts
@@ -1160,7 +1160,10 @@ export const handlers = [
           ingested_at: '2026-06-18T12:00:01.000Z',
         },
       ],
-      has_more: false,
+      total_count: 1,
+      page: 1,
+      per_page: 20,
+      total_pages: 1,
     });
   }),
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transaction listing now uses page-number navigation with `page` and `per_page` (instead of load-more).

* **Refactor**
  * Updated the pagination contract across the API, client, and UI to offset-based responses, including `total_count`, `total_pages`, `page`, and `per_page` (replacing cursor fields like `has_more`).

* **Tests**
  * Updated API/client and unit tests to match the new pagination metadata and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->