### PR TITLE
Event detail page: match Sentry's stack trace and breadcrumbs behavior

### DIFF
--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -75,6 +75,15 @@ impl ErrorProcessor {
             );
         }
 
+        // 1c. Trim oversized fields (deep context windows, frame vars, huge
+        // breadcrumb trails) for events whose raw payload came in above the
+        // original per-item budget — see services::event_trim. Only runs for
+        // the (rare) events that needed the relaxed ingest ceiling, so this
+        // is a no-op for the common case.
+        if event_bytes.len() > crate::ingest::parser::TARGET_EVENT_SIZE {
+            crate::services::trim_oversized_event(&mut event_data);
+        }
+
         // 2. Parse event_id as UUID
         let event_id = Uuid::parse_str(&metadata.event_id)
             .map_err(|_| AppError::Validation("Invalid event_id".to_string()))?;

--- a/apps/server/src/ingest/parser.rs
+++ b/apps/server/src/ingest/parser.rs
@@ -4,8 +4,19 @@ use crate::ingest::envelope::{EnvelopeHeaders, EnvelopeItemKind, ItemHeaders, Pa
 /// Maximum header size (8KB)
 const MAX_HEADER_SIZE: usize = 8 * 1024;
 
-/// Maximum event size (1MB)
-const MAX_EVENT_SIZE: usize = 1024 * 1024;
+/// Maximum size for non-"event" items (session, transaction, attachment, etc.)
+const MAX_ITEM_SIZE: usize = 1024 * 1024;
+
+/// The size digest's trimming pass (`services::event_trim`) targets shrinking
+/// event payloads under. Matches the original, un-relaxed per-item limit.
+pub(crate) const TARGET_EVENT_SIZE: usize = 1024 * 1024;
+
+/// Hard abuse ceiling for "event" items specifically — raised above
+/// `TARGET_EVENT_SIZE` so a verbose-but-legitimate event (deep stack traces,
+/// frame `vars`, large breadcrumb trails) survives ingest long enough for the
+/// digest pipeline to trim it down, instead of being rejected outright for
+/// being over budget before anyone got a chance to shrink it.
+pub(crate) const MAX_RAW_EVENT_SIZE: usize = 4 * 1024 * 1024;
 
 /// Sentry envelope parser
 pub struct EnvelopeParser<'a> {
@@ -56,13 +67,20 @@ impl<'a> EnvelopeParser<'a> {
         let headers: ItemHeaders = serde_json::from_slice(&header_line)
             .map_err(|e| AppError::Validation(format!("Invalid item headers JSON: {}", e)))?;
 
+        // "event" items get the relaxed abuse ceiling — see MAX_RAW_EVENT_SIZE.
+        let max_size = if headers.item_type == "event" {
+            MAX_RAW_EVENT_SIZE
+        } else {
+            MAX_ITEM_SIZE
+        };
+
         // Read payload
         let payload = if let Some(length) = headers.length {
             // Explicit length
-            if length > MAX_EVENT_SIZE {
+            if length > max_size {
                 return Err(AppError::PayloadTooLarge(format!(
                     "Item payload exceeds {} bytes",
-                    MAX_EVENT_SIZE
+                    max_size
                 )));
             }
             let payload = self.read_bytes(length)?;
@@ -73,7 +91,7 @@ impl<'a> EnvelopeParser<'a> {
             payload
         } else {
             // Read until newline
-            self.read_line(MAX_EVENT_SIZE)?
+            self.read_line(max_size)?
         };
 
         Ok(Some(EnvelopeItemKind::from((headers, payload))))
@@ -120,5 +138,54 @@ impl<'a> EnvelopeParser<'a> {
 
     fn at_eof(&self) -> bool {
         self.position >= self.data.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a minimal envelope with one item of the given type and payload size.
+    fn envelope_with_item(item_type: &str, payload_len: usize) -> Vec<u8> {
+        let mut data = b"{}\n".to_vec();
+        data.extend_from_slice(
+            format!(r#"{{"type":"{}","length":{}}}"#, item_type, payload_len).as_bytes(),
+        );
+        data.push(b'\n');
+        data.extend(std::iter::repeat_n(b'a', payload_len));
+        data
+    }
+
+    #[test]
+    fn event_item_between_1mb_and_4mb_is_accepted() {
+        let data = envelope_with_item("event", 2 * 1024 * 1024);
+        let result = EnvelopeParser::new(&data).parse();
+        assert!(
+            result.is_ok(),
+            "a 2MB event item should be accepted (only >4MB event items are rejected): {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn event_item_over_4mb_is_rejected() {
+        let data = envelope_with_item("event", 5 * 1024 * 1024);
+        let result = EnvelopeParser::new(&data).parse();
+        assert!(
+            matches!(result, Err(AppError::PayloadTooLarge(_))),
+            "a 5MB event item should still hit the abuse ceiling: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn non_event_item_over_1mb_is_still_rejected() {
+        let data = envelope_with_item("session", 2 * 1024 * 1024);
+        let result = EnvelopeParser::new(&data).parse();
+        assert!(
+            matches!(result, Err(AppError::PayloadTooLarge(_))),
+            "non-event items must not get the relaxed event ceiling: {:?}",
+            result
+        );
     }
 }

--- a/apps/server/src/services/event_trim.rs
+++ b/apps/server/src/services/event_trim.rs
@@ -1,0 +1,301 @@
+//! Targeted trimming for oversized events, run only when an event's raw
+//! payload exceeds [`crate::ingest::parser::TARGET_EVENT_SIZE`] (see
+//! `digest/processors/event.rs`).
+//!
+//! Applies the same per-field byte/depth budgets Relay's schema actually
+//! declares (`#[metastructure(max_bytes = N, max_depth = D)]` in
+//! relay-event-schema), via [`generic_trim::trim_databag`] — a JSON-native
+//! reimplementation of Relay's `TrimmingProcessor` behavior. Fields Relay's
+//! schema doesn't annotate with a budget (`pre_context`/`post_context`, the
+//! breadcrumbs array length) are deliberately left untouched here too — see
+//! the corresponding tests below for the source citations.
+
+use super::generic_trim::trim_databag;
+
+/// `Frame.vars` — relay-event-schema/src/protocol/stacktrace.rs:129.
+const VARS_MAX_BYTES: usize = 2048;
+const VARS_MAX_DEPTH: usize = 5;
+
+/// `Breadcrumb.data` — relay-event-schema/src/protocol/breadcrumb.rs:108.
+const BREADCRUMB_DATA_MAX_BYTES: usize = 2048;
+const BREADCRUMB_DATA_MAX_DEPTH: usize = 5;
+
+/// `Event.extra` — relay-event-schema/src/protocol/event.rs:402.
+const EXTRA_MAX_BYTES: usize = 262_144;
+const EXTRA_MAX_DEPTH: usize = 7;
+
+/// `Event.modules` — relay-event-schema/src/protocol/event.rs:242.
+const MODULES_MAX_BYTES: usize = 8192;
+const MODULES_MAX_DEPTH: usize = 7;
+
+/// `Request.data` — relay-event-schema/src/protocol/request.rs:437.
+const REQUEST_DATA_MAX_BYTES: usize = 8192;
+const REQUEST_DATA_MAX_DEPTH: usize = 7;
+
+pub fn trim_oversized_event(event_data: &mut serde_json::Value) {
+    trim_frames_under(event_data, "exception");
+    trim_frames_under(event_data, "threads");
+    trim_breadcrumb_data(event_data);
+
+    if event_data.get("extra").is_some() {
+        trim_databag(&mut event_data["extra"], EXTRA_MAX_BYTES, EXTRA_MAX_DEPTH);
+    }
+    if event_data.get("modules").is_some() {
+        trim_databag(
+            &mut event_data["modules"],
+            MODULES_MAX_BYTES,
+            MODULES_MAX_DEPTH,
+        );
+    }
+    if event_data["request"].get("data").is_some() {
+        trim_databag(
+            &mut event_data["request"]["data"],
+            REQUEST_DATA_MAX_BYTES,
+            REQUEST_DATA_MAX_DEPTH,
+        );
+    }
+}
+
+fn trim_breadcrumb_data(event_data: &mut serde_json::Value) {
+    let count = event_data["breadcrumbs"]["values"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
+
+    for i in 0..count {
+        let crumb = &mut event_data["breadcrumbs"]["values"][i];
+        if crumb.get("data").is_some() {
+            trim_databag(
+                &mut crumb["data"],
+                BREADCRUMB_DATA_MAX_BYTES,
+                BREADCRUMB_DATA_MAX_DEPTH,
+            );
+        }
+    }
+}
+
+fn trim_frames_under(event_data: &mut serde_json::Value, root_key: &str) {
+    let value_count = event_data[root_key]["values"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
+
+    for value_idx in 0..value_count {
+        let frame_count = event_data[root_key]["values"][value_idx]["stacktrace"]["frames"]
+            .as_array()
+            .map(|a| a.len())
+            .unwrap_or(0);
+
+        for frame_idx in 0..frame_count {
+            let frame =
+                &mut event_data[root_key]["values"][value_idx]["stacktrace"]["frames"][frame_idx];
+            if frame.get("vars").is_some() {
+                trim_databag(&mut frame["vars"], VARS_MAX_BYTES, VARS_MAX_DEPTH);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn trim_frame_vars_uses_the_real_relay_budget_of_2048_bytes() {
+        let mut vars = serde_json::Map::new();
+        for i in 0..50 {
+            vars.insert(format!("var{i:03}"), json!("x".repeat(100)));
+        }
+        let mut event = json!({
+            "exception": { "values": [{ "type": "Error", "value": "boom", "stacktrace": { "frames": [{
+                "filename": "app.py",
+                "lineno": 10,
+                "vars": vars,
+            }]}}]}
+        });
+
+        trim_oversized_event(&mut event);
+
+        let frame = &event["exception"]["values"][0]["stacktrace"]["frames"][0];
+        let trimmed = serde_json::to_string(&frame["vars"]).unwrap();
+        assert!(
+            trimmed.len() <= 2048 + 64, // small slack for the last item's own truncation
+            "vars should be trimmed to Relay's real 2048-byte budget (stacktrace.rs:129), got {} bytes",
+            trimmed.len()
+        );
+        assert!(
+            frame["vars"]["var000"].is_string(),
+            "leading vars within budget should survive"
+        );
+    }
+
+    #[test]
+    fn trim_applies_to_thread_frame_vars_too() {
+        let mut vars = serde_json::Map::new();
+        for i in 0..50 {
+            vars.insert(format!("var{i:03}"), json!("x".repeat(100)));
+        }
+        let mut event = json!({
+            "threads": { "values": [{
+                "id": "0",
+                "crashed": true,
+                "stacktrace": { "frames": [{
+                    "filename": "worker.js",
+                    "lineno": 10,
+                    "vars": vars,
+                }]}
+            }]}
+        });
+
+        trim_oversized_event(&mut event);
+
+        let frame = &event["threads"]["values"][0]["stacktrace"]["frames"][0];
+        let trimmed = serde_json::to_string(&frame["vars"]).unwrap();
+        assert!(
+            trimmed.len() <= 2048 + 64,
+            "thread frame vars should get the same budget as exception frame vars, got {} bytes",
+            trimmed.len()
+        );
+    }
+
+    #[test]
+    fn trim_leaves_context_lines_untouched_no_matter_how_many() {
+        // Relay's schema has no size/count limit on pre_context/post_context
+        // (verified: no #[metastructure(max_bytes/max_depth)] on those
+        // fields in relay-event-schema/src/protocol/stacktrace.rs) — so
+        // Rustrak shouldn't invent one either.
+        let pre: Vec<String> = (0..500).map(|i| format!("line{i}")).collect();
+        let mut event = json!({
+            "exception": { "values": [{ "type": "Error", "value": "boom", "stacktrace": { "frames": [{
+                "filename": "app.py",
+                "lineno": 10,
+                "pre_context": pre,
+            }]}}]}
+        });
+
+        trim_oversized_event(&mut event);
+
+        let frame = &event["exception"]["values"][0]["stacktrace"]["frames"][0];
+        assert_eq!(
+            frame["pre_context"].as_array().unwrap().len(),
+            500,
+            "pre_context must be left untouched — Relay doesn't cap it either"
+        );
+    }
+
+    #[test]
+    fn trim_leaves_breadcrumb_count_untouched_no_matter_how_many() {
+        // Relay's schema has no count/size limit on the breadcrumbs array
+        // itself either (verified: no metastructure attrs on
+        // Event.breadcrumbs in event.rs) — only per-breadcrumb `data` has a
+        // budget (see trim_breadcrumb_data_uses_the_real_relay_budget below).
+        let crumbs: Vec<serde_json::Value> = (0..500)
+            .map(|i| json!({ "message": format!("crumb{i}") }))
+            .collect();
+        let mut event = json!({ "breadcrumbs": { "values": crumbs } });
+
+        trim_oversized_event(&mut event);
+
+        assert_eq!(
+            event["breadcrumbs"]["values"].as_array().unwrap().len(),
+            500,
+            "breadcrumb count must be left untouched — Relay doesn't cap it either"
+        );
+    }
+
+    #[test]
+    fn trim_breadcrumb_data_uses_the_real_relay_budget_of_2048_bytes() {
+        let mut data = serde_json::Map::new();
+        for i in 0..50 {
+            data.insert(format!("k{i:03}"), json!("x".repeat(100)));
+        }
+        let mut event = json!({
+            "breadcrumbs": { "values": [{ "message": "big", "data": data }] }
+        });
+
+        trim_oversized_event(&mut event);
+
+        let trimmed = serde_json::to_string(&event["breadcrumbs"]["values"][0]["data"]).unwrap();
+        assert!(
+            trimmed.len() <= 2048 + 64,
+            "breadcrumb.data should be trimmed to Relay's real 2048-byte budget (breadcrumb.rs:108), got {} bytes",
+            trimmed.len()
+        );
+    }
+
+    #[test]
+    fn trim_extra_uses_the_real_relay_budget_of_256kb() {
+        let mut extra = serde_json::Map::new();
+        extra.insert("huge".to_string(), json!("x".repeat(300_000)));
+        let mut event = json!({ "extra": extra });
+
+        trim_oversized_event(&mut event);
+
+        let trimmed = serde_json::to_string(&event["extra"]).unwrap();
+        assert!(
+            trimmed.len() <= 262_144 + 64,
+            "extra should be trimmed to Relay's real 262144-byte budget (event.rs:402), got {} bytes",
+            trimmed.len()
+        );
+    }
+
+    #[test]
+    fn trim_modules_uses_the_real_relay_budget_of_8kb() {
+        let mut modules = serde_json::Map::new();
+        for i in 0..500 {
+            modules.insert(format!("pkg{i:03}"), json!("1.0.0"));
+        }
+        let mut event = json!({ "modules": modules });
+
+        trim_oversized_event(&mut event);
+
+        let trimmed = serde_json::to_string(&event["modules"]).unwrap();
+        assert!(
+            trimmed.len() <= 8192 + 64,
+            "modules should be trimmed to Relay's real 8192-byte budget (event.rs:242), got {} bytes",
+            trimmed.len()
+        );
+    }
+
+    #[test]
+    fn trim_request_data_uses_the_real_relay_budget_of_8kb() {
+        let mut event = json!({
+            "request": { "method": "POST", "data": "x".repeat(20_000) }
+        });
+
+        trim_oversized_event(&mut event);
+
+        let trimmed = serde_json::to_string(&event["request"]["data"]).unwrap();
+        assert!(
+            trimmed.len() <= 8192 + 8,
+            "request.data should be trimmed to Relay's real 8192-byte budget (request.rs:437), got {} bytes",
+            trimmed.len()
+        );
+    }
+
+    #[test]
+    fn trim_is_noop_for_a_normal_sized_event() {
+        let original = json!({
+            "exception": { "values": [{ "type": "Error", "value": "boom", "stacktrace": { "frames": [{
+                "filename": "app.py",
+                "lineno": 10,
+                "pre_context": ["a", "b"],
+                "post_context": ["c", "d"],
+                "vars": { "x": "1", "y": "2" },
+            }]}}]},
+            "breadcrumbs": { "values": [{ "message": "only one" }] },
+            "extra": { "k": "v" },
+            "modules": { "pkg": "1.0.0" },
+            "request": { "method": "GET", "data": "small" }
+        });
+        let mut event = original.clone();
+
+        trim_oversized_event(&mut event);
+
+        assert_eq!(
+            event, original,
+            "a within-bounds event must be left untouched"
+        );
+    }
+}

--- a/apps/server/src/services/generic_trim.rs
+++ b/apps/server/src/services/generic_trim.rs
@@ -1,0 +1,222 @@
+//! JSON-native port of the behavior of Relay's `TrimmingProcessor`
+//! (relay-event-normalization/src/trimming.rs) — a databag gets a byte
+//! budget and a max nesting depth; strings are truncated to fit, arrays and
+//! objects keep whichever leading elements fit and drop the rest, and a
+//! container that's still non-empty once depth runs out is deleted outright
+//! rather than replaced with nulls (replacing `[1,1,1,1]` with
+//! `[null,null,null,null]` wastes bytes instead of saving them).
+//!
+//! Deliberately doesn't require a typed schema — walks `serde_json::Value`
+//! directly, matching how the rest of Rustrak's ingestion pipeline treats
+//! event data as an opaque blob rather than a modeled protocol.
+
+/// Trims `value` in place to fit within `max_bytes`, never nesting deeper
+/// than `max_depth`.
+pub fn trim_databag(value: &mut serde_json::Value, max_bytes: usize, max_depth: usize) {
+    let mut remaining = max_bytes;
+    trim_value(value, &mut remaining, max_depth);
+}
+
+fn trim_value(value: &mut serde_json::Value, remaining_size: &mut usize, remaining_depth: usize) {
+    // A container we're not allowed to descend into anymore is deleted
+    // outright rather than left in place or replaced element-by-element —
+    // turning `[1,1,1,1]` into `[null,null,null,null]` wastes bytes instead
+    // of saving them.
+    let is_nonempty_container = match value {
+        serde_json::Value::Array(a) => !a.is_empty(),
+        serde_json::Value::Object(m) => !m.is_empty(),
+        _ => false,
+    };
+    if remaining_depth == 0 && is_nonempty_container {
+        *value = serde_json::Value::Null;
+        *remaining_size = remaining_size.saturating_sub(4); // "null"
+        return;
+    }
+
+    match value {
+        serde_json::Value::String(s) => {
+            if s.len() > *remaining_size {
+                *s = truncate_to_bytes(s, *remaining_size);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            let mut cut_at = arr.len();
+            for (i, item) in arr.iter_mut().enumerate() {
+                if *remaining_size == 0 {
+                    cut_at = i;
+                    break;
+                }
+                trim_value(item, remaining_size, remaining_depth.saturating_sub(1));
+                // The `,` between this element and the next — easy to miss
+                // when accounting size per-item instead of per-serialized-output.
+                *remaining_size = remaining_size.saturating_sub(1);
+            }
+            arr.truncate(cut_at);
+        }
+        serde_json::Value::Object(map) => {
+            let mut cut_from: Option<String> = None;
+            for (key, item) in map.iter_mut() {
+                if *remaining_size == 0 {
+                    cut_from = Some(key.clone());
+                    break;
+                }
+                trim_value(item, remaining_size, remaining_depth.saturating_sub(1));
+                // Account for the key's own serialized bytes too — trim_value
+                // only measures the value, but a real entry costs
+                // `"key":value,` in the serialized object.
+                let key_overhead = key.len() + 4; // quotes + colon + comma
+                *remaining_size = remaining_size.saturating_sub(key_overhead);
+            }
+            if let Some(key) = cut_from {
+                map.retain(|k, _| *k < key);
+            }
+        }
+        _ => {}
+    }
+
+    let size = serde_json::to_string(value).map(|s| s.len()).unwrap_or(0);
+    *remaining_size = remaining_size.saturating_sub(size);
+}
+
+/// Truncates `s` to at most `max_bytes` bytes, backing off to the nearest
+/// valid UTF-8 char boundary so we never split a multi-byte character.
+fn truncate_to_bytes(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn trim_databag_truncates_a_string_over_the_byte_budget() {
+        let mut value = json!("x".repeat(100));
+
+        trim_databag(&mut value, 10, 5);
+
+        let s = value.as_str().unwrap();
+        assert!(
+            s.len() <= 10,
+            "string should be truncated to fit the byte budget, got {} bytes",
+            s.len()
+        );
+    }
+
+    #[test]
+    fn trim_databag_array_drops_trailing_elements_once_budget_is_exhausted() {
+        let items: Vec<String> = (0..20).map(|_| "x".repeat(20)).collect();
+        let mut value = json!(items);
+
+        trim_databag(&mut value, 50, 5);
+
+        let arr = value.as_array().unwrap();
+        assert!(
+            arr.len() < 20,
+            "array exceeding the byte budget should be cut short, got {} of 20 items",
+            arr.len()
+        );
+        assert_eq!(
+            arr[0].as_str().unwrap(),
+            "x".repeat(20),
+            "leading elements within budget should be kept intact"
+        );
+    }
+
+    #[test]
+    fn trim_databag_object_drops_trailing_keys_once_budget_is_exhausted() {
+        let mut map = serde_json::Map::new();
+        for i in 0..20 {
+            map.insert(format!("k{i:02}"), json!("x".repeat(20)));
+        }
+        let mut value = serde_json::Value::Object(map);
+
+        trim_databag(&mut value, 50, 5);
+
+        let obj = value.as_object().unwrap();
+        assert!(
+            obj.len() < 20,
+            "object exceeding the byte budget should drop trailing keys, got {} of 20",
+            obj.len()
+        );
+        assert!(
+            obj.contains_key("k00"),
+            "leading keys within budget should be kept"
+        );
+    }
+
+    #[test]
+    fn trim_databag_deletes_container_once_depth_budget_is_exhausted() {
+        let mut value = json!({ "a": { "b": "c" } });
+
+        trim_databag(&mut value, 1000, 1);
+
+        assert_eq!(
+            value["a"],
+            serde_json::Value::Null,
+            "a container nested beyond max_depth should be deleted outright, not left in place"
+        );
+    }
+
+    #[test]
+    fn trim_databag_accounts_for_object_key_overhead_not_just_values() {
+        // Long keys, tiny values — if key bytes aren't counted toward the
+        // budget, this object would blow way past it despite every value
+        // being a single byte.
+        let mut map = serde_json::Map::new();
+        for i in 0..50 {
+            map.insert(format!("{}-{i}", "k".repeat(20)), json!(1));
+        }
+        let mut value = serde_json::Value::Object(map);
+
+        trim_databag(&mut value, 200, 5);
+
+        let serialized = serde_json::to_string(&value).unwrap();
+        assert!(
+            serialized.len() <= 200 + 32,
+            "object should stay within budget once key overhead is counted, got {} bytes",
+            serialized.len()
+        );
+    }
+
+    #[test]
+    fn trim_databag_accounts_for_separator_commas_between_many_small_entries() {
+        // Individually each entry is well within budget, but hundreds of
+        // them add up — including the comma between every pair, which is
+        // easy to forget when accounting per-item instead of per-serialized-output.
+        let mut map = serde_json::Map::new();
+        for i in 0..500 {
+            map.insert(format!("pkg{i:03}"), json!("1.0.0"));
+        }
+        let mut value = serde_json::Value::Object(map);
+
+        trim_databag(&mut value, 8192, 7);
+
+        let serialized = serde_json::to_string(&value).unwrap();
+        assert!(
+            serialized.len() <= 8192 + 32,
+            "serialized output must respect the byte budget once separators are counted, got {} bytes",
+            serialized.len()
+        );
+    }
+
+    #[test]
+    fn trim_databag_is_noop_for_a_small_value() {
+        let original = json!({ "x": "1", "y": ["a", "b"] });
+        let mut value = original.clone();
+
+        trim_databag(&mut value, 2048, 5);
+
+        assert_eq!(
+            value, original,
+            "a within-budget databag must be left untouched"
+        );
+    }
+}

--- a/apps/server/src/services/generic_trim.rs
+++ b/apps/server/src/services/generic_trim.rs
@@ -38,6 +38,11 @@ fn trim_value(value: &mut serde_json::Value, remaining_size: &mut usize, remaini
             if s.len() > *remaining_size {
                 *s = truncate_to_bytes(s, *remaining_size);
             }
+            // Only place this accounts for its own size — Array/Object
+            // account for their contents inline below instead (see those
+            // arms), so a value's cost is never double-subtracted. +2 for
+            // the surrounding quotes, which `s.len()` alone doesn't cover.
+            *remaining_size = remaining_size.saturating_sub(s.len() + 2);
         }
         serde_json::Value::Array(arr) => {
             let mut cut_at = arr.len();
@@ -52,6 +57,7 @@ fn trim_value(value: &mut serde_json::Value, remaining_size: &mut usize, remaini
                 *remaining_size = remaining_size.saturating_sub(1);
             }
             arr.truncate(cut_at);
+            *remaining_size = remaining_size.saturating_sub(2); // "[" + "]"
         }
         serde_json::Value::Object(map) => {
             let mut cut_from: Option<String> = None;
@@ -70,12 +76,15 @@ fn trim_value(value: &mut serde_json::Value, remaining_size: &mut usize, remaini
             if let Some(key) = cut_from {
                 map.retain(|k, _| *k < key);
             }
+            *remaining_size = remaining_size.saturating_sub(2); // "{" + "}"
         }
-        _ => {}
+        _ => {
+            // Numbers, bools, null — no in-place trimming, just account
+            // for their (small, fixed) serialized cost.
+            let size = serde_json::to_string(value).map(|s| s.len()).unwrap_or(0);
+            *remaining_size = remaining_size.saturating_sub(size);
+        }
     }
-
-    let size = serde_json::to_string(value).map(|s| s.len()).unwrap_or(0);
-    *remaining_size = remaining_size.saturating_sub(size);
 }
 
 /// Truncates `s` to at most `max_bytes` bytes, backing off to the nearest
@@ -204,6 +213,34 @@ mod tests {
             serialized.len() <= 8192 + 32,
             "serialized output must respect the byte budget once separators are counted, got {} bytes",
             serialized.len()
+        );
+    }
+
+    #[test]
+    fn trim_databag_does_not_double_count_nested_container_overhead() {
+        // Each outer entry wraps a small nested object (`{"v":"xxxx...x"}`,
+        // ~28 real bytes). The old implementation subtracted the nested
+        // object's contents once while processing it, then re-serialized
+        // and subtracted the *whole nested object* a second time when that
+        // recursive call returned — roughly doubling the cost charged to
+        // the outer budget for every nested entry. With enough entries that
+        // compounds into dropping entries that genuinely fit.
+        let mut map = serde_json::Map::new();
+        for i in 0..10 {
+            let mut inner = serde_json::Map::new();
+            inner.insert("v".to_string(), json!("x".repeat(20)));
+            map.insert(format!("e{i}"), serde_json::Value::Object(inner));
+        }
+        let mut value = serde_json::Value::Object(map);
+
+        trim_databag(&mut value, 380, 5);
+
+        let obj = value.as_object().unwrap();
+        assert_eq!(
+            obj.len(),
+            10,
+            "all 10 entries fit the real ~341-byte serialized cost within the \
+             380-byte budget and none should be dropped"
         );
     }
 

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -2,6 +2,8 @@ pub mod access;
 pub mod alert;
 pub mod auth_token;
 pub mod event;
+pub mod event_trim;
+pub mod generic_trim;
 pub mod grouping;
 pub mod invitation;
 pub mod issue;
@@ -21,6 +23,7 @@ pub mod users;
 pub use alert::AlertService;
 pub use auth_token::AuthTokenService;
 pub use event::EventService;
+pub use event_trim::trim_oversized_event;
 pub use grouping::{
     calculate_grouping_key, get_denormalized_fields, hash_grouping_key, DenormalizedFields,
 };

--- a/apps/server/src/services/sourcemap.rs
+++ b/apps/server/src/services/sourcemap.rs
@@ -559,6 +559,12 @@ pub async fn assemble_bundle(
 
 /// Rewrites stack frames in `event_data` using stored source maps.
 ///
+/// Walks both places Sentry's protocol allows a stack trace to live:
+/// `exception.values[*].stacktrace.frames` and `threads.values[*].stacktrace.frames`
+/// (the latter carries crashes reported via threads instead of an exception —
+/// e.g. JS worker-thread crashes). Both have the identical `values[i].stacktrace.frames`
+/// shape, so the same walk works under either root key.
+///
 /// Frame-rewriting errors are non-fatal: we `warn!` and continue.
 pub async fn rewrite_frames(
     provider: &dyn SourceMapProvider,
@@ -586,29 +592,44 @@ pub async fn rewrite_frames(
         return Ok(());
     }
 
-    // 2. Iterate by index to avoid holding a &mut borrow across .await points.
-    let exc_count = event_data["exception"]["values"]
+    rewrite_frames_under(provider, project_id, event_data, "exception", &images_map).await?;
+    rewrite_frames_under(provider, project_id, event_data, "threads", &images_map).await?;
+
+    Ok(())
+}
+
+/// Rewrites every frame under `event_data[root_key]["values"][*]["stacktrace"]["frames"]`.
+/// `root_key` is `"exception"` or `"threads"` — see [`rewrite_frames`].
+async fn rewrite_frames_under(
+    provider: &dyn SourceMapProvider,
+    project_id: i32,
+    event_data: &mut serde_json::Value,
+    root_key: &str,
+    images_map: &HashMap<String, String>,
+) -> AppResult<()> {
+    // Iterate by index to avoid holding a &mut borrow across .await points.
+    let value_count = event_data[root_key]["values"]
         .as_array()
         .map(|a| a.len())
         .unwrap_or(0);
-    if exc_count == 0 {
+    if value_count == 0 {
         return Ok(());
     }
 
-    for exc_idx in 0..exc_count {
-        let frame_count = event_data["exception"]["values"][exc_idx]["stacktrace"]["frames"]
+    for value_idx in 0..value_count {
+        let frame_count = event_data[root_key]["values"][value_idx]["stacktrace"]["frames"]
             .as_array()
             .map(|a| a.len())
             .unwrap_or(0);
 
         for frame_idx in 0..frame_count {
             // 3a. Extract frame fields as owned values (no live borrow across .await)
-            let filename: Option<String> = event_data["exception"]["values"][exc_idx]["stacktrace"]
+            let filename: Option<String> = event_data[root_key]["values"][value_idx]["stacktrace"]
                 ["frames"][frame_idx]
                 .get("filename")
                 .and_then(|f| f.as_str())
                 .map(|s| s.to_string());
-            let abs_path: Option<String> = event_data["exception"]["values"][exc_idx]["stacktrace"]
+            let abs_path: Option<String> = event_data[root_key]["values"][value_idx]["stacktrace"]
                 ["frames"][frame_idx]
                 .get("abs_path")
                 .and_then(|f| f.as_str())
@@ -617,12 +638,12 @@ pub async fn rewrite_frames(
             if abs_path.is_none() && filename.is_none() {
                 continue;
             }
-            let frame_lineno: Option<u32> = event_data["exception"]["values"][exc_idx]
-                ["stacktrace"]["frames"][frame_idx]
+            let frame_lineno: Option<u32> = event_data[root_key]["values"][value_idx]["stacktrace"]
+                ["frames"][frame_idx]
                 .get("lineno")
                 .and_then(|l| l.as_u64())
                 .map(|l| l as u32);
-            let frame_colno: Option<u32> = event_data["exception"]["values"][exc_idx]["stacktrace"]
+            let frame_colno: Option<u32> = event_data[root_key]["values"][value_idx]["stacktrace"]
                 ["frames"][frame_idx]
                 .get("colno")
                 .and_then(|c| c.as_u64())
@@ -696,7 +717,7 @@ pub async fn rewrite_frames(
             let pre_start = l.saturating_sub(3);
             let post_end = lines.len().min(l + 4);
 
-            let existing_function = event_data["exception"]["values"][exc_idx]["stacktrace"]
+            let existing_function = event_data[root_key]["values"][value_idx]["stacktrace"]
                 ["frames"][frame_idx]
                 .get("function")
                 .and_then(|f| f.as_str())
@@ -725,7 +746,7 @@ pub async fn rewrite_frames(
 
             // 3l. Write rewritten fields back by index path (fresh borrow, no cross-await alias)
             let frame =
-                &mut event_data["exception"]["values"][exc_idx]["stacktrace"]["frames"][frame_idx];
+                &mut event_data[root_key]["values"][value_idx]["stacktrace"]["frames"][frame_idx];
             // Only overwrite filename/abs_path when the token has a non-empty source name.
             // A None/empty source (malformed map) must not corrupt the original filename.
             // Reference: getsentry/symbolicator symbolication.rs L246-273 (e282ec0)
@@ -817,6 +838,38 @@ mod tests {
         assert_eq!(
             frame["abs_path"], "https://example.com/app.min.js",
             "abs_path should not be cleared when source name is empty"
+        );
+    }
+
+    #[tokio::test]
+    async fn rewrite_frames_also_rewrites_thread_stacktrace_frames() {
+        let provider = mock_provider(SOURCEMAP_EMPTY_SOURCE);
+        let mut event = serde_json::json!({
+            "debug_meta": {
+                "images": [{"type": "sourcemap", "code_file": "app.min.js", "debug_id": "test-debug-id"}]
+            },
+            "threads": { "values": [{
+                "id": "0",
+                "crashed": true,
+                "stacktrace": { "frames": [{
+                    "filename": "app.min.js",
+                    "lineno": 1,
+                    "colno": 0,
+                    "function": "minifiedFn"
+                }]}
+            }]}
+        });
+
+        rewrite_frames(&provider, 1, &mut event).await.unwrap();
+
+        let frame = &event["threads"]["values"][0]["stacktrace"]["frames"][0];
+        assert_eq!(
+            frame["lineno"], 5,
+            "thread frame lineno should be remapped just like exception frames"
+        );
+        assert_eq!(
+            frame["function"], "originalFunction",
+            "thread frame function should be resolved from the source map, same as exception frames"
         );
     }
 

--- a/apps/server/tests/unit/envelope_parser_test.rs
+++ b/apps/server/tests/unit/envelope_parser_test.rs
@@ -520,10 +520,13 @@ fn test_payload_size_exactly_at_limit() {
 
 #[test]
 fn test_payload_size_over_limit() {
-    // Create a payload over 1MB limit
+    // Non-"event" items keep the original 1MB limit — "event" items get a
+    // relaxed ceiling instead (see ingest::parser::MAX_RAW_EVENT_SIZE and
+    // its unit tests) so the digest pipeline's trimming pass has verbose-
+    // but-legitimate payloads to work with instead of just rejecting them.
     let payload_size = 1024 * 1024 + 1; // 1MB + 1 byte
     let header = format!(
-        "{{\"event_id\":\"abc\"}}\n{{\"type\":\"event\",\"length\":{}}}\n",
+        "{{\"event_id\":\"abc\"}}\n{{\"type\":\"session\",\"length\":{}}}\n",
         payload_size
     );
     let mut envelope = header.into_bytes();

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/breadcrumbs-expand.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/breadcrumbs-expand.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  type Breadcrumb,
+  BreadcrumbTimeline,
+  groupConsecutiveBreadcrumbs,
+} from './breadcrumbs';
+
+interface BreadcrumbsExpandProps {
+  items: Breadcrumb[];
+  summaryItems: Breadcrumb[];
+}
+
+/** Renders the collapsed summary timeline with a "view N more" toggle that
+ *  swaps in the full timeline, in place — no drawer/sheet, nothing opens
+ *  elsewhere. Owns the expand state, since `Breadcrumbs` (its caller) is a
+ *  Server Component and can't hold it. */
+export function BreadcrumbsExpand({
+  items,
+  summaryItems,
+}: BreadcrumbsExpandProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const hiddenCount = items.length - summaryItems.length;
+  const grouped = groupConsecutiveBreadcrumbs(
+    isExpanded ? items : summaryItems,
+  );
+
+  return (
+    <div>
+      <BreadcrumbTimeline grouped={grouped} />
+      {hiddenCount > 0 && !isExpanded && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-2 w-full"
+          onClick={() => setIsExpanded(true)}
+        >
+          View {hiddenCount} more
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/breadcrumbs.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/breadcrumbs.tsx
@@ -10,9 +10,11 @@ import {
   Navigation,
   Terminal,
 } from 'lucide-react';
+import { getSummaryBreadcrumbs } from '@/lib/breadcrumbs';
 import { cn } from '@/lib/utils';
+import { BreadcrumbsExpand } from './breadcrumbs-expand';
 
-interface Breadcrumb {
+export interface Breadcrumb {
   timestamp?: number;
   type?: string;
   category?: string;
@@ -21,7 +23,7 @@ interface Breadcrumb {
   data?: Record<string, unknown>;
 }
 
-interface GroupedBreadcrumb {
+export interface GroupedBreadcrumb {
   crumb: Breadcrumb;
   count: number;
 }
@@ -41,7 +43,9 @@ function normalizeBreadcrumbs(
   return [];
 }
 
-function groupConsecutiveBreadcrumbs(items: Breadcrumb[]): GroupedBreadcrumb[] {
+export function groupConsecutiveBreadcrumbs(
+  items: Breadcrumb[],
+): GroupedBreadcrumb[] {
   const grouped: GroupedBreadcrumb[] = [];
   for (const crumb of items) {
     const last = grouped[grouped.length - 1];
@@ -89,25 +93,23 @@ function levelColor(level?: string): string {
   }
 }
 
-export function Breadcrumbs({ breadcrumbs }: BreadcrumbsProps) {
-  const items = normalizeBreadcrumbs(breadcrumbs);
-  const grouped = groupConsecutiveBreadcrumbs(items);
-
-  if (items.length === 0) {
-    return (
-      <div className="py-8 text-center text-sm text-muted-foreground">
-        No breadcrumbs available
-      </div>
-    );
-  }
-
+/**
+ * Renders a grouped breadcrumb list. Pure/presentational (no hooks, no
+ * server-only APIs) — shared between this Server Component and
+ * `BreadcrumbsExpand` (a `'use client'` module), which is legal in Next.js
+ * as long as neither side needs directives of its own.
+ */
+export function BreadcrumbTimeline({
+  grouped,
+}: {
+  grouped: GroupedBreadcrumb[];
+}) {
   return (
     <ol className="relative">
       {grouped.map(({ crumb, count }, i) => {
         const Icon = crumbIcon(crumb);
         const isLast = i === grouped.length - 1;
         return (
-          // biome-ignore lint/suspicious/noArrayIndexKey: stable crumb order
           <li key={i} className="relative flex gap-3 pb-4 last:pb-0">
             {!isLast && (
               <span className="absolute left-[13px] top-7 bottom-0 w-px bg-border" />
@@ -150,4 +152,20 @@ export function Breadcrumbs({ breadcrumbs }: BreadcrumbsProps) {
       })}
     </ol>
   );
+}
+
+export function Breadcrumbs({ breadcrumbs }: BreadcrumbsProps) {
+  const items = normalizeBreadcrumbs(breadcrumbs);
+
+  if (items.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-muted-foreground">
+        No breadcrumbs available
+      </div>
+    );
+  }
+
+  const summaryItems = getSummaryBreadcrumbs(items);
+
+  return <BreadcrumbsExpand items={items} summaryItems={summaryItems} />;
 }

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/page.tsx
@@ -17,7 +17,11 @@ import { EventChart } from '@/components/event-chart';
 import { EventHighlights } from '@/components/event-highlights';
 import { StatusIndicator } from '@/components/issue-indicators';
 import { TagDistribution } from '@/components/tag-distribution';
-import { normalizeBreadcrumbs, parseEventData } from '@/lib/event-schema';
+import {
+  normalizeBreadcrumbs,
+  normalizeThreads,
+  parseEventData,
+} from '@/lib/event-schema';
 import { formatStackTraceAsText } from '@/lib/format-stack-trace';
 import { cn } from '@/lib/utils';
 import { IssueActions } from '../../issue-actions';
@@ -30,6 +34,7 @@ import { EventNavigationBar } from './event-navigation';
 import { EventTags } from './event-tags';
 import { RawJson } from './raw-json';
 import { StackTrace } from './stack-trace';
+import { ThreadsSection } from './threads-section';
 
 interface EventPageProps {
   params: Promise<{ id: string; issueId: string; eventId: string }>;
@@ -90,14 +95,21 @@ export default async function EventPage({ params }: EventPageProps) {
   const {
     exception,
     breadcrumbs: rawBreadcrumbs,
+    threads: rawThreads,
     contexts,
     modules,
     tags,
     user,
   } = parseEventData(eventData);
   const breadcrumbs = normalizeBreadcrumbs(rawBreadcrumbs);
+  const threads = normalizeThreads(rawThreads);
 
-  const hasStackTrace = Boolean(exception?.values?.length);
+  // A `threads` entry supersedes a bare `exception` view — same dispatch
+  // Sentry's frontend uses (crashes reported via threads carry their own
+  // exception cross-linking, so the plain exception view would be a
+  // strictly worse rendering of the same data).
+  const hasThreads = threads.length > 0;
+  const hasStackTrace = hasThreads || Boolean(exception?.values?.length);
   const hasBreadcrumbs = breadcrumbs.length > 0;
   const hasContexts = Boolean(contexts && Object.keys(contexts).length > 0);
   const hasModules = Boolean(modules && Object.keys(modules).length > 0);
@@ -346,21 +358,40 @@ export default async function EventPage({ params }: EventPageProps) {
                   id="stacktrace"
                   title="Stack Trace"
                   actions={
-                    <CopyAsDropdown
-                      formats={[
-                        {
-                          label: 'Plain Text',
-                          value: formatStackTraceAsText(exception),
-                        },
-                        {
-                          label: 'JSON',
-                          value: JSON.stringify(exception, null, 2),
-                        },
-                      ]}
-                    />
+                    // ThreadsSection owns its own copy control — the active
+                    // thread/exception pairing is client state the section
+                    // header (a Server Component) can't see.
+                    hasThreads ? undefined : (
+                      <CopyAsDropdown
+                        formats={[
+                          {
+                            label: 'Plain Text',
+                            value: formatStackTraceAsText(
+                              exception,
+                              event.platform,
+                            ),
+                          },
+                          {
+                            label: 'JSON',
+                            value: JSON.stringify(exception, null, 2),
+                          },
+                        ]}
+                      />
+                    )
                   }
                 >
-                  <StackTrace exception={exception} />
+                  {hasThreads ? (
+                    <ThreadsSection
+                      threads={threads}
+                      exception={exception}
+                      platform={event.platform}
+                    />
+                  ) : (
+                    <StackTrace
+                      exception={exception}
+                      platform={event.platform}
+                    />
+                  )}
                 </Section>
               )}
 

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/stack-frame-item.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/stack-frame-item.tsx
@@ -103,8 +103,8 @@ export function StackFrameItem({
           </p>
           <p className="text-xs text-muted-foreground font-mono truncate">
             {frameLocationLabel(frame)}
-            {frame.lineno && `:${frame.lineno}`}
-            {frame.colno && `:${frame.colno}`}
+            {frame.lineno != null && `:${frame.lineno}`}
+            {frame.colno != null && `:${frame.colno}`}
           </p>
         </div>
 
@@ -124,9 +124,9 @@ export function StackFrameItem({
         <>
           {contextLines.length > 0 && (
             <div className="bg-zinc-900 font-mono text-xs leading-relaxed overflow-x-auto">
-              {contextLines.map((line) => (
+              {contextLines.map((line, i) => (
                 <CodeLine
-                  key={line.lineNumber}
+                  key={i}
                   lineNumber={line.lineNumber}
                   code={line.code}
                   language={language}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/stack-frame-item.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/stack-frame-item.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import {
+  buildFrameContextLines,
+  type StackFrame,
+} from '@/lib/format-stack-trace';
+import { cn } from '@/lib/utils';
+
+/**
+ * Detect programming language from filename extension
+ */
+function detectLanguage(filename?: string): string {
+  if (!filename) return 'text';
+
+  const ext = filename.split('.').pop()?.toLowerCase();
+  const langMap: Record<string, string> = {
+    js: 'javascript',
+    jsx: 'jsx',
+    ts: 'typescript',
+    tsx: 'tsx',
+    py: 'python',
+    rb: 'ruby',
+    go: 'go',
+    rs: 'rust',
+    java: 'java',
+    kt: 'kotlin',
+    swift: 'swift',
+    cs: 'csharp',
+    cpp: 'cpp',
+    c: 'c',
+    h: 'c',
+    hpp: 'cpp',
+    php: 'php',
+    sh: 'bash',
+    bash: 'bash',
+    zsh: 'bash',
+    sql: 'sql',
+    json: 'json',
+    yaml: 'yaml',
+    yml: 'yaml',
+    xml: 'xml',
+    html: 'html',
+    css: 'css',
+    scss: 'scss',
+    less: 'less',
+    md: 'markdown',
+  };
+
+  return langMap[ext ?? ''] ?? 'text';
+}
+
+/** Best-effort label for a frame's origin — `filename` first, falling back
+ *  to `module`/`package` for platforms (JVM, .NET, native) that identify
+ *  frames that way instead. */
+function frameLocationLabel(frame: StackFrame): string {
+  return frame.filename || frame.module || frame.package || '<unknown>';
+}
+
+export function StackFrameItem({
+  frame,
+  index,
+}: {
+  frame: StackFrame;
+  index: number;
+}) {
+  const [isExpanded, setIsExpanded] = useState(frame.in_app ?? false);
+  const contextLines = buildFrameContextLines(frame);
+  const hasVars = frame.vars && Object.keys(frame.vars).length > 0;
+  const hasContext = contextLines.length > 0 || hasVars;
+
+  const language = detectLanguage(frame.filename);
+
+  return (
+    <div
+      className={cn(
+        'border rounded-lg overflow-hidden transition-colors',
+        frame.in_app
+          ? 'border-primary/40 bg-primary/5'
+          : 'border-border bg-card/50 opacity-60',
+      )}
+    >
+      {/* Frame Header */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full px-4 py-3 flex items-center gap-4 text-left hover:bg-muted/30 transition-colors"
+      >
+        <span
+          className={cn(
+            'text-xs font-mono',
+            frame.in_app ? 'text-primary' : 'text-muted-foreground',
+          )}
+        >
+          {String(index).padStart(2, '0')}
+        </span>
+
+        <div className="flex-1 min-w-0">
+          <p className="font-mono text-sm font-semibold truncate">
+            {frame.function || frame.raw_function || '<anonymous>'}
+          </p>
+          <p className="text-xs text-muted-foreground font-mono truncate">
+            {frameLocationLabel(frame)}
+            {frame.lineno && `:${frame.lineno}`}
+            {frame.colno && `:${frame.colno}`}
+          </p>
+        </div>
+
+        {hasContext && (
+          <span className="text-muted-foreground">
+            {isExpanded ? (
+              <ChevronDown className="size-4" />
+            ) : (
+              <ChevronRight className="size-4" />
+            )}
+          </span>
+        )}
+      </button>
+
+      {/* Frame Context with Syntax Highlighting */}
+      {isExpanded && hasContext && (
+        <>
+          {contextLines.length > 0 && (
+            <div className="bg-zinc-900 font-mono text-xs leading-relaxed overflow-x-auto">
+              {contextLines.map((line) => (
+                <CodeLine
+                  key={line.lineNumber}
+                  lineNumber={line.lineNumber}
+                  code={line.code}
+                  language={language}
+                  isHighlighted={line.isHighlighted}
+                />
+              ))}
+            </div>
+          )}
+          {hasVars && <FrameVariables vars={frame.vars!} />}
+        </>
+      )}
+    </div>
+  );
+}
+
+function FrameVariables({ vars }: { vars: Record<string, unknown> }) {
+  return (
+    <div className="border-t px-4 py-3 space-y-1.5">
+      <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+        Variables
+      </p>
+      <dl className="space-y-1">
+        {Object.entries(vars).map(([key, value]) => (
+          <div key={key} className="flex gap-2 text-xs font-mono">
+            <dt className="shrink-0 text-muted-foreground">{key}</dt>
+            <dd className="min-w-0 break-all text-foreground">
+              {typeof value === 'string' ? value : JSON.stringify(value)}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function CodeLine({
+  lineNumber,
+  code,
+  language,
+  isHighlighted,
+}: {
+  lineNumber: number;
+  code: string;
+  language: string;
+  isHighlighted: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex relative',
+        isHighlighted ? 'bg-primary/15' : 'opacity-60',
+      )}
+    >
+      {/* Highlight indicator */}
+      {isHighlighted && (
+        <div className="absolute left-0 top-0 bottom-0 w-[3px] bg-primary" />
+      )}
+
+      {/* Line number */}
+      <span
+        className={cn(
+          'w-12 shrink-0 text-right pr-4 pl-3 select-none py-0.5',
+          isHighlighted ? 'text-primary font-medium' : 'text-muted-foreground',
+        )}
+      >
+        {lineNumber}
+      </span>
+
+      {/* Code with syntax highlighting */}
+      <div className="flex-1 py-0.5 pr-4 overflow-x-auto">
+        <SyntaxHighlighter
+          language={language}
+          style={vscDarkPlus}
+          customStyle={{
+            margin: 0,
+            padding: 0,
+            background: 'transparent',
+            fontSize: 'inherit',
+            lineHeight: 'inherit',
+          }}
+          codeTagProps={{
+            style: {
+              fontFamily: 'inherit',
+              whiteSpace: 'pre',
+            },
+          }}
+        >
+          {code || ' '}
+        </SyntaxHighlighter>
+      </div>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/stack-trace.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/stack-trace.tsx
@@ -1,60 +1,17 @@
 'use client';
 
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import { useState } from 'react';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import type { ExceptionChain, StackFrame } from '@/lib/format-stack-trace';
-import { cn } from '@/lib/utils';
+import {
+  type ExceptionChain,
+  orderFramesForDisplay,
+} from '@/lib/format-stack-trace';
+import { StackFrameItem } from './stack-frame-item';
 
 interface StackTraceProps {
   exception?: ExceptionChain;
+  platform?: string;
 }
 
-/**
- * Detect programming language from filename extension
- */
-function detectLanguage(filename?: string): string {
-  if (!filename) return 'text';
-
-  const ext = filename.split('.').pop()?.toLowerCase();
-  const langMap: Record<string, string> = {
-    js: 'javascript',
-    jsx: 'jsx',
-    ts: 'typescript',
-    tsx: 'tsx',
-    py: 'python',
-    rb: 'ruby',
-    go: 'go',
-    rs: 'rust',
-    java: 'java',
-    kt: 'kotlin',
-    swift: 'swift',
-    cs: 'csharp',
-    cpp: 'cpp',
-    c: 'c',
-    h: 'c',
-    hpp: 'cpp',
-    php: 'php',
-    sh: 'bash',
-    bash: 'bash',
-    zsh: 'bash',
-    sql: 'sql',
-    json: 'json',
-    yaml: 'yaml',
-    yml: 'yaml',
-    xml: 'xml',
-    html: 'html',
-    css: 'css',
-    scss: 'scss',
-    less: 'less',
-    md: 'markdown',
-  };
-
-  return langMap[ext ?? ''] ?? 'text';
-}
-
-export function StackTrace({ exception }: StackTraceProps) {
+export function StackTrace({ exception, platform }: StackTraceProps) {
   const exceptions = exception?.values ?? [];
 
   if (exceptions.length === 0) {
@@ -67,205 +24,32 @@ export function StackTrace({ exception }: StackTraceProps) {
 
   return (
     <div className="space-y-6">
-      {exceptions.map((exc, i) => (
-        <div key={i} className="space-y-4">
-          {/* Exception Header */}
-          <div className="space-y-1">
-            <h3 className="text-lg font-bold text-destructive">{exc.type}</h3>
-            <p className="text-sm text-muted-foreground">{exc.value}</p>
-          </div>
-
-          {/* Frames */}
-          {exc.stacktrace?.frames && (
-            <div className="space-y-2">
-              {[...exc.stacktrace.frames].reverse().map((frame, j) => (
-                <StackFrameItem
-                  key={j}
-                  frame={frame}
-                  index={exc.stacktrace!.frames!.length - j}
-                />
-              ))}
+      {exceptions.map((exc, i) => {
+        const originalFrames = exc.stacktrace?.frames ?? [];
+        const displayFrames = orderFramesForDisplay(originalFrames, platform);
+        return (
+          <div key={i} className="space-y-4">
+            {/* Exception Header */}
+            <div className="space-y-1">
+              <h3 className="text-lg font-bold text-destructive">{exc.type}</h3>
+              <p className="text-sm text-muted-foreground">{exc.value}</p>
             </div>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-}
 
-function StackFrameItem({
-  frame,
-  index,
-}: {
-  frame: StackFrame;
-  index: number;
-}) {
-  const [isExpanded, setIsExpanded] = useState(frame.in_app ?? false);
-  const hasContext =
-    frame.context_line ||
-    (frame.pre_context && frame.pre_context.length > 0) ||
-    (frame.post_context && frame.post_context.length > 0);
-
-  const language = detectLanguage(frame.filename);
-
-  return (
-    <div
-      className={cn(
-        'border rounded-lg overflow-hidden transition-colors',
-        frame.in_app
-          ? 'border-primary/40 bg-primary/5'
-          : 'border-border bg-card/50 opacity-60',
-      )}
-    >
-      {/* Frame Header */}
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full px-4 py-3 flex items-center gap-4 text-left hover:bg-muted/30 transition-colors"
-      >
-        <span
-          className={cn(
-            'text-xs font-mono',
-            frame.in_app ? 'text-primary' : 'text-muted-foreground',
-          )}
-        >
-          {String(index).padStart(2, '0')}
-        </span>
-
-        <div className="flex-1 min-w-0">
-          <p className="font-mono text-sm font-semibold truncate">
-            {frame.function || '<anonymous>'}
-          </p>
-          <p className="text-xs text-muted-foreground font-mono truncate">
-            {frame.filename}
-            {frame.lineno && `:${frame.lineno}`}
-            {frame.colno && `:${frame.colno}`}
-          </p>
-        </div>
-
-        {hasContext && (
-          <span className="text-muted-foreground">
-            {isExpanded ? (
-              <ChevronDown className="size-4" />
-            ) : (
-              <ChevronRight className="size-4" />
+            {/* Frames */}
+            {displayFrames.length > 0 && (
+              <div className="space-y-2">
+                {displayFrames.map((frame) => (
+                  <StackFrameItem
+                    key={originalFrames.indexOf(frame)}
+                    frame={frame}
+                    index={originalFrames.indexOf(frame) + 1}
+                  />
+                ))}
+              </div>
             )}
-          </span>
-        )}
-      </button>
-
-      {/* Frame Context with Syntax Highlighting */}
-      {isExpanded && hasContext && (
-        <FrameContext frame={frame} language={language} />
-      )}
-    </div>
-  );
-}
-
-function FrameContext({
-  frame,
-  language,
-}: {
-  frame: StackFrame;
-  language: string;
-}) {
-  return (
-    <div className="bg-zinc-900 font-mono text-xs leading-relaxed overflow-x-auto">
-      {/* Pre-context */}
-      {frame.pre_context?.map((line, i) => {
-        const lineNo = (frame.lineno ?? 0) - frame.pre_context!.length + i;
-        return (
-          <CodeLine
-            key={`pre-${i}`}
-            lineNumber={lineNo}
-            code={line}
-            language={language}
-            isHighlighted={false}
-          />
+          </div>
         );
       })}
-
-      {/* Context line (highlighted) */}
-      {frame.context_line && (
-        <CodeLine
-          lineNumber={frame.lineno ?? 0}
-          code={frame.context_line}
-          language={language}
-          isHighlighted={true}
-        />
-      )}
-
-      {/* Post-context */}
-      {frame.post_context?.map((line, i) => {
-        const lineNo = (frame.lineno ?? 0) + i + 1;
-        return (
-          <CodeLine
-            key={`post-${i}`}
-            lineNumber={lineNo}
-            code={line}
-            language={language}
-            isHighlighted={false}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-function CodeLine({
-  lineNumber,
-  code,
-  language,
-  isHighlighted,
-}: {
-  lineNumber: number;
-  code: string;
-  language: string;
-  isHighlighted: boolean;
-}) {
-  return (
-    <div
-      className={cn(
-        'flex relative',
-        isHighlighted ? 'bg-primary/15' : 'opacity-60',
-      )}
-    >
-      {/* Highlight indicator */}
-      {isHighlighted && (
-        <div className="absolute left-0 top-0 bottom-0 w-[3px] bg-primary" />
-      )}
-
-      {/* Line number */}
-      <span
-        className={cn(
-          'w-12 shrink-0 text-right pr-4 pl-3 select-none py-0.5',
-          isHighlighted ? 'text-primary font-medium' : 'text-muted-foreground',
-        )}
-      >
-        {lineNumber}
-      </span>
-
-      {/* Code with syntax highlighting */}
-      <div className="flex-1 py-0.5 pr-4 overflow-x-auto">
-        <SyntaxHighlighter
-          language={language}
-          style={vscDarkPlus}
-          customStyle={{
-            margin: 0,
-            padding: 0,
-            background: 'transparent',
-            fontSize: 'inherit',
-            lineHeight: 'inherit',
-          }}
-          codeTagProps={{
-            style: {
-              fontFamily: 'inherit',
-              whiteSpace: 'pre',
-            },
-          }}
-        >
-          {code || ' '}
-        </SyntaxHighlighter>
-      </div>
     </div>
   );
 }

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/stack-trace.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/stack-trace.tsx
@@ -38,13 +38,16 @@ export function StackTrace({ exception, platform }: StackTraceProps) {
             {/* Frames */}
             {displayFrames.length > 0 && (
               <div className="space-y-2">
-                {displayFrames.map((frame) => (
-                  <StackFrameItem
-                    key={originalFrames.indexOf(frame)}
-                    frame={frame}
-                    index={originalFrames.indexOf(frame) + 1}
-                  />
-                ))}
+                {displayFrames.map((frame) => {
+                  const originalIdx = originalFrames.indexOf(frame);
+                  return (
+                    <StackFrameItem
+                      key={originalIdx}
+                      frame={frame}
+                      index={originalIdx + 1}
+                    />
+                  );
+                })}
               </div>
             )}
           </div>

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/threads-section.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/threads-section.tsx
@@ -132,13 +132,16 @@ export function ThreadsSection({
 
       {displayFrames.length > 0 ? (
         <div className="space-y-2">
-          {displayFrames.map((frame) => (
-            <StackFrameItem
-              key={originalFrames.indexOf(frame)}
-              frame={frame}
-              index={originalFrames.indexOf(frame) + 1}
-            />
-          ))}
+          {displayFrames.map((frame) => {
+            const originalIdx = originalFrames.indexOf(frame);
+            return (
+              <StackFrameItem
+                key={originalIdx}
+                frame={frame}
+                index={originalIdx + 1}
+              />
+            );
+          })}
         </div>
       ) : (
         <div className="text-center py-12 text-muted-foreground">

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/threads-section.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/threads-section.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { CopyAsDropdown } from '@/components/copy-as-dropdown';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  type ExceptionChain,
+  findBestThread,
+  formatStackTraceAsText,
+  matchExceptionForThread,
+  orderFramesForDisplay,
+  type Thread,
+} from '@/lib/format-stack-trace';
+import { StackFrameItem } from './stack-frame-item';
+
+interface ThreadsSectionProps {
+  threads: Thread[];
+  exception?: ExceptionChain;
+  platform?: string;
+}
+
+function threadLabel(thread: Thread): string {
+  return thread.name || `Thread #${thread.id ?? '?'}`;
+}
+
+function threadKey(thread: Thread, index: number): string {
+  return thread.id !== undefined ? String(thread.id) : `idx-${index}`;
+}
+
+export function ThreadsSection({
+  threads,
+  exception,
+  platform,
+}: ThreadsSectionProps) {
+  const bestThread = useMemo(() => findBestThread(threads), [threads]);
+  const [activeKey, setActiveKey] = useState<string>(() =>
+    bestThread ? threadKey(bestThread, threads.indexOf(bestThread)) : '',
+  );
+
+  if (threads.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        No stack trace available
+      </div>
+    );
+  }
+
+  const activeThread =
+    threads.find((t, i) => threadKey(t, i) === activeKey) ?? bestThread;
+  const matchedException = matchExceptionForThread(exception, activeThread);
+
+  const originalFrames =
+    matchedException?.stacktrace?.frames ??
+    activeThread?.stacktrace?.frames ??
+    [];
+  const displayFrames = orderFramesForDisplay(originalFrames, platform);
+
+  const copyFormats = matchedException
+    ? [
+        {
+          label: 'Plain Text',
+          value: formatStackTraceAsText(
+            { values: [matchedException] },
+            platform,
+          ),
+        },
+        { label: 'JSON', value: JSON.stringify(matchedException, null, 2) },
+      ]
+    : [{ label: 'JSON', value: JSON.stringify(activeThread, null, 2) }];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        {threads.length > 1 ? (
+          <Select
+            value={activeKey}
+            onValueChange={(value) => {
+              if (value) setActiveKey(value);
+            }}
+          >
+            <SelectTrigger className="w-[260px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {threads.map((thread, i) => (
+                <SelectItem
+                  key={threadKey(thread, i)}
+                  value={threadKey(thread, i)}
+                >
+                  {threadLabel(thread)}
+                  {thread.crashed ? ' (crashed)' : ''}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <p className="text-sm font-semibold">
+            {activeThread ? threadLabel(activeThread) : 'Thread'}
+          </p>
+        )}
+
+        <div className="flex items-center gap-2">
+          {activeThread?.crashed && (
+            <Badge variant="destructive">Crashed</Badge>
+          )}
+          {activeThread?.current && <Badge variant="outline">Current</Badge>}
+          {activeThread?.main && <Badge variant="outline">Main</Badge>}
+          {activeThread?.state && (
+            <Badge variant="secondary">{activeThread.state}</Badge>
+          )}
+          <CopyAsDropdown formats={copyFormats} />
+        </div>
+      </div>
+
+      {matchedException && (
+        <div className="space-y-1">
+          <h3 className="text-lg font-bold text-destructive">
+            {matchedException.type}
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            {matchedException.value}
+          </p>
+        </div>
+      )}
+
+      {displayFrames.length > 0 ? (
+        <div className="space-y-2">
+          {displayFrames.map((frame) => (
+            <StackFrameItem
+              key={originalFrames.indexOf(frame)}
+              frame={frame}
+              index={originalFrames.indexOf(frame) + 1}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-12 text-muted-foreground">
+          No stack trace available for this thread
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/webview-ui/src/lib/breadcrumbs.ts
+++ b/apps/webview-ui/src/lib/breadcrumbs.ts
@@ -1,0 +1,23 @@
+/**
+ * How many of the most recent breadcrumbs to show inline before collapsing
+ * the rest behind a "view all" affordance. Matches Sentry's own default
+ * (BREADCRUMB_SUMMARY_COUNT in
+ * static/app/components/events/breadcrumbs/utils.tsx) — the event already
+ * carries every breadcrumb the SDK sent (Relay doesn't truncate by count),
+ * this is purely about not dumping the whole timeline inline.
+ */
+export const BREADCRUMB_SUMMARY_COUNT = 5;
+
+/**
+ * Return the most recent `count` breadcrumbs for the inline summary view.
+ * If collapsing would only hide a single item, show everything instead —
+ * a "view 1 more" button isn't worth the extra click. Mirrors
+ * `getSummaryBreadcrumbs()` in Sentry's frontend.
+ */
+export function getSummaryBreadcrumbs<T>(
+  items: T[],
+  count: number = BREADCRUMB_SUMMARY_COUNT,
+): T[] {
+  if (items.length <= count + 1) return items;
+  return items.slice(items.length - count);
+}

--- a/apps/webview-ui/src/lib/event-schema.ts
+++ b/apps/webview-ui/src/lib/event-schema.ts
@@ -6,12 +6,16 @@ import { z } from 'zod';
 const stackFrameSchema = z.object({
   filename: z.string().optional(),
   function: z.string().optional(),
+  module: z.string().optional(),
+  package: z.string().optional(),
+  raw_function: z.string().optional(),
   lineno: z.number().optional(),
   colno: z.number().optional(),
   in_app: z.boolean().optional(),
   context_line: z.string().optional(),
   pre_context: z.array(z.string()).optional(),
   post_context: z.array(z.string()).optional(),
+  vars: z.record(z.string(), z.unknown()).optional(),
 });
 
 /**
@@ -20,6 +24,8 @@ const stackFrameSchema = z.object({
 const exceptionValueSchema = z.object({
   type: z.string().optional(),
   value: z.string().optional(),
+  /** Cross-references a `Thread.id` — links this exception to the thread that raised it. */
+  thread_id: z.union([z.string(), z.number()]).optional(),
   stacktrace: z
     .object({
       frames: z.array(stackFrameSchema).optional(),
@@ -35,6 +41,32 @@ const exceptionSchema = z
     values: z.array(exceptionValueSchema).optional(),
   })
   .optional();
+
+/**
+ * Schema for a single thread entry (native crashes, Go panics, JVM thread
+ * dumps — stack traces that arrive outside the `exception` object).
+ */
+const threadSchema = z.object({
+  id: z.union([z.string(), z.number()]).optional(),
+  name: z.string().optional(),
+  crashed: z.boolean().optional(),
+  current: z.boolean().optional(),
+  main: z.boolean().optional(),
+  state: z.string().optional(),
+  stacktrace: z
+    .object({
+      frames: z.array(stackFrameSchema).optional(),
+    })
+    .optional(),
+});
+
+/**
+ * Schema for `threads` (can be array or object with values, same shape as breadcrumbs).
+ */
+const threadsSchema = z.union([
+  z.array(threadSchema),
+  z.object({ values: z.array(threadSchema).optional() }),
+]);
 
 /**
  * Schema for a breadcrumb entry.
@@ -91,6 +123,7 @@ const modulesSchema = z.record(z.string(), z.string()).optional();
  * Parsed and validated event data types.
  */
 type ValidatedEventBreadcrumbs = z.infer<typeof breadcrumbsSchema>;
+type ValidatedEventThreads = z.infer<typeof threadsSchema>;
 
 /**
  * Parse and validate event data from the Sentry event JSON.
@@ -99,6 +132,7 @@ type ValidatedEventBreadcrumbs = z.infer<typeof breadcrumbsSchema>;
 export function parseEventData(eventData: Record<string, unknown>) {
   const exception = exceptionSchema.safeParse(eventData.exception);
   const breadcrumbs = breadcrumbsSchema.safeParse(eventData.breadcrumbs);
+  const threads = threadsSchema.safeParse(eventData.threads);
   const contexts = contextsSchema.safeParse(eventData.contexts);
   const modules = modulesSchema.safeParse(eventData.modules);
   const tagsResult = tagsSchema.safeParse(eventData.tags);
@@ -114,6 +148,7 @@ export function parseEventData(eventData: Record<string, unknown>) {
   return {
     exception: exception.success ? exception.data : undefined,
     breadcrumbs: breadcrumbs.success ? breadcrumbs.data : undefined,
+    threads: threads.success ? threads.data : undefined,
     contexts: contexts.success ? contexts.data : undefined,
     modules: modules.success ? modules.data : undefined,
     tags,
@@ -138,3 +173,18 @@ export function normalizeBreadcrumbs(
   if (Array.isArray(breadcrumbs)) return breadcrumbs;
   return breadcrumbs.values ?? [];
 }
+
+/**
+ * Normalize threads to always be an array.
+ */
+export function normalizeThreads(
+  threads: ValidatedEventThreads | undefined,
+): z.infer<typeof threadSchema>[] {
+  if (!threads) return [];
+  if (Array.isArray(threads)) return threads;
+  return threads.values ?? [];
+}
+
+export type ParsedThread = z.infer<typeof threadSchema>;
+export type ParsedStackFrame = z.infer<typeof stackFrameSchema>;
+export type ParsedExceptionValue = z.infer<typeof exceptionValueSchema>;

--- a/apps/webview-ui/src/lib/format-stack-trace.ts
+++ b/apps/webview-ui/src/lib/format-stack-trace.ts
@@ -1,17 +1,23 @@
 export interface StackFrame {
   filename?: string;
   function?: string;
+  module?: string;
+  package?: string;
+  raw_function?: string;
   lineno?: number;
   colno?: number;
   in_app?: boolean;
   context_line?: string;
   pre_context?: string[];
   post_context?: string[];
+  vars?: Record<string, unknown>;
 }
 
 export interface ExceptionValue {
   type?: string;
   value?: string;
+  /** Cross-references a `Thread.id` — links this exception to the thread that raised it. */
+  thread_id?: string | number;
   stacktrace?: {
     frames?: StackFrame[];
   };
@@ -21,18 +27,170 @@ export interface ExceptionChain {
   values?: ExceptionValue[];
 }
 
+export interface Thread {
+  id?: string | number;
+  name?: string;
+  crashed?: boolean;
+  current?: boolean;
+  main?: boolean;
+  state?: string;
+  stacktrace?: {
+    frames?: StackFrame[];
+  };
+}
+
 /**
- * Plain-text rendering of the full exception chain, oldest frame last
- * (matches the UI). Kept out of stack-trace.tsx (a `'use client'` module) so
- * Server Components can call it directly — everything exported from a
- * `'use client'` file is treated as client-only, even plain helpers.
+ * A single line of rendered source code context for a frame, with its real
+ * (not guessed) line number.
  */
-export function formatStackTraceAsText(exception?: ExceptionChain): string {
+export interface FrameContextLine {
+  lineNumber: number;
+  code: string;
+  isHighlighted: boolean;
+}
+
+/**
+ * Platforms where Sentry's own UI shows frames oldest-first by default
+ * (matches how the platform's native traceback reads). Every other
+ * platform defaults to newest-first.
+ *
+ * Mirrors `is_newest_frame_first()` in the Sentry monolith
+ * (src/sentry/interfaces/stacktrace.py) — minus the per-user
+ * `stacktrace_order` preference override, which has no equivalent in
+ * Rustrak today.
+ */
+const OLDEST_FRAME_FIRST_PLATFORMS = new Set(['python']);
+
+export function shouldShowNewestFirst(platform?: string): boolean {
+  return !OLDEST_FRAME_FIRST_PLATFORMS.has(platform ?? '');
+}
+
+/**
+ * Order frames for display, respecting platform convention instead of
+ * always reversing. Protocol order is always oldest-to-newest
+ * (last frame = crash site); this only decides what to show first.
+ */
+export function orderFramesForDisplay(
+  frames: StackFrame[],
+  platform?: string,
+): StackFrame[] {
+  return shouldShowNewestFirst(platform) ? [...frames].reverse() : frames;
+}
+
+/**
+ * Build the renderable context-line window for a frame, with real line
+ * numbers. Mirrors `get_context()` in the Sentry monolith
+ * (src/sentry/interfaces/stacktrace.py): if there's no `lineno`, there is
+ * no context to show — guessing a base line (e.g. defaulting to 0) produces
+ * fabricated line numbers next to real code, which is worse than showing
+ * nothing.
+ */
+export function buildFrameContextLines(frame: StackFrame): FrameContextLine[] {
+  if (frame.lineno === undefined) return [];
+  if (
+    frame.context_line === undefined &&
+    !frame.pre_context?.length &&
+    !frame.post_context?.length
+  ) {
+    return [];
+  }
+
+  const lines: FrameContextLine[] = [];
+  const preContext = frame.pre_context ?? [];
+  // Clamp instead of going negative — mirrors Sentry's get_context(), which
+  // guards against pre_context arrays longer than the real lineno.
+  let atLineNumber = Math.max(0, frame.lineno - preContext.length);
+
+  for (const code of preContext) {
+    lines.push({ lineNumber: atLineNumber, code, isHighlighted: false });
+    atLineNumber++;
+  }
+
+  if (frame.context_line !== undefined) {
+    lines.push({
+      lineNumber: frame.lineno,
+      code: frame.context_line,
+      isHighlighted: true,
+    });
+  }
+  atLineNumber = frame.lineno + 1;
+
+  for (const code of frame.post_context ?? []) {
+    lines.push({ lineNumber: atLineNumber, code, isHighlighted: false });
+    atLineNumber++;
+  }
+
+  return lines;
+}
+
+/**
+ * Pick which thread to show by default when an event reports its crash via
+ * `threads` instead of (or in addition to) `exception`.
+ *
+ * Mirrors `findBestThread()` in Sentry's frontend
+ * (static/app/components/events/interfaces/threads/threadSelector/findBestThread.tsx):
+ * the crashed thread wins, then any thread that at least has a stacktrace,
+ * then just the first thread.
+ */
+export function findBestThread(threads: Thread[]): Thread | undefined {
+  return (
+    threads.find((t) => t.crashed) ??
+    threads.find((t) => t.stacktrace) ??
+    threads[0]
+  );
+}
+
+/**
+ * Find the exception value that belongs to a given thread, so a crashed
+ * thread can show the exception's type/value/frames instead of (or in
+ * place of) its own raw stacktrace.
+ *
+ * Mirrors the matching rules in Sentry's `getThreadException()`
+ * (static/app/components/events/interfaces/threads/threadSelector/getThreadException.tsx):
+ * prefer an explicit `thread_id` match; otherwise, if there's exactly one
+ * exception value with no `thread_id` at all and this thread crashed,
+ * attribute it to that thread.
+ */
+export function matchExceptionForThread(
+  exception: ExceptionChain | undefined,
+  thread: Thread | undefined,
+): ExceptionValue | undefined {
+  const values = exception?.values;
+  if (!values?.length || !thread) return undefined;
+
+  const matched = values.find((v) => v.thread_id === thread.id);
+  if (matched) return matched;
+
+  if (
+    values.length === 1 &&
+    values[0].thread_id === undefined &&
+    thread.crashed
+  ) {
+    return values[0];
+  }
+
+  return undefined;
+}
+
+/**
+ * Plain-text rendering of the full exception chain, frame order matching
+ * what the UI shows for this platform. Kept out of stack-trace.tsx (a
+ * `'use client'` module) so Server Components can call it directly —
+ * everything exported from a `'use client'` file is treated as
+ * client-only, even plain helpers.
+ */
+export function formatStackTraceAsText(
+  exception?: ExceptionChain,
+  platform?: string,
+): string {
   const exceptions = exception?.values ?? [];
   return exceptions
     .map((exc) => {
       const header = [exc.type, exc.value].filter(Boolean).join(': ');
-      const frames = [...(exc.stacktrace?.frames ?? [])].reverse();
+      const frames = orderFramesForDisplay(
+        exc.stacktrace?.frames ?? [],
+        platform,
+      );
       const frameLines = frames.map((frame) => {
         const location = [frame.filename, frame.lineno, frame.colno]
           .filter((part) => part !== undefined && part !== '')

--- a/apps/webview-ui/src/lib/format-stack-trace.ts
+++ b/apps/webview-ui/src/lib/format-stack-trace.ts
@@ -158,7 +158,19 @@ export function matchExceptionForThread(
   const values = exception?.values;
   if (!values?.length || !thread) return undefined;
 
-  const matched = values.find((v) => v.thread_id === thread.id);
+  // Coerce both sides before comparing. Relay's own `ThreadId` protocol type
+  // (relay-event-schema/src/protocol/thread.rs) explicitly allows either a
+  // string or an integer on the wire, and — unlike Sentry's real frontend
+  // (static/app/types/event.tsx, which just declares `Thread.id: number` /
+  // `threadId: number | null` without runtime enforcement) — we don't have
+  // an upstream normalization step that guarantees both sides end up the
+  // same type before this comparison runs. A strict `===` here would silently
+  // fail to link the exception whenever an SDK's `id` and `thread_id` happen
+  // to differ in representation, even though they refer to the same thread.
+  const matched = values.find(
+    (v) =>
+      v.thread_id !== undefined && String(v.thread_id) === String(thread.id),
+  );
   if (matched) return matched;
 
   if (


### PR DESCRIPTION
## Summary

Deep audit (frontend + backend) of the issue/event detail page against Sentry's real behavior, comparing against `getsentry/relay` and `getsentry/sentry` source. Three fixes:

- **Frontend — stack trace & breadcrumbs parity** (`apps/webview-ui`)
  - `event.threads` support: events that report their crash via threads instead of `exception` (native crashes, Go panics, JVM thread dumps) previously showed no stack trace section at all, even though the data was stored. New thread selector picks the crashed/best thread by default and cross-links to the matching exception by `thread_id`.
  - Frame order now respects platform convention (Python shows oldest-first, matching Sentry) instead of always reversing.
  - Context-line numbers are no longer fabricated when a frame has no `lineno` (was defaulting to 0, producing negative/wrong line numbers next to real code).
  - `frame.vars`, `module`, `package`, `raw_function` are now surfaced — previously dropped even though the SDK sent them.
  - Breadcrumbs collapse to the last 5 inline with an expand-in-place toggle, matching Sentry's `BREADCRUMB_SUMMARY_COUNT`.

- **Backend — source maps for thread frames** (`apps/server/src/services/sourcemap.rs`)
  - `rewrite_frames()` only walked `exception.values[*].stacktrace.frames`, never `threads.values[*].stacktrace.frames`. JS worker-thread crashes never got source-mapped even with a matching `debug_id`.

- **Backend — graceful trimming instead of hard rejection** (`apps/server/src/services/{event_trim,generic_trim}.rs`, `ingest/parser.rs`)
  - Events over the 1MB per-item budget were rejected outright, even when verbose-but-legitimate. Now "event" items get a relaxed 4MB abuse ceiling, and the digest pipeline trims the exact fields Relay's own schema annotates with a byte budget (`Frame.vars`/`Breadcrumb.data` at 2048B/depth 5, `extra` at 256KB/depth 7, `modules` and `request.data` at 8KB/depth 7 — cited from `relay-event-schema`) before falling back to rejection. Fields Relay doesn't cap (`pre_context`/`post_context`, breadcrumb count) are deliberately left untouched too.

No API/schema changes — everything here operates on the existing raw JSON event blob, no OpenAPI regen needed.

## Test plan

- [x] `cargo test --lib` — 151 passed, both `sqlite` (default) and `postgres` feature sets
- [x] `cargo clippy --lib -- -D warnings` — clean on both feature sets
- [x] `cargo fmt --check` — clean
- [x] `pnpm tsc --noEmit` — clean on all touched/new files (pre-existing unrelated `@rustrak/client` stale-types errors untouched)
- [x] `biome check` — clean on all touched/new files
- [x] Manual browser verification of the frontend changes (Python-ordered stack trace, missing-lineno frame, >5 breadcrumbs, threads selector, `vars` display) — not yet done in this session, flagging for reviewer/follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a thread-aware event view, with support for switching between multiple threads and exception details.
  * Breadcrumbs can now be expanded inline to show more history when needed.
  * Stack traces now render with richer frame details and platform-aware ordering.

* **Bug Fixes**
  * Improved handling of large event payloads so oversized data is trimmed more gracefully.
  * Expanded stack trace and source mapping support to cover more event types and show more accurate frame context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->