### PR TITLE
fix(alerts): forward routing override when testing email integrations

### DIFF
--- a/.changeset/lazy-moons-repeat.md
+++ b/.changeset/lazy-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"@rustrak/server": "patch"
+---
+
+Fixed the "Send a test" action on email integrations. The recipients typed into the dialog were dropped before reaching the test endpoint, so the test either failed or sent to the integration's configured addresses instead of the ones entered. The test panel also moved out of the dialog footer into its own section, is now visible (disabled) while creating an integration, and validates the parsed recipient list so input of only commas or spaces can no longer be submitted.

--- a/apps/docs/content/changelog/38-v0-12-1-email-integration-test-fix.mdx
+++ b/apps/docs/content/changelog/38-v0-12-1-email-integration-test-fix.mdx
@@ -1,0 +1,21 @@
+---
+version: v0.12.1
+title: Email Integration Test Fix
+description: The "Send a test" action on email integrations now uses the recipients you type instead of dropping them
+date: 2026-07-20
+tags: [webview-ui, alerts, bugfix]
+---
+
+## Email Integration Test Fix
+
+Testing an email integration ignored the addresses typed into the dialog. The email config dialog passes its recipients through the routing override, but the parent list dropped that second argument before calling the test handler, so the request reached the server without them.
+
+- Forward the routing override from the email dialog to the test handler, so the test goes to the addresses you actually typed
+- Moved the test panel out of the dialog footer into its own section, where the helper text has room to explain that the test uses the last saved SMTP settings, not unsaved edits
+- The panel is now visible while creating an integration, disabled with a hint that the integration must be saved first, instead of appearing out of nowhere after the first save
+- Validate the parsed recipient list rather than the raw string, so input of only commas or whitespace no longer produces a request the server rejects
+- Labelled the recipients input for screen readers
+
+## Improvements
+
+- Delete is now a `destructive` button in the email dialog footer, matching the other integration dialogs

--- a/apps/webview-ui/src/app/(main)/settings/integrations/integrations-list.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/integrations/integrations-list.tsx
@@ -14,7 +14,7 @@ import {
   Webhook,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState, useTransition } from 'react';
+import { useEffect, useMemo, useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -1157,6 +1157,18 @@ function EmailConfigDialog({
   const isLoading = isPending || parentPending;
   const [testRecipients, setTestRecipients] = useState('');
 
+  // Parsed once so the button's enabled state and its payload can never
+  // disagree: input that is only commas or spaces yields an empty list, which
+  // the server rejects with "must include at least one recipient".
+  const parsedRecipients = useMemo(
+    () =>
+      testRecipients
+        .split(',')
+        .map((a) => a.trim())
+        .filter(Boolean),
+    [testRecipients],
+  );
+
   const form = useForm<EmailFormData>({
     resolver: zodResolver(emailFormSchema),
     defaultValues: {
@@ -1423,6 +1435,7 @@ function EmailConfigDialog({
               </p>
               <div className="flex gap-2">
                 <Input
+                  aria-label="Test recipients"
                   placeholder="test@example.com"
                   value={testRecipients}
                   onChange={(e) => setTestRecipients(e.target.value)}
@@ -1434,15 +1447,17 @@ function EmailConfigDialog({
                   variant="outline"
                   size="sm"
                   onClick={() => {
-                    if (!existingIntegration || !testRecipients.trim()) return;
-                    const recipients = testRecipients
-                      .split(',')
-                      .map((a) => a.trim())
-                      .filter(Boolean);
-                    onTest(existingIntegration, { recipients });
+                    if (!existingIntegration || parsedRecipients.length === 0) {
+                      return;
+                    }
+                    onTest(existingIntegration, {
+                      recipients: parsedRecipients,
+                    });
                   }}
                   disabled={
-                    isLoading || !existingIntegration || !testRecipients.trim()
+                    isLoading ||
+                    !existingIntegration ||
+                    parsedRecipients.length === 0
                   }
                 >
                   <Play className="size-3.5 mr-1" />

--- a/apps/webview-ui/src/app/(main)/settings/integrations/integrations-list.tsx
+++ b/apps/webview-ui/src/app/(main)/settings/integrations/integrations-list.tsx
@@ -423,7 +423,8 @@ export function IntegrationsList({
         open={configureType === 'email'}
         onOpenChange={(open) => !open && closeConfigure()}
         existingIntegration={editIntegration}
-        onTest={(integration) => handleTest(integration)}
+        // Must forward routingOverride — Email carries its recipients there.
+        onTest={handleTest}
         onDelete={(integration) => setDeleteIntegrationItem(integration)}
         isPending={isPending}
       />
@@ -1414,47 +1415,59 @@ function EmailConfigDialog({
               )}
             />
 
+            {/* Shown while creating too, disabled — the test endpoint needs a
+                persisted integration id, so it only becomes usable on save. */}
+            <div className="rounded-lg border p-3 space-y-2">
+              <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+                Send a test
+              </p>
+              <div className="flex gap-2">
+                <Input
+                  placeholder="test@example.com"
+                  value={testRecipients}
+                  onChange={(e) => setTestRecipients(e.target.value)}
+                  className="h-8 text-xs"
+                  disabled={isLoading || !existingIntegration}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    if (!existingIntegration || !testRecipients.trim()) return;
+                    const recipients = testRecipients
+                      .split(',')
+                      .map((a) => a.trim())
+                      .filter(Boolean);
+                    onTest(existingIntegration, { recipients });
+                  }}
+                  disabled={
+                    isLoading || !existingIntegration || !testRecipients.trim()
+                  }
+                >
+                  <Play className="size-3.5 mr-1" />
+                  Test
+                </Button>
+              </div>
+              <p className="text-[11px] text-muted-foreground">
+                {existingIntegration
+                  ? 'Comma-separate multiple addresses. The test uses the SMTP settings you last saved, not unsaved edits above.'
+                  : 'Save this integration first to send a test email.'}
+              </p>
+            </div>
+
             <DialogFooter className="gap-2 sm:gap-0">
               {existingIntegration && (
-                <div className="flex gap-2 mr-auto">
-                  <div className="flex gap-1 items-center">
-                    <Input
-                      placeholder="test@example.com"
-                      value={testRecipients}
-                      onChange={(e) => setTestRecipients(e.target.value)}
-                      className="h-8 w-36 text-xs"
-                      disabled={isLoading}
-                    />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        if (!testRecipients.trim()) return;
-                        const recipients = testRecipients
-                          .split(',')
-                          .map((a) => a.trim())
-                          .filter(Boolean);
-                        onTest(existingIntegration, { recipients });
-                      }}
-                      disabled={isLoading || !testRecipients.trim()}
-                    >
-                      <Play className="size-4 mr-1" />
-                      Test
-                    </Button>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => onDelete(existingIntegration)}
-                    disabled={isLoading}
-                    className="text-destructive hover:text-destructive"
-                  >
-                    <Trash2 className="size-4 mr-1" />
-                    Delete
-                  </Button>
-                </div>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => onDelete(existingIntegration)}
+                  disabled={isLoading}
+                >
+                  <Trash2 className="size-4 mr-1" />
+                  Delete
+                </Button>
               )}
               <Button
                 type="button"


### PR DESCRIPTION
Fixes #203

## The bug

`EmailConfigDialog` collected test recipients and passed them to `onTest`, but the wiring in `IntegrationsList` dropped the second argument:

```tsx
// before
onTest={(integration) => handleTest(integration)}   // discards routingOverride
// after
onTest={handleTest}
```

The server therefore always received an empty routing override and rejected the request with `Email routing_override must include at least one recipient`. **Email integrations could never be tested, with any credentials** — which is why the reporter was confident theirs were correct. They were; the request never reached their SMTP server.

Slack was wired correctly (`onTest={handleTest}`), so only Email was affected. Webhook uses the same wrapper but never passes a routing override, so it was unaffected.

## Why it was hard to see

The real reason was masked twice over. The client rendered the server's error as `[object Object]`, and in production React redacts errors thrown out of Server Actions, so users saw a generic message instead. Both are tracked in #204 and deliberately left out of this branch.

## UI changes

The test block moved out of `DialogFooter` into the form body, matching the pattern `SlackConfigDialog` already uses.

The footer previously held a fixed-width input plus Test, Delete, Cancel and Save on one row (~509px inside a ~464px dialog), and nothing could shrink, so the modal scrolled horizontally. The footer is now just Delete, Cancel and Save.

The block is also shown while creating, disabled, with "Save this integration first to send a test email." The test endpoint is `POST /api/integrations/{id}/test` and needs a persisted id, so it cannot run before the first save.

Two smaller things: `Delete` now uses `variant="destructive"` to match the Slack dialog, and the help text documents that recipients are comma-separated and that the test uses the last saved SMTP settings, not unsaved edits in the form.

## Testing

Typecheck passes. Verified manually that the email test now reaches the SMTP server.

No automated test covers the fix — there is no component test scaffolding in `webview-ui` yet. Worth noting that forwarding props through a wrapper is exactly what broke here, so this is the kind of regression a test would catch cheaply once that scaffolding exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Send a test” section to the email integration setup flow.
  * Test email recipients can now be specified before sending.

* **Bug Fixes**
  * Fixed test email recipient settings not being forwarded correctly.
  * Clarified test instructions based on whether the integration has been saved.
  * Disabled test actions until an email integration is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->