### PR TITLE
fix: support clipboard copying over HTTP

### DIFF
--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/event-details.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/event-details.tsx
@@ -4,7 +4,9 @@ import type { EventDetail } from '@rustrak/client';
 import { format } from 'date-fns';
 import { Check, Copy } from 'lucide-react';
 import { useState } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { copyToClipboard } from '@/lib/clipboard';
 
 interface EventDetailsProps {
   event: EventDetail;
@@ -31,7 +33,14 @@ function DetailRow({
     typeof value === 'boolean' ? (value ? 'Yes' : 'No') : String(value);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(displayValue);
+    if (!(await copyToClipboard(displayValue))) {
+      toast.info('Clipboard unavailable', {
+        description:
+          'Select the value and copy it manually, or access Rustrak over HTTPS.',
+      });
+      return;
+    }
+
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/event-tags.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/event-tags.tsx
@@ -2,7 +2,9 @@
 
 import { AlertCircle, Check, Copy } from 'lucide-react';
 import { useState } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { copyToClipboard } from '@/lib/clipboard';
 
 interface EventTagsProps {
   tags: Record<string, string> | undefined;
@@ -17,7 +19,14 @@ function TagRow({ tagKey, tagValue }: TagRowProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(`${tagKey}:${tagValue}`);
+    if (!(await copyToClipboard(`${tagKey}:${tagValue}`))) {
+      toast.info('Clipboard unavailable', {
+        description:
+          'Select the value and copy it manually, or access Rustrak over HTTPS.',
+      });
+      return;
+    }
+
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/raw-json.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/raw-json.tsx
@@ -2,7 +2,9 @@
 
 import { Check, Copy } from 'lucide-react';
 import { useState } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { copyToClipboard } from '@/lib/clipboard';
 
 interface RawJsonProps {
   data: Record<string, unknown>;
@@ -13,7 +15,14 @@ export function RawJson({ data }: RawJsonProps) {
   const jsonString = JSON.stringify(data, null, 2);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(jsonString);
+    if (!(await copyToClipboard(jsonString))) {
+      toast.info('Clipboard unavailable', {
+        description:
+          'Select the JSON and copy it manually, or access Rustrak over HTTPS.',
+      });
+      return;
+    }
+
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/apps/webview-ui/src/app/(main)/projects/[id]/project-settings-dialog.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/project-settings-dialog.tsx
@@ -19,6 +19,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
+import { copyToClipboard } from '@/lib/clipboard';
 
 interface ProjectSettingsDialogProps {
   project: Project;
@@ -74,7 +75,14 @@ export function ProjectSettingsDialog({ project }: ProjectSettingsDialogProps) {
   }, [isDark, Highlighter]);
 
   const copyDsn = async () => {
-    await navigator.clipboard.writeText(project.dsn);
+    if (!(await copyToClipboard(project.dsn))) {
+      toast.info('Clipboard unavailable', {
+        description:
+          'Select the DSN and copy it manually, or access Rustrak over HTTPS.',
+      });
+      return;
+    }
+
     setCopiedDsn(true);
     setTimeout(() => setCopiedDsn(false), 2000);
   };
@@ -86,7 +94,14 @@ Sentry.init({
 });`;
 
   const copyCode = async () => {
-    await navigator.clipboard.writeText(codeExample);
+    if (!(await copyToClipboard(codeExample))) {
+      toast.info('Clipboard unavailable', {
+        description:
+          'Select the example and copy it manually, or access Rustrak over HTTPS.',
+      });
+      return;
+    }
+
     setCopiedCode(true);
     setTimeout(() => setCopiedCode(false), 2000);
   };

--- a/apps/webview-ui/src/app/(main)/settings/tokens/tokens-list.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/tokens/tokens-list.tsx
@@ -8,6 +8,7 @@ import { useState, useTransition } from 'react';
 import { toast } from 'sonner';
 import { createToken, deleteToken } from '@/actions/tokens';
 import { Button } from '@/components/ui/button';
+import { copyToClipboard } from '@/lib/clipboard';
 
 const TOKEN_DESCRIPTION_MAX_LENGTH = 200;
 
@@ -96,11 +97,18 @@ export function TokensList({ initialTokens }: TokensListProps) {
   };
 
   const copyToken = async () => {
-    if (newToken) {
-      await navigator.clipboard.writeText(newToken);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+    if (!newToken) return;
+
+    if (!(await copyToClipboard(newToken))) {
+      toast.info('Clipboard unavailable', {
+        description:
+          'Select the token and copy it manually, or access Rustrak over HTTPS.',
+      });
+      return;
     }
+
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (

--- a/apps/webview-ui/src/lib/clipboard.ts
+++ b/apps/webview-ui/src/lib/clipboard.ts
@@ -18,6 +18,8 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   textarea.value = text;
   textarea.readOnly = true;
   textarea.style.position = 'fixed';
+  textarea.style.top = '0';
+  textarea.style.left = '0';
   textarea.style.opacity = '0';
   textarea.style.pointerEvents = 'none';
 
@@ -26,6 +28,8 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   textarea.setSelectionRange(0, textarea.value.length);
 
   try {
+    // execCommand's boolean result varies by browser, but it is the best
+    // available signal when the Clipboard API is unavailable over HTTP.
     return document.execCommand('copy');
   } catch {
     return false;

--- a/apps/webview-ui/src/lib/clipboard.ts
+++ b/apps/webview-ui/src/lib/clipboard.ts
@@ -1,9 +1,8 @@
 /**
  * Copies text to the clipboard, returning whether it succeeded.
  *
- * `navigator.clipboard` is only available in secure contexts (HTTPS or
- * localhost). Self-hosted Rustrak may run over plain HTTP, so this never throws
- * — callers can fall back to showing the text for manual copying.
+ * Uses the Clipboard API in secure contexts and falls back to the legacy
+ * selection-based copy command for plain HTTP deployments.
  */
 export async function copyToClipboard(text: string): Promise<boolean> {
   try {
@@ -12,7 +11,25 @@ export async function copyToClipboard(text: string): Promise<boolean> {
       return true;
     }
   } catch {
-    // fall through
+    // Fall back when browser permissions reject the Clipboard API.
   }
-  return false;
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.readOnly = true;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  textarea.style.pointerEvents = 'none';
+
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  try {
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
 }


### PR DESCRIPTION
## Summary

Fix clipboard copying for self-hosted Rustrak instances accessed over plain HTTP.

Browsers restrict `navigator.clipboard` to secure contexts such as HTTPS and localhost. This caused the DSN and JavaScript example copy buttons to throw an error on LAN/homelab deployments.

Closes #145.

## Changes

- Use the Clipboard API when available.
- Fall back to `document.execCommand('copy')` on insecure HTTP origins.
- Use the shared clipboard helper in Project Settings.
- Show manual-copy guidance when both methods fail.
- Document the correct Cargo command for PostgreSQL development.

## Testing

- Tested through a plain HTTP LAN address.
- Confirmed DSN and code-example copying works without console errors.
- Ran TypeScript type checking.
- Ran Biome formatting and checks.
- Confirmed the documented PostgreSQL server command starts successfully.

## Reproduction

1. Access Rustrak through HTTP, such as `http://192.168.1.6:3003`.
2. Open a project’s settings.
3. Click the copy button beside the DSN or JavaScript example.
4. Confirm the content is copied and no clipboard exception occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-to-clipboard behavior across project details, event info, raw JSON, tags, and tokens by using a shared clipboard helper.
  * Added robust fallback copying when the modern clipboard flow is unavailable or fails, including a legacy selection-based approach.
  * When clipboard copy isn’t possible, users now get an informational toast prompting manual copy or HTTPS access instead of silently failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->