### PR TITLE
feat(storage): granular data-type selection for cleanup

### DIFF
--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -4855,6 +4855,18 @@
           "older_than_days"
         ],
         "properties": {
+          "include_events": {
+            "type": "boolean",
+            "description": "Whether to purge error events (and the issues they empty). Defaults to\n`true` so an older client that omits it keeps the \"delete everything\"\nbehaviour."
+          },
+          "include_logs": {
+            "type": "boolean",
+            "description": "Whether to purge logs. Defaults to `true`."
+          },
+          "include_transactions": {
+            "type": "boolean",
+            "description": "Whether to purge transactions (and their cascaded spans). Defaults to `true`."
+          },
           "older_than_days": {
             "type": "integer",
             "format": "int64",

--- a/apps/server/src/models/mod.rs
+++ b/apps/server/src/models/mod.rs
@@ -58,8 +58,8 @@ pub use log::LogResponse;
 pub use project::{CreateProject, Project, ProjectResponse, UpdateProject};
 pub use project_member::{ProjectMember, ProjectMemberResponse, ProjectRole, UpsertProjectMember};
 pub use storage::{
-    CleanupCounts, CleanupRequest, ProjectStorage, SourceMapGcResult, SourceMapStorage,
-    StorageSummary,
+    CleanupCounts, CleanupFilter, CleanupRequest, ProjectStorage, SourceMapGcResult,
+    SourceMapStorage, StorageSummary,
 };
 pub use transaction::{
     SpanResponse, TransactionDetailResponse, TransactionResponse, TransactionStatsResponse,

--- a/apps/server/src/models/storage.rs
+++ b/apps/server/src/models/storage.rs
@@ -13,6 +13,57 @@ pub struct CleanupRequest {
     pub older_than_days: i64,
     #[serde(default)]
     pub project_id: Option<i32>,
+    /// Whether to purge error events (and the issues they empty). Defaults to
+    /// `true` so an older client that omits it keeps the "delete everything"
+    /// behaviour.
+    #[serde(default = "default_true")]
+    pub include_events: bool,
+    /// Whether to purge transactions (and their cascaded spans). Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub include_transactions: bool,
+    /// Whether to purge logs. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub include_logs: bool,
+}
+
+/// serde default for the `include_*` flags: an omitted flag means "yes, include
+/// this category", preserving the pre-filter contract for older callers.
+fn default_true() -> bool {
+    true
+}
+
+impl CleanupRequest {
+    /// The data-category selection this request describes.
+    pub fn filter(&self) -> CleanupFilter {
+        CleanupFilter {
+            include_events: self.include_events,
+            include_transactions: self.include_transactions,
+            include_logs: self.include_logs,
+        }
+    }
+}
+
+/// Which data categories a cleanup acts on. Lets an admin reclaim one kind of
+/// data (e.g. logs) without touching the others. `spans` are governed by
+/// `include_transactions` (they cascade from their parent transaction) and
+/// `issues_removed` only happens when `include_events` is set — a transaction- or
+/// log-only purge never empties an issue.
+#[derive(Debug, Clone, Copy)]
+pub struct CleanupFilter {
+    pub include_events: bool,
+    pub include_transactions: bool,
+    pub include_logs: bool,
+}
+
+impl CleanupFilter {
+    /// Every category — the historical "delete everything older than the cutoff".
+    pub fn all() -> Self {
+        Self {
+            include_events: true,
+            include_transactions: true,
+            include_logs: true,
+        }
+    }
 }
 
 /// Instance-wide storage summary: what Rustrak is holding right now.

--- a/apps/server/src/routes/storage.rs
+++ b/apps/server/src/routes/storage.rs
@@ -82,9 +82,13 @@ pub async fn preview_cleanup(
     body: web::Json<CleanupRequest>,
 ) -> AppResult<HttpResponse> {
     require_admin(&actor)?;
-    let counts =
-        StorageService::preview_cleanup(pool.get_ref(), body.older_than_days, body.project_id)
-            .await?;
+    let counts = StorageService::preview_cleanup(
+        pool.get_ref(),
+        body.older_than_days,
+        body.project_id,
+        body.filter(),
+    )
+    .await?;
     Ok(HttpResponse::Ok().json(counts))
 }
 
@@ -106,9 +110,13 @@ pub async fn execute_cleanup(
     body: web::Json<CleanupRequest>,
 ) -> AppResult<HttpResponse> {
     require_admin(&actor)?;
-    let counts =
-        StorageService::execute_cleanup(pool.get_ref(), body.older_than_days, body.project_id)
-            .await?;
+    let counts = StorageService::execute_cleanup(
+        pool.get_ref(),
+        body.older_than_days,
+        body.project_id,
+        body.filter(),
+    )
+    .await?;
     Ok(HttpResponse::Ok().json(counts))
 }
 

--- a/apps/server/src/services/storage.rs
+++ b/apps/server/src/services/storage.rs
@@ -9,7 +9,8 @@ use chrono::Utc;
 use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
 use crate::models::{
-    CleanupCounts, ProjectStorage, SourceMapGcResult, SourceMapStorage, StorageSummary,
+    CleanupCounts, CleanupFilter, ProjectStorage, SourceMapGcResult, SourceMapStorage,
+    StorageSummary,
 };
 use crate::services::sourcemap_store::SourceMapStore;
 
@@ -126,10 +127,11 @@ impl StorageService {
         pool: &DbPool,
         older_than_days: i64,
         project_id: Option<i32>,
+        filter: CleanupFilter,
     ) -> AppResult<CleanupCounts> {
         validate_retention(older_than_days)?;
         let cutoff = Utc::now() - chrono::Duration::days(older_than_days);
-        Self::count_cleanup(pool, cutoff, project_id).await
+        Self::count_cleanup(pool, cutoff, project_id, filter).await
     }
 
     /// Executes a cleanup: deletes data older than `older_than_days` (optionally
@@ -140,39 +142,50 @@ impl StorageService {
         pool: &DbPool,
         older_than_days: i64,
         project_id: Option<i32>,
+        filter: CleanupFilter,
     ) -> AppResult<CleanupCounts> {
         validate_retention(older_than_days)?;
         let cutoff = Utc::now() - chrono::Duration::days(older_than_days);
-        let counts = Self::count_cleanup(pool, cutoff, project_id).await?;
+        let counts = Self::count_cleanup(pool, cutoff, project_id, filter).await?;
 
         let mut tx = pool.begin().await?;
 
         // Transactions first — their spans cascade away via ON DELETE CASCADE.
-        sqlx::query(
-            "DELETE FROM transactions WHERE ingested_at < $1 AND ($2 IS NULL OR project_id = $3)",
-        )
-        .bind(cutoff)
-        .bind(project_id)
-        .bind(project_id)
-        .execute(&mut *tx)
-        .await?;
-
-        // Logs carry no issue_id and never touch the issue/project counters, so
-        // this is a plain delete — same shape as transactions.
-        sqlx::query("DELETE FROM logs WHERE ingested_at < $1 AND ($2 IS NULL OR project_id = $3)")
+        if filter.include_transactions {
+            sqlx::query(
+                "DELETE FROM transactions WHERE ingested_at < $1 AND ($2 IS NULL OR project_id = $3)",
+            )
             .bind(cutoff)
             .bind(project_id)
             .bind(project_id)
             .execute(&mut *tx)
             .await?;
+        }
 
-        // Keep the per-issue event counters in sync BEFORE deleting the rows. The
-        // `e.issue_id = issues.id` join means only events that belong to an issue
-        // (errors) are ever subtracted — transaction/log rows carry a NULL
-        // issue_id and never touched these counters, so they can't underflow them.
-        // Correlated subqueries keep this dialect-portable.
-        sqlx::query(
-            r#"
+        // Logs carry no issue_id and never touch the issue/project counters, so
+        // this is a plain delete — same shape as transactions.
+        if filter.include_logs {
+            sqlx::query(
+                "DELETE FROM logs WHERE ingested_at < $1 AND ($2 IS NULL OR project_id = $3)",
+            )
+            .bind(cutoff)
+            .bind(project_id)
+            .bind(project_id)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        // Events (and the issue/project bookkeeping they drive) are deleted only
+        // when in scope — a transaction- or log-only purge leaves error history,
+        // its issues, and the denormalized counters completely untouched.
+        if filter.include_events {
+            // Keep the per-issue event counters in sync BEFORE deleting the rows. The
+            // `e.issue_id = issues.id` join means only events that belong to an issue
+            // (errors) are ever subtracted — transaction/log rows carry a NULL
+            // issue_id and never touched these counters, so they can't underflow them.
+            // Correlated subqueries keep this dialect-portable.
+            sqlx::query(
+                r#"
             UPDATE issues SET
                 stored_event_count = stored_event_count - (
                     SELECT COUNT(*) FROM events e
@@ -190,27 +203,27 @@ impl StorageService {
                   AND ($8 IS NULL OR e.project_id = $9)
             )
             "#,
-        )
-        .bind(cutoff)
-        .bind(project_id)
-        .bind(project_id)
-        .bind(cutoff)
-        .bind(project_id)
-        .bind(project_id)
-        .bind(cutoff)
-        .bind(project_id)
-        .bind(project_id)
-        .execute(&mut *tx)
-        .await?;
+            )
+            .bind(cutoff)
+            .bind(project_id)
+            .bind(project_id)
+            .bind(cutoff)
+            .bind(project_id)
+            .bind(project_id)
+            .bind(cutoff)
+            .bind(project_id)
+            .bind(project_id)
+            .execute(&mut *tx)
+            .await?;
 
-        // Rebuild each in-scope project's counters from the (now-updated) issue
-        // counters instead of subtracting an event delta. The project counter is
-        // by definition the sum of its issues' counts, so this is always correct
-        // and can never underflow — no event_type/issue_id predicate needed, and
-        // it heals any pre-existing drift. The DELETE below still removes every
-        // old row (transactions included); those rows simply never had a counter.
-        sqlx::query(
-            r#"
+            // Rebuild each in-scope project's counters from the (now-updated) issue
+            // counters instead of subtracting an event delta. The project counter is
+            // by definition the sum of its issues' counts, so this is always correct
+            // and can never underflow — no event_type/issue_id predicate needed, and
+            // it heals any pre-existing drift. The DELETE below still removes every
+            // old row (transactions included); those rows simply never had a counter.
+            sqlx::query(
+                r#"
             UPDATE projects SET
                 stored_event_count = (
                     SELECT COALESCE(SUM(i.stored_event_count), 0)
@@ -222,30 +235,31 @@ impl StorageService {
                 )
             WHERE ($1 IS NULL OR projects.id = $2)
             "#,
-        )
-        .bind(project_id)
-        .bind(project_id)
-        .execute(&mut *tx)
-        .await?;
+            )
+            .bind(project_id)
+            .bind(project_id)
+            .execute(&mut *tx)
+            .await?;
 
-        sqlx::query(
-            "DELETE FROM events WHERE ingested_at < $1 AND ($2 IS NULL OR project_id = $3)",
-        )
-        .bind(cutoff)
-        .bind(project_id)
-        .bind(project_id)
-        .execute(&mut *tx)
-        .await?;
+            sqlx::query(
+                "DELETE FROM events WHERE ingested_at < $1 AND ($2 IS NULL OR project_id = $3)",
+            )
+            .bind(cutoff)
+            .bind(project_id)
+            .bind(project_id)
+            .execute(&mut *tx)
+            .await?;
 
-        // Drop issues left with no events — no ghost shells (in-scope only).
-        sqlx::query(
-            "DELETE FROM issues WHERE ($1 IS NULL OR project_id = $2) \
+            // Drop issues left with no events — no ghost shells (in-scope only).
+            sqlx::query(
+                "DELETE FROM issues WHERE ($1 IS NULL OR project_id = $2) \
              AND NOT EXISTS (SELECT 1 FROM events e WHERE e.issue_id = issues.id)",
-        )
-        .bind(project_id)
-        .bind(project_id)
-        .execute(&mut *tx)
-        .await?;
+            )
+            .bind(project_id)
+            .bind(project_id)
+            .execute(&mut *tx)
+            .await?;
+        }
 
         tx.commit().await?;
 
@@ -260,6 +274,7 @@ impl StorageService {
         pool: &DbPool,
         cutoff: chrono::DateTime<Utc>,
         project_id: Option<i32>,
+        filter: CleanupFilter,
     ) -> AppResult<CleanupCounts> {
         let (events, transactions, spans, issues_removed, logs): (i64, i64, i64, i64, i64) =
             sqlx::query_as(
@@ -300,12 +315,27 @@ impl StorageService {
             .fetch_one(pool)
             .await?;
 
+        // Mask out categories the filter excludes. `spans` follow their parent
+        // transaction, and an issue can only be emptied when its events are in
+        // scope — so both track their governing flag, not a separate one.
         Ok(CleanupCounts {
-            events,
-            transactions,
-            spans,
-            logs,
-            issues_removed,
+            events: if filter.include_events { events } else { 0 },
+            transactions: if filter.include_transactions {
+                transactions
+            } else {
+                0
+            },
+            spans: if filter.include_transactions {
+                spans
+            } else {
+                0
+            },
+            logs: if filter.include_logs { logs } else { 0 },
+            issues_removed: if filter.include_events {
+                issues_removed
+            } else {
+                0
+            },
         })
     }
 

--- a/apps/server/tests/integration/storage_api_test.rs
+++ b/apps/server/tests/integration/storage_api_test.rs
@@ -8,15 +8,17 @@
 use crate::common::TestDb;
 use actix_session::{storage::CookieSessionStore, SessionMiddleware};
 use actix_web::{cookie::Key, test, web, App};
+use chrono::Utc;
 use rustrak::config::{Config, DatabaseConfig, RateLimitConfig, SecurityConfig};
 use rustrak::db::DbPool;
-use rustrak::models::{CreateAuthToken, CreateUserRequest, User, UserRole};
+use rustrak::models::{CreateAuthToken, CreateProject, CreateUserRequest, User, UserRole};
 use rustrak::routes;
 use rustrak::services::sourcemap_store::{LocalSourceMapStore, SourceMapStore};
-use rustrak::services::{AuthTokenService, UsersService};
+use rustrak::services::{AuthTokenService, ProjectService, UsersService};
 use serde_json::{json, Value};
 use std::sync::Arc;
 use std::time::Duration;
+use uuid::Uuid;
 
 fn create_test_config() -> Config {
     Config {
@@ -197,6 +199,91 @@ async fn execute_cleanup_is_admin_only() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), 200, "admin can execute cleanup");
+}
+
+#[actix_web::test]
+async fn execute_cleanup_honors_data_type_filter_from_request_body() {
+    // The cleanup request can scope itself to specific data categories. A
+    // logs-only purge sent over HTTP must delete the old log and spare the old
+    // transaction — proving the request-body flags actually reach the service
+    // instead of the route always wiping everything.
+    let db = TestDb::new().await;
+    let admin = seed_user(&db.pool, "admin@x.com", UserRole::Admin).await;
+    let admin_token = token_for(&db.pool, admin.id).await;
+
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "filter-http".to_string(),
+            slug: None,
+        },
+    )
+    .await
+    .expect("create project");
+
+    let old = Utc::now() - chrono::Duration::days(60);
+
+    sqlx::query(
+        "INSERT INTO transactions (id, event_id, project_id, timestamp, ingested_at, data) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(project.id)
+    .bind(old)
+    .bind(old)
+    .bind(json!({}))
+    .execute(&db.pool)
+    .await
+    .expect("seed transaction");
+
+    sqlx::query(
+        "INSERT INTO logs (id, project_id, trace_id, span_id, level, severity_number, \
+         body, attributes, timestamp, ingested_at) \
+         VALUES ($1, $2, $3, NULL, $4, $5, $6, $7, $8, $9)",
+    )
+    .bind(Uuid::new_v4())
+    .bind(project.id)
+    .bind("trace")
+    .bind("info")
+    .bind(9_i16)
+    .bind("hello")
+    .bind(json!({}))
+    .bind(old)
+    .bind(old)
+    .execute(&db.pool)
+    .await
+    .expect("seed log");
+
+    let app = build_app!(db.pool.clone(), create_test_config());
+
+    let (k, v) = bearer(&admin_token);
+    let req = test::TestRequest::post()
+        .uri("/api/storage/cleanup")
+        .insert_header((k, v))
+        .set_json(json!({
+            "older_than_days": 30,
+            "include_events": false,
+            "include_transactions": false,
+            "include_logs": true,
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["logs"], 1, "the old log is removed");
+    assert_eq!(
+        body["transactions"], 0,
+        "transactions out of scope → untouched"
+    );
+
+    // The transaction really survived.
+    let txns: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE project_id = $1")
+        .bind(project.id)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(txns, 1, "logs-only purge left the transaction in place");
 }
 
 #[actix_web::test]

--- a/apps/server/tests/unit/storage_test.rs
+++ b/apps/server/tests/unit/storage_test.rs
@@ -6,7 +6,7 @@
 use crate::common::TestDb;
 use bytes::Bytes;
 use chrono::Utc;
-use rustrak::models::CreateProject;
+use rustrak::models::{CleanupFilter, CreateProject};
 use rustrak::services::sourcemap_store::{LocalSourceMapStore, SourceMapStore};
 use rustrak::services::{ProjectService, StorageService};
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -241,7 +241,7 @@ async fn test_preview_cleanup_counts_old_rows_without_mutating() {
     seed_transaction_with_spans_at(&db.pool, project.id, 2, old).await;
     seed_transaction_with_spans_at(&db.pool, project.id, 1, now).await;
 
-    let preview = StorageService::preview_cleanup(&db.pool, 30, None)
+    let preview = StorageService::preview_cleanup(&db.pool, 30, None, CleanupFilter::all())
         .await
         .unwrap();
 
@@ -307,12 +307,12 @@ async fn test_cleanup_counts_and_deletes_old_logs() {
     seed_log_at(&db.pool, project.id, old).await;
     seed_log_at(&db.pool, project.id, now).await;
 
-    let preview = StorageService::preview_cleanup(&db.pool, 30, None)
+    let preview = StorageService::preview_cleanup(&db.pool, 30, None, CleanupFilter::all())
         .await
         .unwrap();
     assert_eq!(preview.logs, 1, "one log older than 30d");
 
-    StorageService::execute_cleanup(&db.pool, 30, None)
+    StorageService::execute_cleanup(&db.pool, 30, None, CleanupFilter::all())
         .await
         .unwrap();
 
@@ -374,13 +374,13 @@ async fn test_cleanup_rejects_nonpositive_retention_window() {
 
     for bad in [0_i64, -1, -365] {
         assert!(
-            StorageService::preview_cleanup(&db.pool, bad, None)
+            StorageService::preview_cleanup(&db.pool, bad, None, CleanupFilter::all())
                 .await
                 .is_err(),
             "preview must reject older_than_days = {bad}"
         );
         assert!(
-            StorageService::execute_cleanup(&db.pool, bad, None)
+            StorageService::execute_cleanup(&db.pool, bad, None, CleanupFilter::all())
                 .await
                 .is_err(),
             "execute must reject older_than_days = {bad}"
@@ -457,7 +457,7 @@ async fn test_execute_cleanup_deletes_old_cascades_spans_and_removes_empty_issue
     seed_transaction_with_spans_at(&db.pool, project.id, 2, old).await;
     seed_transaction_with_spans_at(&db.pool, project.id, 1, now).await;
 
-    let result = StorageService::execute_cleanup(&db.pool, 30, None)
+    let result = StorageService::execute_cleanup(&db.pool, 30, None, CleanupFilter::all())
         .await
         .unwrap();
 
@@ -510,7 +510,7 @@ async fn test_execute_cleanup_decrements_project_event_counters() {
     .await
     .unwrap();
 
-    StorageService::execute_cleanup(&db.pool, 30, None)
+    StorageService::execute_cleanup(&db.pool, 30, None, CleanupFilter::all())
         .await
         .unwrap();
 
@@ -558,7 +558,7 @@ async fn test_execute_cleanup_purges_legacy_transaction_events_without_underflow
     .await
     .unwrap();
 
-    StorageService::execute_cleanup(&db.pool, 30, None)
+    StorageService::execute_cleanup(&db.pool, 30, None, CleanupFilter::all())
         .await
         .unwrap();
 
@@ -622,7 +622,7 @@ async fn test_execute_cleanup_deletes_every_old_row_regardless_of_type() {
     .await
     .unwrap();
 
-    StorageService::execute_cleanup(&db.pool, 30, None)
+    StorageService::execute_cleanup(&db.pool, 30, None, CleanupFilter::all())
         .await
         .unwrap();
 
@@ -645,6 +645,156 @@ async fn test_execute_cleanup_deletes_every_old_row_regardless_of_type() {
     .unwrap();
     assert_eq!(stored, 1, "counter tracks the one surviving error event");
     assert_eq!(digested, 1);
+}
+
+#[tokio::test]
+async fn test_execute_cleanup_with_only_events_selected_spares_transactions_and_logs() {
+    // The mirror case: selecting events only must purge old error events and the
+    // issue they emptied, while every transaction, span and log — of any age —
+    // survives untouched. Guards the issue-removal/counter path under a filter.
+    let db = TestDb::new().await;
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "filter-events-only".to_string(),
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let old = Utc::now() - chrono::Duration::days(60);
+    seed_event_at(&db.pool, project.id, old).await; // its issue empties out
+    seed_transaction_with_spans_at(&db.pool, project.id, 2, old).await;
+    seed_log_at(&db.pool, project.id, old).await;
+
+    let counts = StorageService::execute_cleanup(
+        &db.pool,
+        30,
+        None,
+        CleanupFilter {
+            include_events: true,
+            include_transactions: false,
+            include_logs: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(counts.events, 1, "the old error event is deleted");
+    assert_eq!(counts.issues_removed, 1, "its emptied issue is removed");
+    assert_eq!(counts.transactions, 0, "transactions out of scope → zero");
+    assert_eq!(counts.spans, 0);
+    assert_eq!(counts.logs, 0, "logs out of scope → zero");
+
+    let summary = StorageService::global_summary(&db.pool).await.unwrap();
+    assert_eq!(summary.events_count, 0, "old event purged");
+    assert_eq!(summary.transactions_count, 1, "transaction survives");
+    assert_eq!(summary.spans_count, 2, "spans survive");
+    assert_eq!(summary.logs_count, 1, "log survives");
+}
+
+#[tokio::test]
+async fn test_preview_cleanup_respects_filter_without_mutating() {
+    // Preview must honour the same filter as execute: a transactions-only dry-run
+    // reports transactions+spans, zeroes events and logs, and changes nothing.
+    let db = TestDb::new().await;
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "preview-filter".to_string(),
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let old = Utc::now() - chrono::Duration::days(60);
+    seed_event_at(&db.pool, project.id, old).await;
+    seed_transaction_with_spans_at(&db.pool, project.id, 3, old).await;
+    seed_log_at(&db.pool, project.id, old).await;
+
+    let preview = StorageService::preview_cleanup(
+        &db.pool,
+        30,
+        None,
+        CleanupFilter {
+            include_events: false,
+            include_transactions: true,
+            include_logs: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(preview.transactions, 1);
+    assert_eq!(preview.spans, 3, "spans under the old transaction");
+    assert_eq!(preview.events, 0, "events excluded → not reported");
+    assert_eq!(preview.logs, 0, "logs excluded → not reported");
+    assert_eq!(
+        preview.issues_removed, 0,
+        "no issue emptied without event scope"
+    );
+
+    // Nothing was deleted.
+    let summary = StorageService::global_summary(&db.pool).await.unwrap();
+    assert_eq!(summary.events_count, 1);
+    assert_eq!(summary.transactions_count, 1);
+    assert_eq!(summary.logs_count, 1);
+}
+
+#[tokio::test]
+async fn test_execute_cleanup_with_only_logs_selected_spares_events_and_transactions() {
+    // Granular selection: an admin who wants to reclaim log volume without losing
+    // error history picks logs only. Execute must delete the old logs and leave
+    // every event, transaction and span — of any age — untouched, and report the
+    // skipped categories as zero so the UI never claims it removed them.
+    let db = TestDb::new().await;
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "filter-logs-only".to_string(),
+            slug: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let old = Utc::now() - chrono::Duration::days(60);
+    seed_event_at(&db.pool, project.id, old).await; // would be deleted if events were in scope
+    seed_transaction_with_spans_at(&db.pool, project.id, 2, old).await;
+    seed_log_at(&db.pool, project.id, old).await;
+
+    let counts = StorageService::execute_cleanup(
+        &db.pool,
+        30,
+        None,
+        CleanupFilter {
+            include_events: false,
+            include_transactions: false,
+            include_logs: true,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(counts.logs, 1, "the one old log is deleted");
+    assert_eq!(counts.events, 0, "events out of scope → reported zero");
+    assert_eq!(counts.transactions, 0, "transactions out of scope → zero");
+    assert_eq!(counts.spans, 0, "spans follow their transaction → zero");
+    assert_eq!(
+        counts.issues_removed, 0,
+        "no issue emptied when events are spared"
+    );
+
+    let summary = StorageService::global_summary(&db.pool).await.unwrap();
+    assert_eq!(summary.events_count, 1, "event survives");
+    assert_eq!(summary.transactions_count, 1, "transaction survives");
+    assert_eq!(
+        summary.spans_count, 2,
+        "spans survive with their transaction"
+    );
+    assert_eq!(summary.logs_count, 0, "old log purged");
 }
 
 #[tokio::test]
@@ -677,7 +827,7 @@ async fn test_execute_cleanup_scoped_to_project_spares_other_projects() {
     seed_event_at(&db.pool, proj_b.id, old).await;
     seed_transaction_with_spans_at(&db.pool, proj_b.id, 1, old).await;
 
-    StorageService::execute_cleanup(&db.pool, 30, Some(proj_a.id))
+    StorageService::execute_cleanup(&db.pool, 30, Some(proj_a.id), CleanupFilter::all())
         .await
         .unwrap();
 

--- a/apps/webview-ui/src/app/(main)/settings/storage/storage-cleanup.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/storage/storage-cleanup.tsx
@@ -333,6 +333,8 @@ function summarizeRemoved(counts: CleanupCounts): string {
     parts.push(`${counts.transactions.toLocaleString()} transactions`);
   if (counts.spans) parts.push(`${counts.spans.toLocaleString()} spans`);
   if (counts.logs) parts.push(`${counts.logs.toLocaleString()} logs`);
+  if (counts.issues_removed)
+    parts.push(`${counts.issues_removed.toLocaleString()} empty issues`);
   return parts.length > 0
     ? `Removed ${parts.join(', ')}`
     : 'Nothing matched — no data removed';

--- a/apps/webview-ui/src/app/(main)/settings/storage/storage-cleanup.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/storage/storage-cleanup.tsx
@@ -28,6 +28,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Select,
   SelectContent,
@@ -50,18 +51,42 @@ const PERIODS = [
 
 const ALL_SCOPE = 'all';
 
+/** The three selectable data categories. `events` also governs the issues that
+ *  empty out; `transactions` also governs cascaded spans. */
+type DataType = 'events' | 'transactions' | 'logs';
+
+const TYPE_OPTIONS: { key: DataType; label: string }[] = [
+  { key: 'events', label: 'Errors' },
+  { key: 'transactions', label: 'Transactions' },
+  { key: 'logs', label: 'Logs' },
+];
+
 export function StorageCleanup({ projects }: StorageCleanupProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [period, setPeriod] = useState('90');
   const [scope, setScope] = useState(ALL_SCOPE);
+  const [selected, setSelected] = useState<Record<DataType, boolean>>({
+    events: true,
+    transactions: true,
+    logs: true,
+  });
   const [preview, setPreview] = useState<CleanupCounts | null>(null);
 
   const olderThanDays = Number(period);
   const projectId = scope === ALL_SCOPE ? undefined : Number(scope);
 
-  // A new period/scope invalidates a stale preview — force a fresh dry-run.
+  // Any change to period/scope/selection invalidates a stale preview — the
+  // breakdown only ever reflects the exact options it was run with.
   const resetPreview = () => setPreview(null);
+
+  const noneSelected =
+    !selected.events && !selected.transactions && !selected.logs;
+
+  const toggle = (key: DataType) => {
+    setSelected((prev) => ({ ...prev, [key]: !prev[key] }));
+    resetPreview();
+  };
 
   const handlePreview = () => {
     startTransition(async () => {
@@ -69,6 +94,9 @@ export function StorageCleanup({ projects }: StorageCleanupProps) {
         const counts = await previewStorageCleanup({
           older_than_days: olderThanDays,
           project_id: projectId,
+          include_events: selected.events,
+          include_transactions: selected.transactions,
+          include_logs: selected.logs,
         });
         setPreview(counts);
       } catch {
@@ -83,10 +111,11 @@ export function StorageCleanup({ projects }: StorageCleanupProps) {
         const counts = await executeStorageCleanup({
           older_than_days: olderThanDays,
           project_id: projectId,
+          include_events: selected.events,
+          include_transactions: selected.transactions,
+          include_logs: selected.logs,
         });
-        toast.success(
-          `Removed ${counts.events.toLocaleString()} events, ${counts.transactions.toLocaleString()} transactions, ${counts.spans.toLocaleString()} spans, ${counts.logs.toLocaleString()} logs`,
-        );
+        toast.success(summarizeRemoved(counts));
         setPreview(null);
         router.refresh();
       } catch {
@@ -102,12 +131,11 @@ export function StorageCleanup({ projects }: StorageCleanupProps) {
       ? 'All projects'
       : (projects.find((p) => String(p.id) === value)?.name ?? value);
 
+  // Breakdown rows for the categories the preview was run with — only the
+  // selected ones, so it never claims to touch data the selection spared.
+  const previewLines = preview ? buildLines(preview, selected) : [];
   const nothingToDelete =
-    preview !== null &&
-    preview.events === 0 &&
-    preview.transactions === 0 &&
-    preview.spans === 0 &&
-    preview.logs === 0;
+    preview !== null && previewLines.every((l) => l.count === 0);
 
   return (
     <Card className="border-destructive/30">
@@ -117,8 +145,8 @@ export function StorageCleanup({ projects }: StorageCleanupProps) {
           Clean up old data
         </CardTitle>
         <CardDescription>
-          Permanently delete events, transactions, spans and logs older than the
-          selected period. Always preview first — this cannot be undone.
+          Permanently delete the selected data older than the chosen period.
+          Preview first — this cannot be undone.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -167,42 +195,67 @@ export function StorageCleanup({ projects }: StorageCleanupProps) {
               ))}
             </SelectContent>
           </Select>
-
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handlePreview}
-            disabled={isPending}
-          >
-            {isPending ? 'Working…' : 'Preview'}
-          </Button>
         </div>
 
-        {preview !== null && (
-          <div className="rounded-md border bg-muted/40 p-4 text-sm">
-            <p className="font-semibold mb-1">This cleanup would remove:</p>
-            <ul className="text-muted-foreground space-y-0.5 tabular-nums">
-              <li>{preview.events.toLocaleString()} events</li>
-              <li>{preview.transactions.toLocaleString()} transactions</li>
-              <li>{preview.spans.toLocaleString()} spans</li>
-              <li>{preview.logs.toLocaleString()} logs</li>
-              <li>{preview.issues_removed.toLocaleString()} empty issues</li>
-            </ul>
+        {/* Sober inline selection — pick the categories, no numbers until the
+            dry-run actually runs. */}
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+          <span className="text-sm font-medium text-muted-foreground">
+            Data
+          </span>
+          {TYPE_OPTIONS.map((t) => (
+            <label
+              key={t.key}
+              className="flex items-center gap-2 text-sm cursor-pointer select-none"
+            >
+              <Checkbox
+                checked={selected[t.key]}
+                onCheckedChange={() => toggle(t.key)}
+                disabled={isPending}
+              />
+              {t.label}
+            </label>
+          ))}
+        </div>
 
-            {nothingToDelete ? (
-              <p className="mt-3 text-muted-foreground">
-                Nothing matches this period — there's nothing to delete.
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handlePreview}
+          disabled={isPending || noneSelected}
+        >
+          {isPending ? 'Working…' : 'Preview'}
+        </Button>
+
+        {preview !== null &&
+          (nothingToDelete ? (
+            <div className="border-t pt-4">
+              <p className="text-sm text-muted-foreground">
+                Nothing matches this selection{' '}
+                {periodLabel(period).toLowerCase()} for {scopeLabel(scope)} —
+                there's nothing to delete.
               </p>
-            ) : (
+            </div>
+          ) : (
+            <div className="border-t pt-4 space-y-3">
+              <p className="text-sm font-medium">This cleanup would remove</p>
+              <dl className="text-sm">
+                {previewLines.map((line) => (
+                  <div
+                    key={line.label}
+                    className="flex items-center justify-between border-b py-1.5 last:border-b-0"
+                  >
+                    <dt className="text-muted-foreground">{line.label}</dt>
+                    <dd className="tabular-nums font-medium">
+                      {line.count.toLocaleString()}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+
               <AlertDialog>
                 <AlertDialogTrigger
-                  render={
-                    <Button
-                      variant="destructive"
-                      className="mt-3"
-                      disabled={isPending}
-                    />
-                  }
+                  render={<Button variant="destructive" disabled={isPending} />}
                 >
                   <Trash2 className="mr-2 size-4" />
                   Delete permanently
@@ -211,16 +264,12 @@ export function StorageCleanup({ projects }: StorageCleanupProps) {
                   <AlertDialogHeader>
                     <AlertDialogTitle className="flex items-center gap-2">
                       <AlertTriangle className="size-5 text-destructive" />
-                      Delete {preview.events.toLocaleString()} events and more?
+                      Delete {totalRows(previewLines).toLocaleString()} rows?
                     </AlertDialogTitle>
                     <AlertDialogDescription>
-                      This permanently deletes data {periodLabel(period)} for{' '}
-                      {scopeLabel(scope)} (
-                      {preview.transactions.toLocaleString()} transactions,{' '}
-                      {preview.spans.toLocaleString()} spans,{' '}
-                      {preview.logs.toLocaleString()} logs,{' '}
-                      {preview.issues_removed.toLocaleString()} empty issues).
-                      This action cannot be undone.
+                      This permanently deletes the selected data{' '}
+                      {periodLabel(period).toLowerCase()} for{' '}
+                      {scopeLabel(scope)}. This action cannot be undone.
                     </AlertDialogDescription>
                   </AlertDialogHeader>
                   <AlertDialogFooter>
@@ -237,10 +286,54 @@ export function StorageCleanup({ projects }: StorageCleanupProps) {
                   </AlertDialogFooter>
                 </AlertDialogContent>
               </AlertDialog>
-            )}
-          </div>
-        )}
+            </div>
+          ))}
       </CardContent>
     </Card>
   );
+}
+
+interface PreviewLine {
+  label: string;
+  count: number;
+}
+
+/** Breakdown rows for the categories the selection includes. `spans` and
+ *  `empty issues` ride along with their governing category (transactions and
+ *  events respectively). */
+function buildLines(
+  counts: CleanupCounts,
+  selected: Record<DataType, boolean>,
+): PreviewLine[] {
+  const lines: PreviewLine[] = [];
+  if (selected.events) {
+    lines.push({ label: 'Errors', count: counts.events });
+    lines.push({ label: 'Empty issues', count: counts.issues_removed });
+  }
+  if (selected.transactions) {
+    lines.push({ label: 'Transactions', count: counts.transactions });
+    lines.push({ label: 'Spans', count: counts.spans });
+  }
+  if (selected.logs) {
+    lines.push({ label: 'Logs', count: counts.logs });
+  }
+  return lines;
+}
+
+function totalRows(lines: PreviewLine[]): number {
+  return lines.reduce((sum, l) => sum + l.count, 0);
+}
+
+/** Success toast text after an executed cleanup — categories the server reports
+ *  as zero (spared or empty) simply don't show up. */
+function summarizeRemoved(counts: CleanupCounts): string {
+  const parts: string[] = [];
+  if (counts.events) parts.push(`${counts.events.toLocaleString()} errors`);
+  if (counts.transactions)
+    parts.push(`${counts.transactions.toLocaleString()} transactions`);
+  if (counts.spans) parts.push(`${counts.spans.toLocaleString()} spans`);
+  if (counts.logs) parts.push(`${counts.logs.toLocaleString()} logs`);
+  return parts.length > 0
+    ? `Removed ${parts.join(', ')}`
+    : 'Nothing matched — no data removed';
 }

--- a/packages/client/src/schemas/storage.ts
+++ b/packages/client/src/schemas/storage.ts
@@ -62,11 +62,20 @@ export const sourceMapGcResultSchema = z.object({
 
 /**
  * Request body for a cleanup (preview or execute): remove data older than
- * `older_than_days`, optionally scoped to one project (omit for all). The
- * minimum of 1 mirrors the server contract — a smaller window would wipe the
- * whole dataset.
+ * `older_than_days`, optionally scoped to one project (omit for all) and to
+ * specific data categories. The minimum of 1 mirrors the server contract — a
+ * smaller window would wipe the whole dataset.
+ *
+ * The `include_*` flags select which data categories the cleanup acts on. Each
+ * is optional and defaults to `true` server-side, so omitting all of them keeps
+ * the "delete everything older than the cutoff" behaviour. `include_transactions`
+ * also governs the cascaded spans, and `include_events` governs the emptied
+ * issues that get removed alongside their events.
  */
 export const cleanupOptionsSchema = z.object({
   older_than_days: z.number().int().min(1),
   project_id: z.number().int().optional(),
+  include_events: z.boolean().optional(),
+  include_transactions: z.boolean().optional(),
+  include_logs: z.boolean().optional(),
 });

--- a/packages/client/tests/integration/storage.test.ts
+++ b/packages/client/tests/integration/storage.test.ts
@@ -1,5 +1,7 @@
+import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
 import { RustrakClient } from '../../src/index.js';
+import { server } from '../setup.js';
 
 const client = new RustrakClient({
   baseUrl: 'http://localhost:8080',
@@ -73,6 +75,39 @@ describe('StorageResource', () => {
 
       expect(counts.events).toBe(20);
       expect(counts.issues_removed).toBe(3);
+    });
+
+    it('forwards the data-type selection flags in the request body', async () => {
+      let sentBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          'http://localhost:8080/api/storage/cleanup',
+          async ({ request }) => {
+            sentBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              events: 0,
+              transactions: 0,
+              spans: 0,
+              logs: 50,
+              issues_removed: 0,
+            });
+          },
+        ),
+      );
+
+      await client.storage.executeCleanup({
+        older_than_days: 30,
+        include_events: false,
+        include_transactions: false,
+        include_logs: true,
+      });
+
+      expect(sentBody).toMatchObject({
+        older_than_days: 30,
+        include_events: false,
+        include_transactions: false,
+        include_logs: true,
+      });
     });
   });
 

--- a/packages/mcp/src/tools/storage.ts
+++ b/packages/mcp/src/tools/storage.ts
@@ -49,7 +49,7 @@ export function registerStorageTools(
     'preview_storage_cleanup',
     {
       description:
-        'Dry-run a Rustrak retention cleanup (admin only): report how many events, transactions, spans, logs and issues would be removed if data older than `older_than_days` were deleted, optionally scoped to one project. Mutates nothing — always run this before execute_storage_cleanup.',
+        'Dry-run a Rustrak retention cleanup (admin only): report how many events, transactions, spans, logs and issues would be removed if data older than `older_than_days` were deleted, optionally scoped to one project and to specific data categories. Mutates nothing — always run this before execute_storage_cleanup.',
       inputSchema: {
         older_than_days: z
           .number()
@@ -61,13 +61,38 @@ export function registerStorageTools(
           .int()
           .optional()
           .describe('Scope to one project (omit for all projects)'),
+        include_events: z
+          .boolean()
+          .optional()
+          .describe(
+            'Include error events (and the issues they empty). Defaults to true.',
+          ),
+        include_transactions: z
+          .boolean()
+          .optional()
+          .describe(
+            'Include transactions and their cascaded spans. Defaults to true.',
+          ),
+        include_logs: z
+          .boolean()
+          .optional()
+          .describe('Include logs. Defaults to true.'),
       },
     },
-    async ({ older_than_days, project_id }) => {
+    async ({
+      older_than_days,
+      project_id,
+      include_events,
+      include_transactions,
+      include_logs,
+    }) => {
       try {
         const result = await client.storage.previewCleanup({
           older_than_days,
           project_id,
+          include_events,
+          include_transactions,
+          include_logs,
         });
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
@@ -82,7 +107,7 @@ export function registerStorageTools(
     'execute_storage_cleanup',
     {
       description:
-        'DESTRUCTIVE (admin only): permanently delete Rustrak data older than `older_than_days` (optionally scoped to one project) and remove any issue left with zero events. This cannot be undone. You MUST set confirm=true to proceed; without it the tool refuses and returns an error. Always run preview_storage_cleanup first and show the user the counts before confirming.',
+        'DESTRUCTIVE (admin only): permanently delete Rustrak data older than `older_than_days` (optionally scoped to one project and to specific data categories) and remove any issue left with zero events. This cannot be undone. You MUST set confirm=true to proceed; without it the tool refuses and returns an error. Always run preview_storage_cleanup first and show the user the counts before confirming.',
       inputSchema: {
         older_than_days: z
           .number()
@@ -94,6 +119,22 @@ export function registerStorageTools(
           .int()
           .optional()
           .describe('Scope to one project (omit for all projects)'),
+        include_events: z
+          .boolean()
+          .optional()
+          .describe(
+            'Include error events (and the issues they empty). Defaults to true.',
+          ),
+        include_transactions: z
+          .boolean()
+          .optional()
+          .describe(
+            'Include transactions and their cascaded spans. Defaults to true.',
+          ),
+        include_logs: z
+          .boolean()
+          .optional()
+          .describe('Include logs. Defaults to true.'),
         confirm: z
           .boolean()
           .optional()
@@ -101,7 +142,14 @@ export function registerStorageTools(
       },
       annotations: { destructiveHint: true },
     },
-    async ({ older_than_days, project_id, confirm }) => {
+    async ({
+      older_than_days,
+      project_id,
+      include_events,
+      include_transactions,
+      include_logs,
+      confirm,
+    }) => {
       if (confirm !== true) {
         return toMcpError(
           new Error(
@@ -113,6 +161,9 @@ export function registerStorageTools(
         const result = await client.storage.executeCleanup({
           older_than_days,
           project_id,
+          include_events,
+          include_transactions,
+          include_logs,
         });
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],

--- a/packages/mcp/tests/tools/storage.test.ts
+++ b/packages/mcp/tests/tools/storage.test.ts
@@ -106,6 +106,29 @@ describe('storage tools', () => {
         project_id: 1,
       });
     });
+
+    it('forwards the data-type selection flags', async () => {
+      mockClient.storage.previewCleanup.mockResolvedValue(mockCounts);
+
+      await callTool({
+        name: 'preview_storage_cleanup',
+        arguments: {
+          older_than_days: 30,
+          include_events: false,
+          include_transactions: false,
+          include_logs: true,
+        },
+      });
+
+      expect(mockClient.storage.previewCleanup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          older_than_days: 30,
+          include_events: false,
+          include_transactions: false,
+          include_logs: true,
+        }),
+      );
+    });
   });
 
   describe('execute_storage_cleanup', () => {
@@ -134,6 +157,30 @@ describe('storage tools', () => {
         older_than_days: 30,
         project_id: undefined,
       });
+    });
+
+    it('forwards the data-type selection flags when confirmed', async () => {
+      mockClient.storage.executeCleanup.mockResolvedValue(mockCounts);
+
+      await callTool({
+        name: 'execute_storage_cleanup',
+        arguments: {
+          older_than_days: 30,
+          confirm: true,
+          include_events: false,
+          include_transactions: true,
+          include_logs: false,
+        },
+      });
+
+      expect(mockClient.storage.executeCleanup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          older_than_days: 30,
+          include_events: false,
+          include_transactions: true,
+          include_logs: false,
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## What

Storage cleanup could only delete **everything** older than the cutoff. Now an admin can scope a cleanup to specific data categories — e.g. reclaim log volume while keeping error history.

## Changes (4 layers, TDD)

- **server** — `CleanupFilter { include_events, include_transactions, include_logs }` threaded through `preview_cleanup`/`execute_cleanup`. Each `DELETE` and its bookkeeping is gated by the filter; counts are masked accordingly. `CleanupRequest` gains the three flags with `#[serde(default = "default_true")]`, so omitting them keeps the prior "delete everything" behaviour. `openapi.json` regenerated.
- **client** — `cleanupOptionsSchema` gains optional `include_events/transactions/logs`, forwarded to the cleanup endpoints.
- **mcp** — `preview_storage_cleanup` / `execute_storage_cleanup` accept the same optional flags.
- **webview-ui** — sober inline checkboxes (Errors / Transactions / Logs); the per-category breakdown appears **only after Preview** and lists just the selected types. Changing period/scope/selection invalidates a stale preview.

## Design notes

- **Spans** cascade with their transaction (a span can't exist without one), so they have no separate toggle — `include_transactions` governs them.
- **Empty issues** follow their events — only removed when `include_events` is set.
- Fully backward compatible across server, client and MCP: omitting the flags = today's behaviour.

## Out of scope

`alert_history`, session tables and `assembly_jobs` accumulate over time but are not surfaced by the Storage page today — leaving them as a separate follow-up.

## Tests

- server: 222 passing (new unit tests for logs-only / events-only / preview-respects-filter + integration test that the request-body flags reach the service); clippy clean
- client: 353 passing (new test that flags are forwarded)
- mcp: 74 passing (new tests that both tools forward the flags)
- webview-ui: tsc + biome clean