### PR TITLE
fix: correct storage counts, robust cleanup, and streamed storage page

### DIFF
--- a/apps/server/src/services/storage.rs
+++ b/apps/server/src/services/storage.rs
@@ -157,10 +157,11 @@ impl StorageService {
         .execute(&mut *tx)
         .await?;
 
-        // Keep the denormalized event counters in sync BEFORE deleting the rows —
-        // same contract as IssueService::delete. We subtract the exact number of
-        // events being removed (correlated COUNT), so the counters can't underflow
-        // in a consistent DB. Correlated subqueries keep this dialect-portable.
+        // Keep the per-issue event counters in sync BEFORE deleting the rows. The
+        // `e.issue_id = issues.id` join means only events that belong to an issue
+        // (errors) are ever subtracted — transaction/log rows carry a NULL
+        // issue_id and never touched these counters, so they can't underflow them.
+        // Correlated subqueries keep this dialect-portable.
         sqlx::query(
             r#"
             UPDATE issues SET
@@ -193,33 +194,26 @@ impl StorageService {
         .execute(&mut *tx)
         .await?;
 
+        // Rebuild each in-scope project's counters from the (now-updated) issue
+        // counters instead of subtracting an event delta. The project counter is
+        // by definition the sum of its issues' counts, so this is always correct
+        // and can never underflow — no event_type/issue_id predicate needed, and
+        // it heals any pre-existing drift. The DELETE below still removes every
+        // old row (transactions included); those rows simply never had a counter.
         sqlx::query(
             r#"
             UPDATE projects SET
-                stored_event_count = stored_event_count - (
-                    SELECT COUNT(*) FROM events e
-                    WHERE e.project_id = projects.id AND e.ingested_at < $1
-                      AND ($2 IS NULL OR e.project_id = $3)
+                stored_event_count = (
+                    SELECT COALESCE(SUM(i.stored_event_count), 0)
+                    FROM issues i WHERE i.project_id = projects.id
                 ),
-                digested_event_count = digested_event_count - (
-                    SELECT COUNT(*) FROM events e
-                    WHERE e.project_id = projects.id AND e.ingested_at < $4
-                      AND ($5 IS NULL OR e.project_id = $6)
+                digested_event_count = (
+                    SELECT COALESCE(SUM(i.digested_event_count), 0)
+                    FROM issues i WHERE i.project_id = projects.id
                 )
-            WHERE EXISTS (
-                SELECT 1 FROM events e
-                WHERE e.project_id = projects.id AND e.ingested_at < $7
-                  AND ($8 IS NULL OR e.project_id = $9)
-            )
+            WHERE ($1 IS NULL OR projects.id = $2)
             "#,
         )
-        .bind(cutoff)
-        .bind(project_id)
-        .bind(project_id)
-        .bind(cutoff)
-        .bind(project_id)
-        .bind(project_id)
-        .bind(cutoff)
         .bind(project_id)
         .bind(project_id)
         .execute(&mut *tx)

--- a/apps/server/tests/unit/storage_test.rs
+++ b/apps/server/tests/unit/storage_test.rs
@@ -129,6 +129,46 @@ async fn seed_event_at(
     .unwrap();
 }
 
+/// Seeds an issue-less event row of an arbitrary `event_type` directly into the
+/// `events` table (NULL `issue_id`/`grouping_id`) stamped at `ingested_at`. This
+/// is the shape of non-error rows: legacy `transaction` rows stranded from before
+/// the dedicated table, or future types like `log`. None of them ever
+/// incremented a counter.
+async fn seed_issueless_event_at(
+    pool: &rustrak::db::DbPool,
+    project_id: i32,
+    event_type: &str,
+    ingested_at: chrono::DateTime<Utc>,
+) {
+    let now = ingested_at;
+    sqlx::query(
+        "INSERT INTO events \
+         (id, event_id, project_id, data, timestamp, ingested_at, digested_at, digest_order, event_type) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+    )
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(project_id)
+    .bind(serde_json::json!({ "event_type": event_type }))
+    .bind(now)
+    .bind(now)
+    .bind(now)
+    .bind(1_i32)
+    .bind(event_type)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// Convenience: the legacy `transaction`-in-`events` shape.
+async fn seed_legacy_transaction_event_at(
+    pool: &rustrak::db::DbPool,
+    project_id: i32,
+    ingested_at: chrono::DateTime<Utc>,
+) {
+    seed_issueless_event_at(pool, project_id, "transaction", ingested_at).await;
+}
+
 /// Seeds one transaction (stamped at `ingested_at`) plus `span_count` spans
 /// cascaded under it.
 async fn seed_transaction_with_spans_at(
@@ -394,6 +434,127 @@ async fn test_execute_cleanup_decrements_project_event_counters() {
 }
 
 #[tokio::test]
+async fn test_execute_cleanup_purges_legacy_transaction_events_without_underflowing_counters() {
+    // Legacy `event_type='transaction'` rows never incremented the project
+    // counters. A cleanup that catches them must still physically purge the rows
+    // while leaving the project's error-event counters correct (the counters are
+    // rebuilt from the surviving issues, so deleting issue-less rows can't drive
+    // them negative).
+    let db = TestDb::new().await;
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "tx-underflow".to_string(),
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let old = Utc::now() - chrono::Duration::days(60);
+    seed_event(&db.pool, project.id).await; // one recent error event, survives
+    seed_legacy_transaction_event_at(&db.pool, project.id, old).await;
+    seed_legacy_transaction_event_at(&db.pool, project.id, old).await;
+
+    // Counter reflects the single error event the digest path would have counted.
+    sqlx::query(
+        "UPDATE projects SET stored_event_count = 1, digested_event_count = 1 WHERE id = $1",
+    )
+    .bind(project.id)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+
+    StorageService::execute_cleanup(&db.pool, 30, None)
+        .await
+        .unwrap();
+
+    let (stored, digested): (i32, i32) = sqlx::query_as(
+        "SELECT stored_event_count, digested_event_count FROM projects WHERE id = $1",
+    )
+    .bind(project.id)
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        stored, 1,
+        "error-event counter untouched by transaction purge"
+    );
+    assert_eq!(digested, 1);
+
+    // The legacy transaction rows are gone; the error event remains.
+    let tx_left: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE event_type = 'transaction'")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        tx_left, 0,
+        "old legacy transaction events physically purged"
+    );
+
+    let summary = StorageService::global_summary(&db.pool).await.unwrap();
+    assert_eq!(summary.events_count, 1, "the error event survives");
+}
+
+#[tokio::test]
+async fn test_execute_cleanup_deletes_every_old_row_regardless_of_type() {
+    // The user-facing contract: a cleanup deletes EVERYTHING older than the cutoff
+    // with no exceptions — errors and legacy transaction rows alike — and the
+    // surviving project counter still equals the surviving error events.
+    let db = TestDb::new().await;
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "delete-all".to_string(),
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let old = Utc::now() - chrono::Duration::days(60);
+    let now = Utc::now();
+    seed_event_at(&db.pool, project.id, old).await; // old error → deleted
+    seed_event_at(&db.pool, project.id, now).await; // recent error → survives
+    seed_legacy_transaction_event_at(&db.pool, project.id, old).await; // deleted
+    seed_legacy_transaction_event_at(&db.pool, project.id, old).await; // deleted
+
+    // Two error events were counted by the digest path.
+    sqlx::query(
+        "UPDATE projects SET stored_event_count = 2, digested_event_count = 2 WHERE id = $1",
+    )
+    .bind(project.id)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+
+    StorageService::execute_cleanup(&db.pool, 30, None)
+        .await
+        .unwrap();
+
+    // Every old row gone (1 error + 2 transactions); only the recent error remains.
+    let total_events: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        total_events, 1,
+        "all old rows deleted, recent error survives"
+    );
+
+    let (stored, digested): (i32, i32) = sqlx::query_as(
+        "SELECT stored_event_count, digested_event_count FROM projects WHERE id = $1",
+    )
+    .bind(project.id)
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(stored, 1, "counter tracks the one surviving error event");
+    assert_eq!(digested, 1);
+}
+
+#[tokio::test]
 async fn test_execute_cleanup_scoped_to_project_spares_other_projects() {
     // Safety guard: a project-scoped purge must never reach into a sibling
     // project's data, no matter how old that data is.
@@ -436,6 +597,42 @@ async fn test_execute_cleanup_scoped_to_project_spares_other_projects() {
     assert_eq!(b.events_count, 1, "sibling project untouched");
     assert_eq!(b.transactions_count, 1);
     assert_eq!(b.spans_count, 1);
+}
+
+#[tokio::test]
+async fn test_storage_event_count_reflects_every_stored_event_row() {
+    // The storage page shows the truth of what's on disk: every `events` row
+    // counts, no exceptions — errors, future types (e.g. `log`), and legacy
+    // `transaction` rows alike. Admins must see the real total so they know
+    // there's data to reclaim; a cleanup then deletes it all by date.
+    let db = TestDb::new().await;
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "mixed-types".to_string(),
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    seed_event(&db.pool, project.id).await; // error event (has an issue)
+    seed_issueless_event_at(&db.pool, project.id, "log", Utc::now()).await;
+    seed_legacy_transaction_event_at(&db.pool, project.id, Utc::now()).await;
+    seed_legacy_transaction_event_at(&db.pool, project.id, Utc::now()).await;
+
+    let summary = StorageService::global_summary(&db.pool).await.unwrap();
+    assert_eq!(
+        summary.events_count, 4,
+        "every stored event row counts: error + log + 2 transactions"
+    );
+
+    let rows = StorageService::by_project(&db.pool).await.unwrap();
+    let p = rows.iter().find(|r| r.project_id == project.id).unwrap();
+    assert_eq!(
+        p.events_count, 4,
+        "per-project count reflects all stored event rows"
+    );
 }
 
 #[tokio::test]

--- a/apps/webview-ui/src/app/(main)/settings/storage/page.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/storage/page.tsx
@@ -1,6 +1,8 @@
 import { Database, FileCode2, Layers, ListTree, ShieldX } from 'lucide-react';
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 import { getCurrentUser } from '@/actions/auth';
+import { getProjects } from '@/actions/projects';
 import { getStorageProjects, getStorageSummary } from '@/actions/storage';
 import {
   Card,
@@ -20,6 +22,11 @@ import {
 import { formatBytes } from '@/lib/utils';
 import { SourceMapGc } from './source-map-gc';
 import { StorageCleanup } from './storage-cleanup';
+import {
+  CleanupSkeleton,
+  ProjectsTableSkeleton,
+  SummaryCardsSkeleton,
+} from './storage-skeletons';
 
 export const metadata: Metadata = {
   title: 'Storage | Rustrak',
@@ -39,32 +46,12 @@ function PageHeader() {
   );
 }
 
-export default async function StoragePage() {
-  const user = await getCurrentUser();
-
-  // Guard: storage usage and cleanup are instance-admin only.
-  if (user?.role !== 'admin') {
-    return (
-      <>
-        <PageHeader />
-        <Card className="border-dashed">
-          <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-            <ShieldX className="size-12 text-muted-foreground/50 mb-4" />
-            <p className="font-semibold">Not authorized</p>
-            <p className="text-muted-foreground mt-1 text-sm max-w-sm">
-              Only instance administrators can view storage usage and run
-              cleanups. Contact an admin if you need access.
-            </p>
-          </CardContent>
-        </Card>
-      </>
-    );
-  }
-
-  const [summary, projects] = await Promise.all([
-    getStorageSummary(),
-    getStorageProjects(),
-  ]);
+/**
+ * Overview cards. Owns its own (heavy) summary query so it can stream in behind
+ * a skeleton without blocking the rest of the page.
+ */
+async function SummaryCards() {
+  const summary = await getStorageSummary();
 
   const cards = [
     {
@@ -94,101 +81,152 @@ export default async function StoragePage() {
   ];
 
   return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+      {cards.map((card) => {
+        const Icon = card.icon;
+        return (
+          <Card key={card.label} size="sm">
+            <CardContent>
+              <div className="flex items-center gap-1.5 text-muted-foreground mb-1">
+                <Icon className="size-3.5" />
+                <span className="text-[11px] font-semibold uppercase tracking-wide">
+                  {card.label}
+                </span>
+              </div>
+              <p className="text-xl font-extrabold tracking-tight leading-tight">
+                {card.value}
+              </p>
+              <p className="text-muted-foreground mt-0.5 text-xs">{card.sub}</p>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Per-project breakdown table. Owns the heavy per-project aggregation query and
+ * streams in independently of the cards above.
+ */
+async function ProjectsTable() {
+  const projects = await getStorageProjects();
+
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle>By project</CardTitle>
+        <CardDescription>
+          Counts and estimated weight of the data each project holds
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Project</TableHead>
+              <TableHead className="text-right">Events</TableHead>
+              <TableHead className="text-right">Transactions</TableHead>
+              <TableHead className="text-right">Spans</TableHead>
+              <TableHead className="text-right">Source maps</TableHead>
+              <TableHead className="text-right">Est. size</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {projects.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="text-center text-muted-foreground py-8"
+                >
+                  No projects yet.
+                </TableCell>
+              </TableRow>
+            ) : (
+              projects.map((p) => (
+                <TableRow key={p.project_id}>
+                  <TableCell className="font-medium">
+                    {p.project_name}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {p.events_count.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {p.transactions_count.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {p.spans_count.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {p.source_maps_count.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {formatBytes(p.estimated_bytes)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Cleanup panel. Uses the lightweight projects list (id + name) for its scope
+ * selector instead of waiting on the heavy per-project storage aggregation, so
+ * it can stream in early.
+ */
+async function CleanupPanel() {
+  const { items } = await getProjects({ per_page: 100 });
+
+  return (
+    <StorageCleanup projects={items.map((p) => ({ id: p.id, name: p.name }))} />
+  );
+}
+
+export default async function StoragePage() {
+  const user = await getCurrentUser();
+
+  // Guard: storage usage and cleanup are instance-admin only.
+  if (user?.role !== 'admin') {
+    return (
+      <>
+        <PageHeader />
+        <Card className="border-dashed">
+          <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+            <ShieldX className="size-12 text-muted-foreground/50 mb-4" />
+            <p className="font-semibold">Not authorized</p>
+            <p className="text-muted-foreground mt-1 text-sm max-w-sm">
+              Only instance administrators can view storage usage and run
+              cleanups. Contact an admin if you need access.
+            </p>
+          </CardContent>
+        </Card>
+      </>
+    );
+  }
+
+  // The page shell + header render immediately. Each data-heavy section owns its
+  // own query inside a Suspense boundary, so they stream in independently behind
+  // skeletons instead of the whole page blocking on a single await.
+  return (
     <>
       <PageHeader />
 
-      {/* Overview cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-        {cards.map((card) => {
-          const Icon = card.icon;
-          return (
-            <Card key={card.label} size="sm">
-              <CardContent>
-                <div className="flex items-center gap-1.5 text-muted-foreground mb-1">
-                  <Icon className="size-3.5" />
-                  <span className="text-[11px] font-semibold uppercase tracking-wide">
-                    {card.label}
-                  </span>
-                </div>
-                <p className="text-xl font-extrabold tracking-tight leading-tight">
-                  {card.value}
-                </p>
-                <p className="text-muted-foreground mt-0.5 text-xs">
-                  {card.sub}
-                </p>
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+      <Suspense fallback={<SummaryCardsSkeleton />}>
+        <SummaryCards />
+      </Suspense>
 
-      {/* Per-project breakdown */}
-      <Card className="mb-6">
-        <CardHeader>
-          <CardTitle>By project</CardTitle>
-          <CardDescription>
-            Counts and estimated weight of the data each project holds
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Project</TableHead>
-                <TableHead className="text-right">Events</TableHead>
-                <TableHead className="text-right">Transactions</TableHead>
-                <TableHead className="text-right">Spans</TableHead>
-                <TableHead className="text-right">Source maps</TableHead>
-                <TableHead className="text-right">Est. size</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {projects.length === 0 ? (
-                <TableRow>
-                  <TableCell
-                    colSpan={6}
-                    className="text-center text-muted-foreground py-8"
-                  >
-                    No projects yet.
-                  </TableCell>
-                </TableRow>
-              ) : (
-                projects.map((p) => (
-                  <TableRow key={p.project_id}>
-                    <TableCell className="font-medium">
-                      {p.project_name}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {p.events_count.toLocaleString()}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {p.transactions_count.toLocaleString()}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {p.spans_count.toLocaleString()}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {p.source_maps_count.toLocaleString()}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {formatBytes(p.estimated_bytes)}
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
+      <Suspense fallback={<ProjectsTableSkeleton />}>
+        <ProjectsTable />
+      </Suspense>
 
-      {/* Cleanup panels */}
       <div className="space-y-6">
-        <StorageCleanup
-          projects={projects.map((p) => ({
-            id: p.project_id,
-            name: p.project_name,
-          }))}
-        />
+        <Suspense fallback={<CleanupSkeleton />}>
+          <CleanupPanel />
+        </Suspense>
         <SourceMapGc />
       </div>
     </>

--- a/apps/webview-ui/src/app/(main)/settings/storage/page.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/storage/page.tsx
@@ -179,7 +179,9 @@ async function ProjectsTable() {
  * it can stream in early.
  */
 async function CleanupPanel() {
-  const { items } = await getProjects({ per_page: 100 });
+  // Fetch every project in one shot (the API applies no hard page-size cap) so
+  // the scope selector never silently drops projects.
+  const { items } = await getProjects({ per_page: 10000 });
 
   return (
     <StorageCleanup projects={items.map((p) => ({ id: p.id, name: p.name }))} />

--- a/apps/webview-ui/src/app/(main)/settings/storage/storage-cleanup.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/storage/storage-cleanup.tsx
@@ -41,6 +41,7 @@ interface StorageCleanupProps {
 }
 
 const PERIODS = [
+  { value: '1', label: 'Older than 1 day' },
   { value: '7', label: 'Older than 7 days' },
   { value: '30', label: 'Older than 30 days' },
   { value: '60', label: 'Older than 60 days' },

--- a/apps/webview-ui/src/app/(main)/settings/storage/storage-skeletons.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/storage/storage-skeletons.tsx
@@ -1,0 +1,67 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/** Fallback for the four overview cards while the storage summary loads. */
+export function SummaryCardsSkeleton() {
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Card key={i} size="sm">
+          <CardContent>
+            <div className="flex items-center gap-1.5 mb-1">
+              <Skeleton className="size-3.5 rounded" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+            <Skeleton className="h-6 w-24 mt-1" />
+            <Skeleton className="h-3 w-16 mt-1.5" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+/** Fallback for the per-project breakdown table while it loads. */
+export function ProjectsTableSkeleton() {
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <Skeleton className="h-5 w-28" />
+        <Skeleton className="h-4 w-72 mt-1" />
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-4 w-12 ml-auto" />
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-16" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Fallback for the cleanup panel while the project list loads. */
+export function CleanupSkeleton() {
+  return (
+    <Card>
+      <CardHeader>
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-4 w-80 mt-1" />
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Skeleton className="h-9 w-full sm:w-56" />
+          <Skeleton className="h-9 w-full sm:w-56" />
+          <Skeleton className="h-9 w-24" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Problem

The **Settings → Storage** page disagreed with the home page on event counts, and was slow + blank on entry.

Root cause (confirmed against production): the `events` table holds **legacy `event_type='transaction'` rows** (NULL `issue_id`) stranded from before transactions moved to their own `transactions` table. On one prod instance that's ~62k rows. The storage page counted them via raw `COUNT(*)` while the home page's denormalized counters only track error events — hence the mismatch (e.g. 42,378 vs 2,768 for one project). The cleanup also over-decremented project counters when purging those issue-less rows, which could drive them **negative**.

## Backend (`apps/server`)

- **Cleanup deletes every old row by date, no exceptions** — errors and legacy transaction rows alike (the physical `DELETE` never filtered by type).
- **Project counters are rebuilt from the surviving issue counters** instead of subtracting an event delta. A project's count is by definition the sum of its issues', so this is always correct, can never underflow, and heals any pre-existing drift — with no `event_type`/`issue_id` predicate. Per-issue counters stay join-based (issue-less rows never touched them).
- **Storage counts report the real `COUNT(*)`** of every stored event row so admins see exactly what's on disk to reclaim.

## Frontend (`apps/webview-ui`)

- **Streamed storage page** (Next.js App Router pattern): the shell + header render immediately; each heavy section (summary cards, per-project table, cleanup panel) is an async Server Component owning its own query inside a `<Suspense>` boundary with a **skeleton** fallback — instead of one blocking `await Promise.all` that left the page blank for seconds.
- **Added "Older than 1 day"** retention option (backend already accepts `older_than_days >= 1`).

## Tests

- 209 unit + 6 integration green; clippy clean; compiles on both sqlite and postgres.
- New: counts reflect every stored row; cleanup deletes all old rows regardless of type; counters stay correct (no underflow) when purging legacy transaction rows.

## Notes

- No data migration and no manual prod delete — admins purge legacy rows from the UI by picking a short retention window.
- No API schema changes (no OpenAPI regen needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storage settings now load sections independently, showing skeleton placeholders while data is fetched for a smoother experience.
  * Added an “Older than 1 day” cleanup retention option.

* **Bug Fixes**
  * Cleanup now keeps storage counters accurate after removing old records, including legacy transaction entries.
  * Storage totals now reflect all saved event rows consistently across overall and per-project views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->