### PR TITLE
feat: auto-detect project platform icon (Sentry parity)

### DIFF
--- a/apps/server/migrations/postgres/20260703000000_add_project_platform.down.sql
+++ b/apps/server/migrations/postgres/20260703000000_add_project_platform.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects DROP COLUMN platform;

--- a/apps/server/migrations/postgres/20260703000000_add_project_platform.up.sql
+++ b/apps/server/migrations/postgres/20260703000000_add_project_platform.up.sql
@@ -1,0 +1,4 @@
+-- Sentry-parity project platform auto-detection.
+-- Mirrors sentry.models.project.Project.platform: nullable, set once by the
+-- digest pipeline from the first valid event.platform seen, never overwritten.
+ALTER TABLE projects ADD COLUMN platform VARCHAR(50);

--- a/apps/server/migrations/sqlite/20260703000000_add_project_platform.down.sql
+++ b/apps/server/migrations/sqlite/20260703000000_add_project_platform.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects DROP COLUMN platform;

--- a/apps/server/migrations/sqlite/20260703000000_add_project_platform.up.sql
+++ b/apps/server/migrations/sqlite/20260703000000_add_project_platform.up.sql
@@ -1,0 +1,4 @@
+-- Sentry-parity project platform auto-detection.
+-- Mirrors sentry.models.project.Project.platform: nullable, set once by the
+-- digest pipeline from the first valid event.platform seen, never overwritten.
+ALTER TABLE projects ADD COLUMN platform VARCHAR(50);

--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -875,6 +875,12 @@
                           "name": {
                             "type": "string"
                           },
+                          "platform": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
                           "sentry_key": {
                             "type": "string",
                             "format": "uuid"
@@ -6967,6 +6973,12 @@
           },
           "name": {
             "type": "string"
+          },
+          "platform": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "sentry_key": {
             "type": "string",

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -145,6 +145,12 @@ impl ErrorProcessor {
         .execute(pool)
         .await?;
 
+        // 8b. Sentry-parity platform auto-detection (set once, never overwritten)
+        if let Some(event_platform) = event_data.get("platform").and_then(|p| p.as_str()) {
+            ProjectService::infer_platform_from_event(pool, metadata.project_id, event_platform)
+                .await?;
+        }
+
         // Update rate limiting quotas (handles digested_event_count)
         RateLimitService::update_quota_state(pool, metadata.project_id, &self.rate_limit_config)
             .await?;

--- a/apps/server/src/models/mod.rs
+++ b/apps/server/src/models/mod.rs
@@ -58,7 +58,7 @@ pub use issue::{
     UpdateIssueState, STATUS_IGNORED, STATUS_RESOLVED, STATUS_UNRESOLVED,
 };
 pub use log::LogResponse;
-pub use project::{CreateProject, Project, ProjectResponse, UpdateProject};
+pub use project::{CreateProject, Project, ProjectResponse, UpdateProject, VALID_PLATFORMS};
 pub use project_member::{ProjectMember, ProjectMemberResponse, ProjectRole, UpsertProjectMember};
 pub use storage::{
     CleanupCounts, CleanupFilter, CleanupRequest, ProjectStorage, SourceMapGcResult,

--- a/apps/server/src/models/project.rs
+++ b/apps/server/src/models/project.rs
@@ -3,6 +3,37 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use uuid::Uuid;
 
+/// A list of all valid Sentry `platform` identifiers, mirrored verbatim from
+/// Relay: <https://github.com/getsentry/relay/blob/f42b1c8a15bba8cb96d1dfd3bd2b3158c7817c5f/relay-event-schema/src/protocol/constants.rs#L2-L22>
+///
+/// This is deliberately coarse (language-level only, e.g. "javascript", not
+/// "javascript-nextjs") — real Sentry's own project-platform auto-inference
+/// (`_set_project_platform_if_needed` in `event_manager.py`) only ever writes
+/// one of these 19 values, never a framework-specific id. Framework-specific
+/// platform ids only ever come from the manual project-creation picker, which
+/// Rustrak does not implement, so it is intentionally out of scope here.
+pub const VALID_PLATFORMS: &[&str] = &[
+    "as3",
+    "c",
+    "cfml",
+    "cocoa",
+    "csharp",
+    "elixir",
+    "go",
+    "groovy",
+    "haskell",
+    "java",
+    "javascript",
+    "native",
+    "node",
+    "objc",
+    "other",
+    "perl",
+    "php",
+    "python",
+    "ruby",
+];
+
 /// Project model for reading from the database
 #[derive(Debug, Clone, Serialize, FromRow)]
 pub struct Project {
@@ -14,6 +45,10 @@ pub struct Project {
     pub digested_event_count: i32,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Auto-detected from the first ingested event whose `platform` field is
+    /// a valid Sentry platform (see [`VALID_PLATFORMS`]). Set once, never
+    /// overwritten — same semantics as real Sentry.
+    pub platform: Option<String>,
     // Rate limiting fields
     #[serde(skip_serializing)]
     pub quota_exceeded_until: Option<DateTime<Utc>>,
@@ -53,6 +88,7 @@ pub struct ProjectResponse {
     pub digested_event_count: i32,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub platform: Option<String>,
 }
 
 impl Project {
@@ -82,6 +118,7 @@ impl Project {
             digested_event_count: self.digested_event_count,
             created_at: self.created_at,
             updated_at: self.updated_at,
+            platform: self.platform.clone(),
         }
     }
 }
@@ -102,6 +139,7 @@ mod tests {
             digested_event_count: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            platform: None,
             quota_exceeded_until: None,
             quota_exceeded_reason: None,
             next_quota_check: 0,

--- a/apps/server/src/services/project.rs
+++ b/apps/server/src/services/project.rs
@@ -2,7 +2,7 @@ use slug::slugify;
 
 use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
-use crate::models::{CreateProject, Project, UpdateProject};
+use crate::models::{CreateProject, Project, UpdateProject, VALID_PLATFORMS};
 use crate::pagination::SortOrder;
 
 pub struct ProjectService;
@@ -13,7 +13,7 @@ impl ProjectService {
         let projects = sqlx::query_as::<_, Project>(
             r#"
             SELECT id, name, slug, sentry_key, stored_event_count,
-                   digested_event_count, created_at, updated_at,
+                   digested_event_count, created_at, updated_at, platform,
                    quota_exceeded_until, quota_exceeded_reason, next_quota_check
             FROM projects
             ORDER BY created_at DESC
@@ -48,7 +48,7 @@ impl ProjectService {
         let query = format!(
             r#"
             SELECT id, name, slug, sentry_key, stored_event_count,
-                   digested_event_count, created_at, updated_at,
+                   digested_event_count, created_at, updated_at, platform,
                    quota_exceeded_until, quota_exceeded_reason, next_quota_check
             FROM projects
             {}
@@ -106,7 +106,7 @@ impl ProjectService {
         let query = format!(
             r#"
             SELECT id, name, slug, sentry_key, stored_event_count,
-                   digested_event_count, created_at, updated_at,
+                   digested_event_count, created_at, updated_at, platform,
                    quota_exceeded_until, quota_exceeded_reason, next_quota_check
             FROM projects
             WHERE id IN ({})
@@ -130,7 +130,7 @@ impl ProjectService {
         let project = sqlx::query_as::<_, Project>(
             r#"
             SELECT id, name, slug, sentry_key, stored_event_count,
-                   digested_event_count, created_at, updated_at,
+                   digested_event_count, created_at, updated_at, platform,
                    quota_exceeded_until, quota_exceeded_reason, next_quota_check
             FROM projects
             WHERE id = $1
@@ -153,7 +153,7 @@ impl ProjectService {
         let project = sqlx::query_as::<_, Project>(
             r#"
             SELECT id, name, slug, sentry_key, stored_event_count,
-                   digested_event_count, created_at, updated_at,
+                   digested_event_count, created_at, updated_at, platform,
                    quota_exceeded_until, quota_exceeded_reason, next_quota_check
             FROM projects
             WHERE sentry_key = $1
@@ -213,7 +213,7 @@ impl ProjectService {
                 UPDATE projects SET name = $1, updated_at = CURRENT_TIMESTAMP
                 WHERE id = $2
                 RETURNING id, name, slug, sentry_key, stored_event_count,
-                          digested_event_count, created_at, updated_at,
+                          digested_event_count, created_at, updated_at, platform,
                           quota_exceeded_until, quota_exceeded_reason, next_quota_check
                 "#,
             )
@@ -238,6 +238,29 @@ impl ProjectService {
 
         // If no fields to update, return project unchanged
         Self::get_by_id(pool, id).await
+    }
+
+    /// Auto-detects the project's platform from an ingested event, mirroring
+    /// Sentry's `_set_project_platform_if_needed` (event_manager.py): only
+    /// writes if the project has no platform yet, and only if
+    /// `event_platform` is one of Relay's [`VALID_PLATFORMS`]. No-op
+    /// otherwise. Never overwrites a platform once set.
+    pub async fn infer_platform_from_event(
+        pool: &DbPool,
+        project_id: i32,
+        event_platform: &str,
+    ) -> AppResult<()> {
+        if !VALID_PLATFORMS.contains(&event_platform) {
+            return Ok(());
+        }
+
+        sqlx::query("UPDATE projects SET platform = $1 WHERE id = $2 AND platform IS NULL")
+            .bind(event_platform)
+            .bind(project_id)
+            .execute(pool)
+            .await?;
+
+        Ok(())
     }
 
     /// Deletes a project (hard delete)
@@ -323,7 +346,7 @@ impl ProjectService {
             INSERT INTO projects (name, slug, sentry_key)
             VALUES ($1, $2, $3)
             RETURNING id, name, slug, sentry_key, stored_event_count,
-                      digested_event_count, created_at, updated_at,
+                      digested_event_count, created_at, updated_at, platform,
                       quota_exceeded_until, quota_exceeded_reason, next_quota_check
         "#;
 

--- a/apps/server/tests/integration/digest_test.rs
+++ b/apps/server/tests/integration/digest_test.rs
@@ -752,6 +752,165 @@ async fn test_digest_updates_project_counters() {
 }
 
 // =============================================================================
+// Project Platform Auto-Detection Tests (Sentry parity)
+//
+// Mirrors sentry.event_manager._set_project_platform_if_needed: set once from
+// the first event whose top-level `platform` is a valid Relay VALID_PLATFORMS
+// value, never overwritten, no manual picker.
+// =============================================================================
+
+#[actix_web::test]
+async fn test_digest_sets_project_platform_from_first_valid_event() {
+    let db = TestDb::new().await;
+    let project = create_test_project(&db.pool, "Platform Detect Project").await;
+    assert_eq!(project.platform, None);
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let ingest_dir = temp_dir.path();
+    let rate_limit_config = create_rate_limit_config();
+
+    let event_id = Uuid::new_v4().to_string().replace("-", "");
+    let mut event_json = create_event_json(&event_id);
+    event_json["platform"] = json!("python");
+    let event_bytes = serde_json::to_vec(&event_json).unwrap();
+
+    store_event(ingest_dir, &event_id, &event_bytes)
+        .await
+        .expect("Failed to store event");
+
+    let metadata = EventMetadata {
+        event_id: event_id.clone(),
+        project_id: project.id,
+        ingested_at: Utc::now(),
+        remote_addr: None,
+    };
+
+    process_error_event(
+        &db.pool,
+        &metadata,
+        ingest_dir,
+        &rate_limit_config,
+        crate::common::null_sourcemap_provider(),
+    )
+    .await
+    .expect("Failed to process event");
+
+    let updated_project = ProjectService::get_by_id(&db.pool, project.id)
+        .await
+        .expect("Failed to get project");
+
+    assert_eq!(updated_project.platform, Some("python".to_string()));
+}
+
+#[actix_web::test]
+async fn test_digest_does_not_overwrite_existing_project_platform() {
+    let db = TestDb::new().await;
+    let project = create_test_project(&db.pool, "Platform No Overwrite Project").await;
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let ingest_dir = temp_dir.path();
+    let rate_limit_config = create_rate_limit_config();
+
+    // First event sets platform to "python".
+    let event_id_1 = Uuid::new_v4().to_string().replace("-", "");
+    let mut event_json_1 = create_event_json(&event_id_1);
+    event_json_1["platform"] = json!("python");
+    store_event(
+        ingest_dir,
+        &event_id_1,
+        &serde_json::to_vec(&event_json_1).unwrap(),
+    )
+    .await
+    .expect("Failed to store event");
+    process_error_event(
+        &db.pool,
+        &EventMetadata {
+            event_id: event_id_1,
+            project_id: project.id,
+            ingested_at: Utc::now(),
+            remote_addr: None,
+        },
+        ingest_dir,
+        &rate_limit_config,
+        crate::common::null_sourcemap_provider(),
+    )
+    .await
+    .expect("Failed to process first event");
+
+    // Second event, different valid platform, must NOT change it.
+    let event_id_2 = Uuid::new_v4().to_string().replace("-", "");
+    let mut event_json_2 = create_event_json(&event_id_2);
+    event_json_2["platform"] = json!("php");
+    store_event(
+        ingest_dir,
+        &event_id_2,
+        &serde_json::to_vec(&event_json_2).unwrap(),
+    )
+    .await
+    .expect("Failed to store event");
+    process_error_event(
+        &db.pool,
+        &EventMetadata {
+            event_id: event_id_2,
+            project_id: project.id,
+            ingested_at: Utc::now(),
+            remote_addr: None,
+        },
+        ingest_dir,
+        &rate_limit_config,
+        crate::common::null_sourcemap_provider(),
+    )
+    .await
+    .expect("Failed to process second event");
+
+    let updated_project = ProjectService::get_by_id(&db.pool, project.id)
+        .await
+        .expect("Failed to get project");
+
+    assert_eq!(updated_project.platform, Some("python".to_string()));
+}
+
+#[actix_web::test]
+async fn test_digest_ignores_invalid_platform_for_project_platform_detection() {
+    let db = TestDb::new().await;
+    let project = create_test_project(&db.pool, "Invalid Platform Project").await;
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let ingest_dir = temp_dir.path();
+    let rate_limit_config = create_rate_limit_config();
+
+    // create_event_json() already uses "platform": "rust", which is NOT in
+    // Relay's VALID_PLATFORMS (confirmed against relay-event-schema source).
+    let event_id = Uuid::new_v4().to_string().replace("-", "");
+    let event_json = create_event_json(&event_id);
+    store_event(
+        ingest_dir,
+        &event_id,
+        &serde_json::to_vec(&event_json).unwrap(),
+    )
+    .await
+    .expect("Failed to store event");
+    process_error_event(
+        &db.pool,
+        &EventMetadata {
+            event_id,
+            project_id: project.id,
+            ingested_at: Utc::now(),
+            remote_addr: None,
+        },
+        ingest_dir,
+        &rate_limit_config,
+        crate::common::null_sourcemap_provider(),
+    )
+    .await
+    .expect("Failed to process event");
+
+    let updated_project = ProjectService::get_by_id(&db.pool, project.id)
+        .await
+        .expect("Failed to get project");
+
+    assert_eq!(updated_project.platform, None);
+}
+
+// =============================================================================
 // Temp File Cleanup Tests
 // =============================================================================
 

--- a/apps/webview-ui/package.json
+++ b/apps/webview-ui/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "1.23.0",
     "next": "16.2.10",
     "next-themes": "0.4.6",
+    "platformicons": "9.5.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-hook-form": "7.80.0",

--- a/apps/webview-ui/src/app/(main)/projects/[id]/layout.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/layout.tsx
@@ -29,6 +29,7 @@ export default async function ProjectLayout({
     id: p.id,
     name: p.name,
     slug: p.slug,
+    platform: p.platform,
   }));
   const defaultOpen = cookieStore.get('sidebar_state')?.value !== 'false';
 

--- a/apps/webview-ui/src/app/(main)/projects/[id]/project-sidebar.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/project-sidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { PlatformIcon } from 'platformicons';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -42,6 +43,7 @@ interface ProjectOption {
   id: number;
   name: string;
   slug: string;
+  platform: string | null;
 }
 
 interface ProjectSidebarProps {
@@ -49,26 +51,22 @@ interface ProjectSidebarProps {
   projects: ProjectOption[];
 }
 
-function initialOf(name: string): string {
-  return (name || '?').charAt(0).toUpperCase();
-}
-
 function ProjectAvatar({
-  name,
+  platform,
   className,
+  size = 32,
 }: {
-  name: string;
+  platform: string | null;
   className?: string;
+  size?: number;
 }) {
   return (
-    <div
-      className={cn(
-        'flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted text-sm font-semibold text-foreground',
-        className,
-      )}
-    >
-      {initialOf(name)}
-    </div>
+    <PlatformIcon
+      platform={platform ?? 'other'}
+      size={size}
+      format="lg"
+      className={cn('shrink-0', className)}
+    />
   );
 }
 
@@ -82,7 +80,12 @@ function ProjectSwitcher({
 }) {
   const current =
     projects.find((p) => p.id === projectId) ??
-    ({ id: projectId, name: 'Project', slug: '' } as ProjectOption);
+    ({
+      id: projectId,
+      name: 'Project',
+      slug: '',
+      platform: null,
+    } as ProjectOption);
 
   return (
     <DropdownMenu>
@@ -94,7 +97,7 @@ function ProjectSwitcher({
           />
         }
       >
-        <ProjectAvatar name={current.name} />
+        <ProjectAvatar platform={current.platform} />
         <div className="flex min-w-0 flex-1 flex-col group-data-[collapsible=icon]:hidden">
           <span className="truncate text-sm font-semibold leading-tight">
             {current.name}
@@ -117,7 +120,7 @@ function ProjectSwitcher({
               render={<Link href={`/projects/${p.id}`} />}
               className="gap-2"
             >
-              <ProjectAvatar name={p.name} className="size-6 text-xs" />
+              <ProjectAvatar platform={p.platform} size={24} />
               <div className="flex min-w-0 flex-1 flex-col">
                 <span className="truncate text-sm">{p.name}</span>
                 <span className="truncate font-mono text-xs text-muted-foreground">

--- a/apps/webview-ui/src/app/(main)/projects/projects-list.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/projects-list.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { PlatformIcon } from 'platformicons';
 import { useOptimistic, useState, useTransition } from 'react';
 import { toast } from 'sonner';
 import { deleteProject } from '@/actions/projects';
@@ -205,6 +206,14 @@ export function ProjectsList({
                 <Checkbox
                   checked={selectedIds.has(project.id)}
                   onCheckedChange={() => toggleSelect(project.id)}
+                />
+
+                <PlatformIcon
+                  platform={project.platform ?? 'other'}
+                  size={28}
+                  radius={5}
+                  format="lg"
+                  className="shrink-0"
                 />
 
                 <div className="flex-1 min-w-0">

--- a/packages/client/src/schemas/project.ts
+++ b/packages/client/src/schemas/project.ts
@@ -14,6 +14,7 @@ export const projectSchema = z.object({
   digested_event_count: z.number().int(),
   created_at: dateTimeSchema,
   updated_at: dateTimeSchema,
+  platform: z.string().nullable(),
 });
 
 /**

--- a/packages/client/tests/mocks/handlers.ts
+++ b/packages/client/tests/mocks/handlers.ts
@@ -14,6 +14,7 @@ export const mockProjects = [
     digested_event_count: 95,
     created_at: '2026-01-20T10:00:00.000Z',
     updated_at: '2026-01-20T10:00:00.000Z',
+    platform: 'javascript',
   },
   {
     id: 2,
@@ -25,6 +26,7 @@ export const mockProjects = [
     digested_event_count: 48,
     created_at: '2026-01-19T10:00:00.000Z',
     updated_at: '2026-01-19T10:00:00.000Z',
+    platform: null,
   },
 ];
 
@@ -347,6 +349,7 @@ export const handlers = [
       digested_event_count: 0,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      platform: null,
     };
 
     return HttpResponse.json(newProject, { status: 201 });

--- a/packages/client/tests/unit/schemas.test.ts
+++ b/packages/client/tests/unit/schemas.test.ts
@@ -24,10 +24,32 @@ describe('Schema Validation', () => {
         digested_event_count: 95,
         created_at: '2026-01-20T10:00:00.000Z',
         updated_at: '2026-01-20T10:00:00.000Z',
+        platform: null,
       };
 
       const result = projectSchema.safeParse(validProject);
       expect(result.success).toBe(true);
+    });
+
+    it('should validate project with a detected platform string', () => {
+      const validProject = {
+        id: 1,
+        name: 'Test Project',
+        slug: 'test-project',
+        sentry_key: '123e4567-e89b-12d3-a456-426614174000',
+        dsn: 'http://123e4567-e89b-12d3-a456-426614174000@localhost:8080/1',
+        stored_event_count: 100,
+        digested_event_count: 95,
+        created_at: '2026-01-20T10:00:00.000Z',
+        updated_at: '2026-01-20T10:00:00.000Z',
+        platform: 'python',
+      };
+
+      const result = projectSchema.safeParse(validProject);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.platform).toBe('python');
+      }
     });
 
     it('should reject project with invalid UUID', () => {
@@ -376,6 +398,7 @@ describe('Schema Validation', () => {
             digested_event_count: 95,
             created_at: '2026-01-20T10:00:00.000Z',
             updated_at: '2026-01-20T10:00:00.000Z',
+            platform: null,
           },
         ],
         next_cursor: 'eyJzb3J0IjoiZGlnZXN0X29yZGVyIn0=',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      platformicons:
+        specifier: 9.5.0
+        version: 9.5.0(react@19.2.7)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -4606,6 +4609,11 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  platformicons@9.5.0:
+    resolution: {integrity: sha512-x3mWQ2XAxJKVGmy1fcQ5wytfTpw4U0n2As0rCsf1dKkeq7gtnDSi2Tl6FnPifPggjx4jz532JzSkOsiojOR3sg==}
+    peerDependencies:
+      react: '*'
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -10608,6 +10616,12 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  platformicons@9.5.0(react@19.2.7):
+    dependencies:
+      '@types/node': 26.1.0
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   points-on-curve@0.2.0: {}
 


### PR DESCRIPTION
## Summary

- Auto-detects a project's `platform` from the first ingested event whose top-level `platform` field is one of Relay's 19 valid platform ids (`javascript`, `node`, `python`, `php`, `ruby`, `java`, `go`, ...). Set once, never overwritten — mirrors Sentry's own `_set_project_platform_if_needed` (`event_manager.py`) exactly, including the "backfill" semantics for pre-existing projects (they pick it up on their next event, same as real Sentry).
- Exposes `platform` on `Project` end-to-end: server model/response → `@rustrak/client` Zod schema → webview-ui.
- Renders the platform icon via [`platformicons`](https://github.com/getsentry/platformicons) (OFL-1.1, the same package Sentry's own frontend uses) in the project sidebar switcher, replacing the old initials avatar, and in the `/projects` list. Falls back to the generic "other" icon until a project has received an event.

This is intentionally scoped to language-level icons only (no Next.js/NestJS/Django-specific icons) — verified against real Sentry/Relay source that Sentry's own auto-inference never produces framework-specific platform ids either; those only come from the manual project-creation picker, which is out of scope here by design.

## Test plan

- [x] Rust: TDD (RED→GREEN) for all 3 behaviors — sets platform once, never overwrites, ignores invalid platform strings — against both SQLite and a real Postgres testcontainer (`cargo test` / `cargo test --no-default-features --features postgres`)
- [x] `cargo clippy --all-targets` clean, `openapi.json` regenerated
- [x] `@rustrak/client`: schema test (RED→GREEN) + full suite (383 passed)
- [x] `webview-ui`: `tsc --noEmit` clean
- [x] Manually verified end-to-end against a real Postgres-backed server + browser: sent a live envelope with `platform: "node"`, confirmed `projects.platform` got set and the Node icon rendered in the sidebar