### PR TITLE
chore: lockstep versioning and unified GitHub release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,10 +2,12 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "rustrak/rustrak" }],
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    ["@rustrak/server", "webview-ui", "@rustrak/client", "@rustrak/mcp", "docs"]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@rustrak/test-sentry"]
+  "ignore": ["@rustrak/test-sentry", "@rustrak/benchmarks"]
 }

--- a/.claude/skills/rustrak-release-commit/SKILL.md
+++ b/.claude/skills/rustrak-release-commit/SKILL.md
@@ -37,17 +37,23 @@ Act as release manager for the Rustrak monorepo. This workflow prepares a new ve
    - Commit count since then
    - Breakdown by type
    - Notable changes (features, fixes, breaking changes)
-6. **Suggest a bump level** based on the analysis:
-   - `major` if any commit message contains `BREAKING CHANGE` or `!:` after the type
-   - `minor` if there are `feat:` commits
+6. **Suggest a single bump level** for the release based on the analysis:
+   - `minor` if any commit message contains `BREAKING CHANGE` or `!:` after the type, or if there are `feat:` commits
    - `patch` if only `fix:`, `docs:`, `chore:`, `refactor:`, `test:` commits
-7. **Interactive:** Ask the user to confirm or override the bump for each package. Present the list of packages that had changes:
-   - `@rustrak/server` (apps/server)
-   - `webview-ui` (apps/webview-ui)
-   - `@rustrak/client` (packages/client)
-   - `@rustrak/mcp` (packages/mcp)
-   - `docs` (apps/docs) — always `patch` since a changelog entry is created in docs
-8. **Headless:** Use the suggested bump for all packages, skip confirmation.
+   - Never suggest `major` while the product is on `0.x`. See "Versioning Policy" below.
+7. **Interactive:** Ask the user to confirm or override the single release bump. Do not ask per package, the fixed group makes that irrelevant.
+8. **Headless:** Use the suggested bump, skip confirmation.
+
+### Versioning Policy
+
+Rustrak uses **lockstep versioning**: `@rustrak/server`, `webview-ui`, `@rustrak/client`, `@rustrak/mcp` and `docs` are declared as a `fixed` group in `.changeset/config.json`. They always share one version number and are bumped together even when a given package has no changes.
+
+Consequences for this workflow:
+
+- One changeset naming one package bumps all five. There is no per-package bump decision.
+- The group takes the **highest** bump present, so a `major` anywhere drags the whole product to the next major.
+- **While on `0.x`, never write a `major` changeset.** Use `minor` to signal a breaking change, per the standard 0.x convention. A `major` would push the product to 1.0.0 as a side effect.
+- The version number identifies the Rustrak release, not the semver of an individual artifact. The changelog is what tells users which part actually changed.
 
 ## Stage 2: Create Changeset
 
@@ -62,7 +68,7 @@ Act as release manager for the Rustrak monorepo. This workflow prepares a new ve
    <description of changes>
    ```
 
-   Only include packages that are being bumped (docs is always included as `patch` since a changelog entry is created). The description should be a concise bullet-free summary of what changed, written for the changelog audience. For changes made by external contributors, append `(@github_username)` after the relevant change description.
+   Name only `"@rustrak/server"` with the agreed bump. The fixed group propagates it to `webview-ui`, `@rustrak/client`, `@rustrak/mcp` and `docs` automatically, so listing them is redundant and risks a mismatched bump level. The description should be a concise bullet-free summary of what changed, written for the changelog audience. For changes made by external contributors, append `(@github_username)` after the relevant change description.
 
 3. **Interactive:** Show the generated changeset to the user and ask for approval before writing.
 4. **Headless:** Write directly without confirmation.
@@ -70,7 +76,7 @@ Act as release manager for the Rustrak monorepo. This workflow prepares a new ve
 ## Stage 3: Create Changelog Entry
 
 1. List existing changelog files in `{project-root}/apps/docs/content/changelog/` to find the next sequential number.
-2. Determine the new version string. Read the current version from `{project-root}/apps/server/Cargo.toml` and apply the bump for `@rustrak/server`. For other packages, read their respective `package.json`.
+2. Determine the new version string. Read the current version from `{project-root}/apps/server/Cargo.toml` and apply the agreed bump. Because of the fixed group this is the version for every package in the release, so there is nothing to compute per package.
 3. Generate a slug from the release title (kebab-case, matching existing convention like `session-tracking`).
 4. Create the file at `{project-root}/apps/docs/content/changelog/<NN>-v<version>-<slug>.mdx` with full frontmatter and content:
 
@@ -104,13 +110,15 @@ Act as release manager for the Rustrak monorepo. This workflow prepares a new ve
 ## Finalize
 
 1. Suggest the release commit message. Derive it from the release version and title:
-   - Format: `release: v<version> — <Release Title>`
-   - Example: `release: v0.8.0 — Logs Ingestion Pipeline`
+   - Format: `release: v<version> - <Release Title>`
+   - Example: `release: v0.8.0 - Logs Ingestion Pipeline`
    - Include the changeset, changelog, and any files modified during the release workflow (including this skill) in the commit.
+
+   The changelog MDX from Stage 3 is not just docs: `.github/workflows/release.yml` reads it to build the GitHub release body, matching on the `<NN>-v<version-with-dashes>-<slug>.mdx` filename and stripping the frontmatter. Keep that naming exact, and keep the `title:` field meaningful since it becomes the release title (`Rustrak v0.12.0: <title>`). If no entry matches, the workflow falls back to the generated `apps/server/CHANGELOG.md` section.
 2. Summarize what was created:
    - Changeset file path
    - Changelog file path
-   - Version bumps applied per package
+   - The single version the whole fixed group moves to
    - Suggested commit message
 3. Remind the user of next steps:
    - Review the changeset and changelog

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,65 +12,32 @@ permissions:
   # id-token: write is also required for npm provenance attestation
 
 jobs:
-  detect-package:
+  # All packages are a `fixed` group in .changeset/config.json: one version, one
+  # tag, one release, everything ships together. So there is nothing to detect,
+  # we only need the version off the tag.
+  version:
     runs-on: ubuntu-latest
     outputs:
-      is_server: ${{ steps.check.outputs.is_server }}
-      is_ui: ${{ steps.check.outputs.is_ui }}
-      is_docs: ${{ steps.check.outputs.is_docs }}
-      is_npm_client: ${{ steps.check.outputs.is_npm_client }}
-      is_npm_mcp: ${{ steps.check.outputs.is_npm_mcp }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - name: Detect package from release tag
+      - name: Extract version from release tag
         id: check
         run: |
           TAG="${{ github.event.release.tag_name }}"
           echo "Release tag: $TAG"
 
-          VERSION=$(echo "$TAG" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          VERSION=$(echo "$TAG" | grep -oE '^v([0-9]+\.[0-9]+\.[0-9]+)$' | sed 's/^v//')
           if [[ -z "$VERSION" ]]; then
-            echo "::error::Could not extract semver version from tag '$TAG'. Expected format: package@X.Y.Z"
+            echo "::error::Could not extract semver version from tag '$TAG'. Expected format: vX.Y.Z"
             exit 1
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-          if [[ "$TAG" == *"server"* ]] || [[ "$TAG" == *"@rustrak/server"* ]]; then
-            echo "is_server=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_server=false" >> $GITHUB_OUTPUT
-          fi
-
-          if [[ "$TAG" == *"webview-ui"* ]] || [[ "$TAG" == *"ui"* ]]; then
-            echo "is_ui=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_ui=false" >> $GITHUB_OUTPUT
-          fi
-
-          if [[ "$TAG" == *"docs"* ]]; then
-            echo "is_docs=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_docs=false" >> $GITHUB_OUTPUT
-          fi
-
-          if [[ "$TAG" == "@rustrak/client@"* ]]; then
-            echo "is_npm_client=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_npm_client=false" >> $GITHUB_OUTPUT
-          fi
-
-          if [[ "$TAG" == "@rustrak/mcp@"* ]]; then
-            echo "is_npm_mcp=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_npm_mcp=false" >> $GITHUB_OUTPUT
-          fi
 
   # ── SQLite image (default: latest) ───────────────────────────────────────────
   # Build on native runners (no QEMU). Each platform pushes by digest only.
 
   docker-server-sqlite-build:
-    needs: detect-package
-    if: needs.detect-package.outputs.is_server == 'true'
+    needs: version
     strategy:
       fail-fast: false
       matrix:
@@ -121,8 +88,7 @@ jobs:
           retention-days: 1
 
   docker-server-sqlite-manifest:
-    needs: [detect-package, docker-server-sqlite-build]
-    if: needs.detect-package.outputs.is_server == 'true'
+    needs: [version, docker-server-sqlite-build]
     runs-on: ubuntu-latest
     steps:
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -141,7 +107,7 @@ jobs:
       - name: Create manifest list and push (SQLite — latest)
         working-directory: ${{ runner.temp }}/digests
         run: |
-          VERSION="${{ needs.detect-package.outputs.version }}"
+          VERSION="${{ needs.version.outputs.version }}"
           docker buildx imagetools create \
             -t rustrak/rustrak-server:v${VERSION} \
             -t rustrak/rustrak-server:latest \
@@ -149,14 +115,13 @@ jobs:
 
       - name: Inspect image
         run: |
-          VERSION="${{ needs.detect-package.outputs.version }}"
+          VERSION="${{ needs.version.outputs.version }}"
           docker buildx imagetools inspect rustrak/rustrak-server:v${VERSION}
 
   # ── PostgreSQL image ──────────────────────────────────────────────────────────
 
   docker-server-postgres-build:
-    needs: detect-package
-    if: needs.detect-package.outputs.is_server == 'true'
+    needs: version
     strategy:
       fail-fast: false
       matrix:
@@ -207,8 +172,7 @@ jobs:
           retention-days: 1
 
   docker-server-postgres-manifest:
-    needs: [detect-package, docker-server-postgres-build]
-    if: needs.detect-package.outputs.is_server == 'true'
+    needs: [version, docker-server-postgres-build]
     runs-on: ubuntu-latest
     steps:
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -227,7 +191,7 @@ jobs:
       - name: Create manifest list and push (PostgreSQL)
         working-directory: ${{ runner.temp }}/digests
         run: |
-          VERSION="${{ needs.detect-package.outputs.version }}"
+          VERSION="${{ needs.version.outputs.version }}"
           docker buildx imagetools create \
             -t rustrak/rustrak-server:v${VERSION}-postgres \
             -t rustrak/rustrak-server:postgres \
@@ -235,14 +199,13 @@ jobs:
 
       - name: Inspect image
         run: |
-          VERSION="${{ needs.detect-package.outputs.version }}"
+          VERSION="${{ needs.version.outputs.version }}"
           docker buildx imagetools inspect rustrak/rustrak-server:v${VERSION}-postgres
 
   # ── UI image ──────────────────────────────────────────────────────────────────
 
   docker-ui-build:
-    needs: detect-package
-    if: needs.detect-package.outputs.is_ui == 'true'
+    needs: version
     strategy:
       fail-fast: false
       matrix:
@@ -293,8 +256,7 @@ jobs:
           retention-days: 1
 
   docker-ui-manifest:
-    needs: [detect-package, docker-ui-build]
-    if: needs.detect-package.outputs.is_ui == 'true'
+    needs: [version, docker-ui-build]
     runs-on: ubuntu-latest
     steps:
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -313,7 +275,7 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          VERSION="${{ needs.detect-package.outputs.version }}"
+          VERSION="${{ needs.version.outputs.version }}"
           docker buildx imagetools create \
             -t rustrak/rustrak-ui:v${VERSION} \
             -t rustrak/rustrak-ui:latest \
@@ -321,14 +283,13 @@ jobs:
 
       - name: Inspect image
         run: |
-          VERSION="${{ needs.detect-package.outputs.version }}"
+          VERSION="${{ needs.version.outputs.version }}"
           docker buildx imagetools inspect rustrak/rustrak-ui:v${VERSION}
 
   # ── Docs ──────────────────────────────────────────────────────────────────────
 
   deploy-docs:
-    needs: detect-package
-    if: needs.detect-package.outputs.is_docs == 'true'
+    needs: version
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -362,8 +323,7 @@ jobs:
   # ── npm publish ───────────────────────────────────────────────────────────────
 
   publish-npm:
-    needs: detect-package
-    if: needs.detect-package.outputs.is_npm_client == 'true' || needs.detect-package.outputs.is_npm_mcp == 'true'
+    needs: version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -377,22 +337,16 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build @rustrak/client
-        if: needs.detect-package.outputs.is_npm_client == 'true'
-        run: pnpm --filter @rustrak/client build
-
-      - name: Build @rustrak/mcp
-        if: needs.detect-package.outputs.is_npm_mcp == 'true'
+      # mcp depends on client, so client must build first.
+      - name: Build packages
         run: pnpm --filter @rustrak/client build && pnpm --filter @rustrak/mcp build
 
       - name: Publish @rustrak/client
-        if: needs.detect-package.outputs.is_npm_client == 'true'
         run: pnpm --filter @rustrak/client publish --no-git-checks --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @rustrak/mcp
-        if: needs.detect-package.outputs.is_npm_mcp == 'true'
         run: pnpm --filter @rustrak/mcp publish --no-git-checks --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,19 +126,22 @@ jobs:
           # GitHub picks the previous release, which is ambiguous here: releases
           # before v0.12.0 were tagged per package, five per version. Resolve it
           # explicitly, preferring a previous v* tag and falling back to the old
-          # per-package scheme. Must run before the new tag exists.
+          # per-package scheme.
           PREV_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
           if [[ -z "$PREV_TAG" ]]; then
             PREV_TAG=$(git tag -l '@rustrak/server@*' --sort=-v:refname | head -1)
           fi
 
-          git tag "$TAG"
-          git push origin "$TAG"
-
+          # --target makes the API create the tag together with the release, so a
+          # failed call leaves no orphaned ref and the next run retries cleanly.
+          # Tagging separately beforehand would strand the tag on failure, and the
+          # guard above would then read it as "already released" and skip forever.
+          #
           # --generate-notes appends GitHub's own PR and contributor list after
           # the body above, per the Releases API.
           GH_ARGS=(
             "$TAG"
+            --target "${{ github.sha }}"
             --title "$RELEASE_TITLE"
             --notes-file "$NOTES_FILE"
             --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,86 +57,78 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
 
-      # If there are NO changesets, we just merged a version PR - create releases
-      - name: Get changed packages and create releases
+      # If there are NO changesets, we just merged a version PR - cut the release.
+      # All packages are a `fixed` group in .changeset/config.json, so they share
+      # one version and ship together: one tag, one GitHub release.
+      - name: Create release
         if: steps.check.outputs.has_changesets == 'false'
         run: |
-          # Get the packages that might have new versions
-          # We check if there's a git tag for the current version, if not, create a release
+          set -euo pipefail
 
-          # Server
-          SERVER_VERSION=$(node -p "require('./apps/server/package.json').version")
-          SERVER_TAG="@rustrak/server@$SERVER_VERSION"
-          if ! git tag -l | grep -q "^$SERVER_TAG$"; then
-            echo "Creating release for $SERVER_TAG"
-            git tag "$SERVER_TAG"
-            git push origin "$SERVER_TAG"
-            gh release create "$SERVER_TAG" \
-              --title "🚀 @rustrak/server v$SERVER_VERSION" \
-              --notes "Release of @rustrak/server version $SERVER_VERSION" \
-              --latest=false
-          else
-            echo "Tag $SERVER_TAG already exists, skipping"
+          VERSION=$(node -p "require('./apps/server/package.json').version")
+          TAG="v$VERSION"
+
+          if git tag -l | grep -qx "$TAG"; then
+            echo "Tag $TAG already exists, nothing to release"
+            exit 0
           fi
 
-          # UI
-          UI_VERSION=$(node -p "require('./apps/webview-ui/package.json').version")
-          UI_TAG="webview-ui@$UI_VERSION"
-          if ! git tag -l | grep -q "^$UI_TAG$"; then
-            echo "Creating release for $UI_TAG"
-            git tag "$UI_TAG"
-            git push origin "$UI_TAG"
-            gh release create "$UI_TAG" \
-              --title "🎨 webview-ui v$UI_VERSION" \
-              --notes "Release of webview-ui version $UI_VERSION" \
-              --latest=false
+          # Sanity check: the fixed group must be aligned. If it drifted, the
+          # single tag would be a lie about what the other images contain.
+          for pkg in apps/webview-ui apps/docs packages/client packages/mcp; do
+            PKG_VERSION=$(node -p "require('./$pkg/package.json').version")
+            if [[ "$PKG_VERSION" != "$VERSION" ]]; then
+              echo "::error::$pkg is at $PKG_VERSION but the release is $VERSION."
+              echo "::error::The fixed group in .changeset/config.json is out of sync."
+              exit 1
+            fi
+          done
+
+          # Release body: prefer the curated changelog entry written for the docs
+          # site, fall back to the changesets-generated server CHANGELOG section.
+          NOTES_FILE=$(mktemp)
+          ENTRY=$(ls apps/docs/content/changelog/*-v${VERSION//./-}-*.mdx 2>/dev/null | head -1 || true)
+
+          if [[ -n "$ENTRY" ]]; then
+            echo "Using changelog entry: $ENTRY"
+            TITLE=$(awk -F': *' '/^title: /{print $2; exit}' "$ENTRY")
+            # Drop the MDX frontmatter, keep the prose.
+            awk 'BEGIN{n=0} /^---[[:space:]]*$/ && n<2 {n++; next} n>=2' "$ENTRY" > "$NOTES_FILE"
           else
-            echo "Tag $UI_TAG already exists, skipping"
+            echo "No changelog entry for $VERSION, falling back to CHANGELOG.md"
+            TITLE=""
+            awk -v v="$VERSION" '$0=="## "v{f=1;next} f&&/^## /{exit} f' \
+              apps/server/CHANGELOG.md > "$NOTES_FILE"
           fi
 
-          # Docs
-          DOCS_VERSION=$(node -p "require('./apps/docs/package.json').version")
-          DOCS_TAG="docs@$DOCS_VERSION"
-          if ! git tag -l | grep -q "^$DOCS_TAG$"; then
-            echo "Creating release for $DOCS_TAG"
-            git tag "$DOCS_TAG"
-            git push origin "$DOCS_TAG"
-            gh release create "$DOCS_TAG" \
-              --title "📚 docs v$DOCS_VERSION" \
-              --notes "Release of docs version $DOCS_VERSION" \
-              --latest=false
+          if [[ -n "$TITLE" ]]; then
+            RELEASE_TITLE="Rustrak v$VERSION: $TITLE"
           else
-            echo "Tag $DOCS_TAG already exists, skipping"
+            RELEASE_TITLE="Rustrak v$VERSION"
           fi
 
-          # Client
-          CLIENT_VERSION=$(node -p "require('./packages/client/package.json').version")
-          CLIENT_TAG="@rustrak/client@$CLIENT_VERSION"
-          if ! git tag -l | grep -q "^$CLIENT_TAG$"; then
-            echo "Creating release for $CLIENT_TAG"
-            git tag "$CLIENT_TAG"
-            git push origin "$CLIENT_TAG"
-            gh release create "$CLIENT_TAG" \
-              --title "📦 @rustrak/client v$CLIENT_VERSION" \
-              --notes "Release of @rustrak/client version $CLIENT_VERSION" \
-              --latest=false
-          else
-            echo "Tag $CLIENT_TAG already exists, skipping"
-          fi
+          {
+            echo
+            echo "## Artifacts"
+            echo
+            echo '```'
+            echo "rustrak/rustrak-server:v$VERSION"
+            echo "rustrak/rustrak-server:v$VERSION-postgres"
+            echo "rustrak/rustrak-ui:v$VERSION"
+            echo '```'
+            echo
+            echo "\`@rustrak/client@$VERSION\` and \`@rustrak/mcp@$VERSION\` on npm."
+          } >> "$NOTES_FILE"
 
-          # MCP
-          MCP_VERSION=$(node -p "require('./packages/mcp/package.json').version")
-          MCP_TAG="@rustrak/mcp@$MCP_VERSION"
-          if ! git tag -l | grep -q "^$MCP_TAG$"; then
-            echo "Creating release for $MCP_TAG"
-            git tag "$MCP_TAG"
-            git push origin "$MCP_TAG"
-            gh release create "$MCP_TAG" \
-              --title "🤖 @rustrak/mcp v$MCP_VERSION" \
-              --notes "Release of @rustrak/mcp version $MCP_VERSION" \
-              --latest=false
-          else
-            echo "Tag $MCP_TAG already exists, skipping"
-          fi
+          git tag "$TAG"
+          git push origin "$TAG"
+
+          # --generate-notes appends GitHub's own PR and contributor list after
+          # the body above, per the Releases API.
+          gh release create "$TAG" \
+            --title "$RELEASE_TITLE" \
+            --notes-file "$NOTES_FILE" \
+            --generate-notes \
+            --latest
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,9 @@ jobs:
 
           if [[ -n "$ENTRY" ]]; then
             echo "Using changelog entry: $ENTRY"
-            TITLE=$(awk -F': *' '/^title: /{print $2; exit}' "$ENTRY")
+            # Strip the key rather than splitting on ':', so titles that
+            # themselves contain a colon survive intact.
+            TITLE=$(awk '/^title: /{sub(/^title: */, ""); print; exit}' "$ENTRY")
             # Drop the MDX frontmatter, keep the prose.
             awk 'BEGIN{n=0} /^---[[:space:]]*$/ && n<2 {n++; next} n>=2' "$ENTRY" > "$NOTES_FILE"
           else
@@ -120,15 +122,33 @@ jobs:
             echo "\`@rustrak/client@$VERSION\` and \`@rustrak/mcp@$VERSION\` on npm."
           } >> "$NOTES_FILE"
 
+          # Pin where the generated "Full Changelog" range starts. Left to itself
+          # GitHub picks the previous release, which is ambiguous here: releases
+          # before v0.12.0 were tagged per package, five per version. Resolve it
+          # explicitly, preferring a previous v* tag and falling back to the old
+          # per-package scheme. Must run before the new tag exists.
+          PREV_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
+          if [[ -z "$PREV_TAG" ]]; then
+            PREV_TAG=$(git tag -l '@rustrak/server@*' --sort=-v:refname | head -1)
+          fi
+
           git tag "$TAG"
           git push origin "$TAG"
 
           # --generate-notes appends GitHub's own PR and contributor list after
           # the body above, per the Releases API.
-          gh release create "$TAG" \
-            --title "$RELEASE_TITLE" \
-            --notes-file "$NOTES_FILE" \
-            --generate-notes \
+          GH_ARGS=(
+            "$TAG"
+            --title "$RELEASE_TITLE"
+            --notes-file "$NOTES_FILE"
+            --generate-notes
             --latest
+          )
+          if [[ -n "$PREV_TAG" ]]; then
+            echo "Generating notes since $PREV_TAG"
+            GH_ARGS+=(--notes-start-tag "$PREV_TAG")
+          fi
+
+          gh release create "${GH_ARGS[@]}"
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,20 @@ openssl rand -hex 32
 - Prefer `async/await` over blocking code
 - Use `log` crate with `env_logger` (RUST_LOG env var)
 
+### Versioning
+
+Rustrak uses **lockstep versioning**. `@rustrak/server`, `webview-ui`, `@rustrak/client`, `@rustrak/mcp` and `docs` form a `fixed` group in `.changeset/config.json`: they always share one version number and bump together, even when a package has no changes.
+
+The number identifies the **Rustrak release**, not the semver of one artifact. This is what lets a user answer "which version of Rustrak am I running?" and lets `@rustrak/client@X.Y.Z` be known-compatible with server `X.Y.Z` without a compatibility matrix.
+
+- A changeset only needs to name `@rustrak/server`; the group propagates the bump.
+- The group takes the **highest** bump present.
+- **While on `0.x`, never write a `major` changeset.** Use `minor` for breaking changes, per the 0.x convention. A `major` would push the product to 1.0.0 as a side effect.
+- `@rustrak/test-sentry` and `@rustrak/benchmarks` are internal and excluded via `ignore`.
+- `scripts/sync-version.sh` propagates the version from `apps/server/package.json` to `Cargo.toml` after `changeset version`.
+
+Post-1.0 the management API should get its own `api_version` in `/health/version`, which would allow decoupling the client from the product version if needed.
+
 ### General
 - Commit messages: `type: description` (feat, fix, docs, refactor, test)
 - Keep functions small and focused


### PR DESCRIPTION
## What

Moves the monorepo from independent per-package versioning to **lockstep versioning**, and collapses the five-releases-per-version setup into a single GitHub release.

## Why

Two problems, one root cause.

**Compatibility was undocumented.** `@rustrak/client` and `@rustrak/mcp` are published to npm, but they are the typed bindings to *this* server's management API. Their version numbers told a consumer nothing about which server they work against, and there was no compatibility matrix. Sharing one version makes `@rustrak/client@X.Y.Z` known-compatible with server `X.Y.Z` by construction.

**"Which version of Rustrak am I running?" had no answer.** server was at 0.11.1, webview-ui at 0.9.1, docs at 0.1.43. `docker-compose.yml` pins `:latest` on both images, which papers over it, but anyone pinning versions had no way to know which UI goes with which server.

Note that `docs`'s 0.1.43 was never really a version: it was bumped patch on every release purely so a `docs@X.Y.Z` tag would fire the Pages deploy. Folding it into the group keeps that trigger working while dropping the pretense.

## Changes

**`.changeset/config.json`**
- `fixed` group covering `@rustrak/server`, `webview-ui`, `@rustrak/client`, `@rustrak/mcp`, `docs`.
- `@rustrak/benchmarks` added to `ignore` alongside `test-sentry`.

**`.github/workflows/release.yml`**
- Five tags and five releases become one `vX.Y.Z` tag and one release, marked `--latest` (previously every release was `--latest=false`, so the repo never had a highlighted release).
- Release body comes from the curated `apps/docs/content/changelog/*.mdx` entry, frontmatter stripped, `title:` used for the release title. Falls back to the changesets-generated `apps/server/CHANGELOG.md` section if no entry matches.
- `--notes-file` combined with `--generate-notes` so GitHub appends its own PR and contributor list below the curated prose.
- Adds an alignment guard: if the fixed group ever drifts, the release fails instead of publishing a tag that misrepresents what the images contain.

**`.github/workflows/docker-publish.yml`**
- `detect-package` removed. It guessed the target package by substring-matching the tag (`is_ui` matched any tag containing `"ui"`), which only existed because packages released independently. With lockstep every release ships everything, so the job and its nine conditionals are replaced by one that reads the version off the tag.
- Consolidated a duplicated `@rustrak/client` build in `publish-npm`.

**`CLAUDE.md` and the release skill**
- Versioning policy documented, including the rule that while on `0.x` a `major` changeset must never be written (the group takes the highest bump, so it would push the product to 1.0.0 as a side effect).
- The skill no longer asks for a per-package bump, and records that the changelog MDX filename and `title:` are now consumed by CI rather than being docs-only.

## Effect on the next release

The first release after this merges aligns everything at **0.12.0**: server 0.11.1 is the highest in the group, so webview-ui jumps from 0.9.1 and docs from 0.1.43. One-time and cosmetic, since none of the three is published to npm.

Tag format changes from `@rustrak/server@0.11.1` to `v0.12.0`. No collision with existing tags, but `docker-publish` now requires strict `vX.Y.Z`, so an old-format release published by hand would fail rather than build.

## Verification

Run locally, all reverted afterwards:
- `changeset version` with a changeset naming only `@rustrak/server` correctly aligned all five packages at 0.12.0, leaving `benchmarks` and `test-sentry` untouched.
- The alignment guard fails on the current drifted state and passes once aligned.
- Both changelog extraction paths (curated MDX and CHANGELOG.md fallback) exercised in bash specifically, since an unmatched glob behaves differently there than in zsh.
- Both workflow files parse as valid YAML.

Not verifiable locally: the actual Actions run, meaning PAT permissions, the tag push and the `gh release create` call. Those surface on the first release.

## Open question

`--generate-notes` computes its "Full Changelog" range from the previous release, and until now there were five per version, so which one GitHub picks as previous is ambiguous. The compare range may look off on this first release only. Fixable by passing `--notes-start-tag`, either pinned once or computed each run. Not included here, happy to add it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Releases now use a single version across the server, web interface, documentation, and related packages.
  * GitHub releases are created with consolidated notes and links to available artifacts.
  * Docker images and published packages consistently use the release version.

* **Documentation**
  * Added guidance explaining unified versioning and release behavior, including conventions for pre-1.0 releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->