### PR TITLE
feat(projects): replace create-project modal with a full page

### DIFF
--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -7731,7 +7731,7 @@
               "string",
               "null"
             ],
-            "description": "Platform chosen by the user in the create form, validated against\n[`SELECTABLE_PLATFORMS`] exactly as [`UpdateProject::platform`] is.\nReal Sentry accepts this on the create request too\n(`ProjectPostSerializer`, `src/sentry/core/endpoints/team_projects.py`).\n\nAbsent is legal and is not the same as \"no platform forever\": the\ncolumn stays NULL and the project remains eligible for\n[`super::super::services::ProjectService::infer_platform_from_event`],\nwhich fills it from the first ingested event using the narrower\n[`VALID_PLATFORMS`] list."
+            "description": "Platform identifier for the project, such as `python-django` or\n`javascript-nextjs`. Rejected with a 400 if it is not one of the\nsupported values.\n\nOptional. Omitting it is not the same as having no platform forever:\nthe project is then auto-assigned a platform from the first event it\ningests, drawn from the narrower set of platforms an event may declare."
           },
           "slug": {
             "type": [
@@ -9476,14 +9476,14 @@
               "string",
               "null"
             ],
-            "description": "Manual override of the project's platform, validated against\n[`SELECTABLE_PLATFORMS`]. That list is wider than the one\nauto-detection uses: it includes framework-specific ids such as\n`javascript-nextjs`, which are legal for a project but never for an\nevent.\n\nUnlike auto-detection (which only writes when the column is still\nNULL), a manual update is allowed to overwrite an existing value, so a\nuser can correct what was detected. Sending `null` leaves the current\nvalue untouched rather than clearing it."
+            "description": "Manual override of the project's platform, such as `python-django` or\n`javascript-nextjs`. Rejected with a 400 if it is not one of the\nsupported values.\n\nThe supported set is wider than the platforms an event may declare, so\nframework-specific identifiers are accepted here. An update overwrites\nany auto-assigned value, which is how a wrong detection is corrected.\nSending `null` leaves the current value untouched rather than clearing\nit."
           },
           "slug": {
             "type": [
               "string",
               "null"
             ],
-            "description": "New slug, slugified before storing.\n\nUnlike [`CreateProject::slug`], a collision here is **not** silently\nde-duplicated. On create the slug is usually derived from the name and\nthe user is not really choosing it, so appending `-1` is helpful. Here\nthe user typed it, and storing something other than what they typed\nwould be wrong, so a taken slug is a `Conflict`.\n\nSending `null` leaves the current value untouched."
+            "description": "New slug, slugified before storing.\n\nA slug already taken by another project returns a 409. It is not\nsilently de-duplicated the way a slug derived at creation time is,\nsince storing something other than what was requested would be wrong.\n\nSending `null` leaves the current value untouched."
           }
         }
       },

--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -7726,6 +7726,13 @@
           "name": {
             "type": "string"
           },
+          "platform": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Platform chosen by the user in the create form, validated against\n[`SELECTABLE_PLATFORMS`] exactly as [`UpdateProject::platform`] is.\nReal Sentry accepts this on the create request too\n(`ProjectPostSerializer`, `src/sentry/core/endpoints/team_projects.py`).\n\nAbsent is legal and is not the same as \"no platform forever\": the\ncolumn stays NULL and the project remains eligible for\n[`super::super::services::ProjectService::infer_platform_from_event`],\nwhich fills it from the first ingested event using the narrower\n[`VALID_PLATFORMS`] list."
+          },
           "slug": {
             "type": [
               "string",
@@ -9470,6 +9477,13 @@
               "null"
             ],
             "description": "Manual override of the project's platform, validated against\n[`SELECTABLE_PLATFORMS`]. That list is wider than the one\nauto-detection uses: it includes framework-specific ids such as\n`javascript-nextjs`, which are legal for a project but never for an\nevent.\n\nUnlike auto-detection (which only writes when the column is still\nNULL), a manual update is allowed to overwrite an existing value, so a\nuser can correct what was detected. Sending `null` leaves the current\nvalue untouched rather than clearing it."
+          },
+          "slug": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "New slug, slugified before storing.\n\nUnlike [`CreateProject::slug`], a collision here is **not** silently\nde-duplicated. On create the slug is usually derived from the name and\nthe user is not really choosing it, so appending `-1` is helpful. Here\nthe user typed it, and storing something other than what they typed\nwould be wrong, so a taken slug is a `Conflict`.\n\nSending `null` leaves the current value untouched."
           }
         }
       },

--- a/apps/server/src/models/project.rs
+++ b/apps/server/src/models/project.rs
@@ -208,6 +208,18 @@ pub struct CreateProject {
     pub name: String,
     #[serde(default)]
     pub slug: Option<String>,
+    /// Platform chosen by the user in the create form, validated against
+    /// [`SELECTABLE_PLATFORMS`] exactly as [`UpdateProject::platform`] is.
+    /// Real Sentry accepts this on the create request too
+    /// (`ProjectPostSerializer`, `src/sentry/core/endpoints/team_projects.py`).
+    ///
+    /// Absent is legal and is not the same as "no platform forever": the
+    /// column stays NULL and the project remains eligible for
+    /// [`super::super::services::ProjectService::infer_platform_from_event`],
+    /// which fills it from the first ingested event using the narrower
+    /// [`VALID_PLATFORMS`] list.
+    #[serde(default)]
+    pub platform: Option<String>,
 }
 
 /// DTO for updating a project
@@ -215,6 +227,16 @@ pub struct CreateProject {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct UpdateProject {
     pub name: Option<String>,
+    /// New slug, slugified before storing.
+    ///
+    /// Unlike [`CreateProject::slug`], a collision here is **not** silently
+    /// de-duplicated. On create the slug is usually derived from the name and
+    /// the user is not really choosing it, so appending `-1` is helpful. Here
+    /// the user typed it, and storing something other than what they typed
+    /// would be wrong, so a taken slug is a `Conflict`.
+    ///
+    /// Sending `null` leaves the current value untouched.
+    pub slug: Option<String>,
     /// Manual override of the project's platform, validated against
     /// [`SELECTABLE_PLATFORMS`]. That list is wider than the one
     /// auto-detection uses: it includes framework-specific ids such as

--- a/apps/server/src/models/project.rs
+++ b/apps/server/src/models/project.rs
@@ -208,16 +208,13 @@ pub struct CreateProject {
     pub name: String,
     #[serde(default)]
     pub slug: Option<String>,
-    /// Platform chosen by the user in the create form, validated against
-    /// [`SELECTABLE_PLATFORMS`] exactly as [`UpdateProject::platform`] is.
-    /// Real Sentry accepts this on the create request too
-    /// (`ProjectPostSerializer`, `src/sentry/core/endpoints/team_projects.py`).
+    /// Platform identifier for the project, such as `python-django` or
+    /// `javascript-nextjs`. Rejected with a 400 if it is not one of the
+    /// supported values.
     ///
-    /// Absent is legal and is not the same as "no platform forever": the
-    /// column stays NULL and the project remains eligible for
-    /// [`super::super::services::ProjectService::infer_platform_from_event`],
-    /// which fills it from the first ingested event using the narrower
-    /// [`VALID_PLATFORMS`] list.
+    /// Optional. Omitting it is not the same as having no platform forever:
+    /// the project is then auto-assigned a platform from the first event it
+    /// ingests, drawn from the narrower set of platforms an event may declare.
     #[serde(default)]
     pub platform: Option<String>,
 }
@@ -229,24 +226,21 @@ pub struct UpdateProject {
     pub name: Option<String>,
     /// New slug, slugified before storing.
     ///
-    /// Unlike [`CreateProject::slug`], a collision here is **not** silently
-    /// de-duplicated. On create the slug is usually derived from the name and
-    /// the user is not really choosing it, so appending `-1` is helpful. Here
-    /// the user typed it, and storing something other than what they typed
-    /// would be wrong, so a taken slug is a `Conflict`.
+    /// A slug already taken by another project returns a 409. It is not
+    /// silently de-duplicated the way a slug derived at creation time is,
+    /// since storing something other than what was requested would be wrong.
     ///
     /// Sending `null` leaves the current value untouched.
     pub slug: Option<String>,
-    /// Manual override of the project's platform, validated against
-    /// [`SELECTABLE_PLATFORMS`]. That list is wider than the one
-    /// auto-detection uses: it includes framework-specific ids such as
-    /// `javascript-nextjs`, which are legal for a project but never for an
-    /// event.
+    /// Manual override of the project's platform, such as `python-django` or
+    /// `javascript-nextjs`. Rejected with a 400 if it is not one of the
+    /// supported values.
     ///
-    /// Unlike auto-detection (which only writes when the column is still
-    /// NULL), a manual update is allowed to overwrite an existing value, so a
-    /// user can correct what was detected. Sending `null` leaves the current
-    /// value untouched rather than clearing it.
+    /// The supported set is wider than the platforms an event may declare, so
+    /// framework-specific identifiers are accepted here. An update overwrites
+    /// any auto-assigned value, which is how a wrong detection is corrected.
+    /// Sending `null` leaves the current value untouched rather than clearing
+    /// it.
     pub platform: Option<String>,
 }
 

--- a/apps/server/src/services/project.rs
+++ b/apps/server/src/services/project.rs
@@ -182,13 +182,49 @@ impl ProjectService {
 
         let platform = Self::validate_platform(input.platform.as_deref())?;
 
-        // Generate or validate slug
-        let slug = Self::generate_unique_slug(pool, name, input.slug.as_deref()).await?;
+        // A slug the user typed and a slug derived from the name get opposite
+        // treatment on collision, for the same reason `update` returns a
+        // Conflict: when the user chose the value, storing a de-duplicated
+        // variant of it silently is wrong. When we derived it from the name
+        // the user never chose anything, so appending `-1` is helpful.
+        let (slug, slug_is_user_chosen) = match input.slug.as_deref().map(str::trim) {
+            Some(typed) if !typed.is_empty() => {
+                let slugified = slugify(typed);
+                if slugified.is_empty() {
+                    return Err(AppError::Validation(
+                        "Cannot generate valid slug from input".to_string(),
+                    ));
+                }
+                // Pre-check so the ordinary case is a clean Conflict. The
+                // insert below still has to handle the TOCTOU race.
+                let taken: Option<i32> =
+                    sqlx::query_scalar("SELECT id FROM projects WHERE slug = $1")
+                        .bind(&slugified)
+                        .fetch_optional(pool)
+                        .await?;
+                if taken.is_some() {
+                    return Err(AppError::Conflict(format!(
+                        "Project with slug '{}' already exists",
+                        slugified
+                    )));
+                }
+                (slugified, true)
+            }
+            _ => (Self::generate_unique_slug(pool, name).await?, false),
+        };
 
         // Generate sentry_key in application (for cross-DB compatibility)
         let sentry_key = uuid::Uuid::new_v4();
 
-        let project = Self::try_insert_with_retry(pool, name, &slug, sentry_key, platform).await?;
+        let project = Self::try_insert_with_retry(
+            pool,
+            name,
+            &slug,
+            sentry_key,
+            platform,
+            slug_is_user_chosen,
+        )
+        .await?;
 
         Ok(project)
     }
@@ -365,16 +401,12 @@ impl ProjectService {
         Ok(())
     }
 
-    /// Generates a unique slug based on the name
-    async fn generate_unique_slug(
-        pool: &DbPool,
-        name: &str,
-        custom_slug: Option<&str>,
-    ) -> AppResult<String> {
-        let base_slug = match custom_slug {
-            Some(s) if !s.trim().is_empty() => slugify(s.trim()),
-            _ => slugify(name),
-        };
+    /// Generates a unique slug based on the name.
+    ///
+    /// De-duplication is only ever correct for a *derived* slug. A slug the
+    /// user typed is handled in [`Self::create`] and conflicts instead.
+    async fn generate_unique_slug(pool: &DbPool, name: &str) -> AppResult<String> {
+        let base_slug = slugify(name);
 
         if base_slug.is_empty() {
             return Err(AppError::Validation(
@@ -419,7 +451,8 @@ impl ProjectService {
         platform: Option<&str>,
     ) -> AppResult<Project> {
         let sentry_key = uuid::Uuid::new_v4();
-        Self::try_insert_with_retry(pool, name, stale_slug, sentry_key, platform).await
+        // `false`: this helper exists to exercise the derived-slug retry path.
+        Self::try_insert_with_retry(pool, name, stale_slug, sentry_key, platform, false).await
     }
 
     async fn try_insert_with_retry(
@@ -428,6 +461,7 @@ impl ProjectService {
         slug: &str,
         sentry_key: uuid::Uuid,
         platform: Option<&str>,
+        slug_is_user_chosen: bool,
     ) -> AppResult<Project> {
         const INSERT_SQL: &str = r#"
             INSERT INTO projects (name, slug, sentry_key, platform)
@@ -448,9 +482,25 @@ impl ProjectService {
         match result {
             Ok(p) => Ok(p),
             Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
+                if slug_is_user_chosen {
+                    // Lost the TOCTOU race on a slug the user typed. Retrying
+                    // under a renamed slug would store something they never
+                    // asked for, so report whichever column actually collided.
+                    let slug_taken: Option<i32> =
+                        sqlx::query_scalar("SELECT id FROM projects WHERE slug = $1")
+                            .bind(slug)
+                            .fetch_optional(pool)
+                            .await?;
+                    return Err(AppError::Conflict(if slug_taken.is_some() {
+                        format!("Project with slug '{}' already exists", slug)
+                    } else {
+                        format!("Project with name '{}' already exists", name)
+                    }));
+                }
+
                 // The slug may have been taken by a concurrent request (TOCTOU).
                 // Re-query to get the next available slug and retry once.
-                let new_slug = Self::generate_unique_slug(pool, name, None).await?;
+                let new_slug = Self::generate_unique_slug(pool, name).await?;
                 if new_slug == slug {
                     // Slug is still available → the collision was on name, not slug.
                     return Err(AppError::Conflict(format!(

--- a/apps/server/src/services/project.rs
+++ b/apps/server/src/services/project.rs
@@ -180,15 +180,39 @@ impl ProjectService {
             ));
         }
 
+        let platform = Self::validate_platform(input.platform.as_deref())?;
+
         // Generate or validate slug
         let slug = Self::generate_unique_slug(pool, name, input.slug.as_deref()).await?;
 
         // Generate sentry_key in application (for cross-DB compatibility)
         let sentry_key = uuid::Uuid::new_v4();
 
-        let project = Self::try_insert_with_retry(pool, name, &slug, sentry_key).await?;
+        let project = Self::try_insert_with_retry(pool, name, &slug, sentry_key, platform).await?;
 
         Ok(project)
+    }
+
+    /// Validates a user-supplied platform id against [`SELECTABLE_PLATFORMS`].
+    ///
+    /// Shared by [`Self::create`] and [`Self::update`] so the two can never
+    /// drift. Deliberately *not* used by
+    /// [`Self::infer_platform_from_event`], which filters on the narrower
+    /// [`VALID_PLATFORMS`]: an event's platform and a project's platform are
+    /// different domains with different valid-value lists.
+    fn validate_platform(platform: Option<&str>) -> AppResult<Option<&str>> {
+        match platform {
+            Some(p) => {
+                if !SELECTABLE_PLATFORMS.contains(&p) {
+                    return Err(AppError::Validation(format!(
+                        "'{}' is not a valid platform",
+                        p
+                    )));
+                }
+                Ok(Some(p))
+            }
+            None => Ok(None),
+        }
     }
 
     /// Updates an existing project
@@ -212,20 +236,38 @@ impl ProjectService {
             None => None,
         };
 
-        let platform = match input.platform {
-            Some(ref platform) => {
-                if !SELECTABLE_PLATFORMS.contains(&platform.as_str()) {
-                    return Err(AppError::Validation(format!(
-                        "'{}' is not a valid platform",
-                        platform
+        let platform = Self::validate_platform(input.platform.as_deref())?;
+
+        let slug = match input.slug {
+            Some(ref slug) => {
+                let slugified = slugify(slug.trim());
+                if slugified.is_empty() {
+                    return Err(AppError::Validation(
+                        "Cannot generate valid slug from input".to_string(),
+                    ));
+                }
+                // Explicit availability check so the normal path returns a
+                // clear Conflict rather than a raw unique violation. This is
+                // TOCTOU-racy on its own, so the unique-violation mapping
+                // below still has to cover the slug case.
+                let taken: Option<i32> =
+                    sqlx::query_scalar("SELECT id FROM projects WHERE slug = $1 AND id != $2")
+                        .bind(&slugified)
+                        .bind(id)
+                        .fetch_optional(pool)
+                        .await?;
+                if taken.is_some() {
+                    return Err(AppError::Conflict(format!(
+                        "Project with slug '{}' already exists",
+                        slugified
                     )));
                 }
-                Some(platform.as_str())
+                Some(slugified)
             }
             None => None,
         };
 
-        if name.is_none() && platform.is_none() {
+        if name.is_none() && platform.is_none() && slug.is_none() {
             // If no fields to update, return project unchanged
             return Self::get_by_id(pool, id).await;
         }
@@ -237,8 +279,9 @@ impl ProjectService {
             UPDATE projects
             SET name = COALESCE($1, name),
                 platform = COALESCE($2, platform),
+                slug = COALESCE($3, slug),
                 updated_at = CURRENT_TIMESTAMP
-            WHERE id = $3
+            WHERE id = $4
             RETURNING id, name, slug, sentry_key, stored_event_count,
                       digested_event_count, created_at, updated_at, platform,
                       quota_exceeded_until, quota_exceeded_reason, next_quota_check
@@ -246,12 +289,28 @@ impl ProjectService {
         )
         .bind(name)
         .bind(platform)
+        .bind(slug.as_deref())
         .bind(id)
         .fetch_one(pool)
         .await
         .map_err(|e| {
             if let sqlx::Error::Database(ref db_err) = e {
                 if db_err.is_unique_violation() {
+                    // The availability check above is TOCTOU-racy: a concurrent
+                    // update can take the slug between the SELECT and this
+                    // UPDATE. Without this arm a slug-only update loses the
+                    // race as a 500 instead of a 409. Both dialects name the
+                    // column in the message (Postgres `projects_slug_key`,
+                    // SQLite `projects.slug`), which is what distinguishes it
+                    // from the name constraint.
+                    if db_err.message().contains("slug") {
+                        if let Some(ref slug) = slug {
+                            return AppError::Conflict(format!(
+                                "Project with slug '{}' already exists",
+                                slug
+                            ));
+                        }
+                    }
                     if let Some(name) = name {
                         return AppError::Conflict(format!(
                             "Project with name '{}' already exists",
@@ -357,9 +416,10 @@ impl ProjectService {
         pool: &DbPool,
         name: &str,
         stale_slug: &str,
+        platform: Option<&str>,
     ) -> AppResult<Project> {
         let sentry_key = uuid::Uuid::new_v4();
-        Self::try_insert_with_retry(pool, name, stale_slug, sentry_key).await
+        Self::try_insert_with_retry(pool, name, stale_slug, sentry_key, platform).await
     }
 
     async fn try_insert_with_retry(
@@ -367,10 +427,11 @@ impl ProjectService {
         name: &str,
         slug: &str,
         sentry_key: uuid::Uuid,
+        platform: Option<&str>,
     ) -> AppResult<Project> {
         const INSERT_SQL: &str = r#"
-            INSERT INTO projects (name, slug, sentry_key)
-            VALUES ($1, $2, $3)
+            INSERT INTO projects (name, slug, sentry_key, platform)
+            VALUES ($1, $2, $3, $4)
             RETURNING id, name, slug, sentry_key, stored_event_count,
                       digested_event_count, created_at, updated_at, platform,
                       quota_exceeded_until, quota_exceeded_reason, next_quota_check
@@ -380,6 +441,7 @@ impl ProjectService {
             .bind(name)
             .bind(slug)
             .bind(sentry_key)
+            .bind(platform)
             .fetch_one(pool)
             .await;
 
@@ -400,6 +462,7 @@ impl ProjectService {
                     .bind(name)
                     .bind(&new_slug)
                     .bind(sentry_key)
+                    .bind(platform)
                     .fetch_one(pool)
                     .await
                     .map_err(|e| {

--- a/apps/server/tests/e2e/sentry_sdk_test.rs
+++ b/apps/server/tests/e2e/sentry_sdk_test.rs
@@ -61,6 +61,7 @@ async fn create_test_project(pool: &DbPool, name: &str) -> rustrak::models::Proj
         CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/agents_api_test.rs
+++ b/apps/server/tests/integration/agents_api_test.rs
@@ -102,6 +102,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool) -> i32 {
         CreateProject {
             name: format!("Agents API Test {}", Uuid::new_v4()),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/alerts_api_test.rs
+++ b/apps/server/tests/integration/alerts_api_test.rs
@@ -60,6 +60,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool) -> i32 {
         rustrak::models::CreateProject {
             name: format!("Test Project {}", chrono::Utc::now().timestamp_millis()),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/concurrency_test.rs
+++ b/apps/server/tests/integration/concurrency_test.rs
@@ -32,6 +32,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool, name: &str) -> rustrak:
         CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/digest_test.rs
+++ b/apps/server/tests/integration/digest_test.rs
@@ -30,6 +30,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool, name: &str) -> rustrak:
         CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/envelope_v2_test.rs
+++ b/apps/server/tests/integration/envelope_v2_test.rs
@@ -49,6 +49,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool, name: &str) -> (i32, St
         rustrak::models::CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/events_api_test.rs
+++ b/apps/server/tests/integration/events_api_test.rs
@@ -63,6 +63,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool, name: &str) -> rustrak:
         CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/ingest_test.rs
+++ b/apps/server/tests/integration/ingest_test.rs
@@ -53,6 +53,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool, name: &str) -> (i32, St
         rustrak::models::CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/issues_api_test.rs
+++ b/apps/server/tests/integration/issues_api_test.rs
@@ -63,6 +63,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool, name: &str) -> rustrak:
         CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/logs_api_test.rs
+++ b/apps/server/tests/integration/logs_api_test.rs
@@ -84,6 +84,7 @@ async fn test_list_logs_returns_stored_logs() {
         CreateProject {
             name: "Logs List Test".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -127,6 +128,7 @@ async fn test_list_logs_filters_by_level() {
         CreateProject {
             name: "Logs Filter Test".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -167,6 +169,7 @@ async fn test_list_logs_returns_401_without_token() {
         CreateProject {
             name: "Logs Auth Test".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/projects_api_test.rs
+++ b/apps/server/tests/integration/projects_api_test.rs
@@ -213,6 +213,7 @@ async fn test_slug_toctou_retries_with_next_candidate() {
         CreateProject {
             name: "My Project".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -220,9 +221,10 @@ async fn test_slug_toctou_retries_with_next_candidate() {
 
     // Simulate what happens when generate_unique_slug returned "my-project"
     // from a stale read (TOCTOU race): the INSERT should retry, not 409.
-    let project = ProjectService::create_with_stale_slug(&db.pool, "My-Project", "my-project")
-        .await
-        .expect("stale-slug create must succeed via retry, not 409");
+    let project =
+        ProjectService::create_with_stale_slug(&db.pool, "My-Project", "my-project", None)
+            .await
+            .expect("stale-slug create must succeed via retry, not 409");
 
     assert_eq!(project.slug, "my-project-1");
     assert_eq!(project.name, "My-Project");
@@ -244,6 +246,7 @@ async fn test_update_project_platform_sets_valid_platform() {
         CreateProject {
             name: "Platform Update Project".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -255,6 +258,7 @@ async fn test_update_project_platform_sets_valid_platform() {
         project.id,
         UpdateProject {
             name: None,
+            slug: None,
             platform: Some("python".to_string()),
         },
     )
@@ -277,6 +281,7 @@ async fn test_update_project_platform_accepts_framework_specific_id() {
         CreateProject {
             name: "Framework Platform Project".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -287,6 +292,7 @@ async fn test_update_project_platform_accepts_framework_specific_id() {
         project.id,
         UpdateProject {
             name: None,
+            slug: None,
             platform: Some("javascript-nextjs".to_string()),
         },
     )
@@ -304,6 +310,7 @@ async fn test_update_project_platform_rejects_invalid_value() {
         CreateProject {
             name: "Invalid Platform Project".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -314,6 +321,7 @@ async fn test_update_project_platform_rejects_invalid_value() {
         project.id,
         UpdateProject {
             name: None,
+            slug: None,
             platform: Some("not-a-real-platform".to_string()),
         },
     )
@@ -339,6 +347,7 @@ async fn test_update_project_sets_name_and_platform_together() {
         CreateProject {
             name: "Old Name".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -349,6 +358,7 @@ async fn test_update_project_sets_name_and_platform_together() {
         project.id,
         UpdateProject {
             name: Some("New Name".to_string()),
+            slug: None,
             platform: Some("go".to_string()),
         },
     )
@@ -359,6 +369,254 @@ async fn test_update_project_sets_name_and_platform_together() {
     assert_eq!(updated.platform, Some("go".to_string()));
 }
 
+// =============================================================================
+// Editable Slug Tests
+//
+// Real Sentry exposes the slug as the first field of General Settings. Its
+// warning that renaming "can break your build scripts" does not apply here:
+// Sentry puts the slug in every API URL, whereas Rustrak's DSN and routes key
+// off the numeric project id, so nothing downstream depends on it.
+//
+// Note the deliberate asymmetry with create: `ProjectService::create` silently
+// de-duplicates a taken slug ("api" -> "api-1") because there the slug is
+// usually derived from the name. On update the user typed it, so storing
+// something other than what they typed would be wrong. Update conflicts.
+// =============================================================================
+
+#[actix_web::test]
+async fn test_update_project_slug() {
+    let db = TestDb::new().await;
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Slug Update Project".to_string(),
+            slug: None,
+            platform: None,
+        },
+    )
+    .await
+    .expect("create must succeed");
+    assert_eq!(project.slug, "slug-update-project");
+
+    let updated = ProjectService::update(
+        &db.pool,
+        project.id,
+        UpdateProject {
+            name: None,
+            platform: None,
+            slug: Some("renamed-slug".to_string()),
+        },
+    )
+    .await
+    .expect("slug update must succeed");
+
+    assert_eq!(updated.slug, "renamed-slug");
+
+    let fetched = ProjectService::get_by_id(&db.pool, project.id)
+        .await
+        .expect("get must succeed");
+    assert_eq!(fetched.slug, "renamed-slug");
+}
+
+/// A slug the user typed that is already taken must surface as a Conflict
+/// (409), not a raw database error (500), and must leave the target project
+/// untouched. Note the existing unique-violation mapping only produced a
+/// Conflict when a `name` was being set, so a slug-only update fell through
+/// to `AppError::Database`.
+#[actix_web::test]
+async fn test_update_project_slug_conflict_is_reported_as_conflict() {
+    let db = TestDb::new().await;
+
+    ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Taken Slug Project".to_string(),
+            slug: None,
+            platform: None,
+        },
+    )
+    .await
+    .expect("create must succeed");
+
+    let target = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Target Slug Project".to_string(),
+            slug: None,
+            platform: None,
+        },
+    )
+    .await
+    .expect("create must succeed");
+
+    let result = ProjectService::update(
+        &db.pool,
+        target.id,
+        UpdateProject {
+            name: None,
+            platform: None,
+            slug: Some("taken-slug-project".to_string()),
+        },
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(rustrak::error::AppError::Conflict(_))),
+        "expected a Conflict error, got: {result:?}"
+    );
+
+    let unchanged = ProjectService::get_by_id(&db.pool, target.id)
+        .await
+        .expect("get must succeed");
+    assert_eq!(unchanged.slug, "target-slug-project");
+}
+
+/// Input that slugifies to nothing must be a 400, not a silent no-op and not
+/// an empty slug in the database. `create` already rejects this case; update
+/// must match.
+#[actix_web::test]
+async fn test_update_project_slug_rejects_unslugifiable_input() {
+    let db = TestDb::new().await;
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Unslugifiable Project".to_string(),
+            slug: None,
+            platform: None,
+        },
+    )
+    .await
+    .expect("create must succeed");
+
+    let result = ProjectService::update(
+        &db.pool,
+        project.id,
+        UpdateProject {
+            name: None,
+            platform: None,
+            slug: Some("!!!".to_string()),
+        },
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(rustrak::error::AppError::Validation(_))),
+        "expected a Validation error, got: {result:?}"
+    );
+
+    let unchanged = ProjectService::get_by_id(&db.pool, project.id)
+        .await
+        .expect("get must succeed");
+    assert_eq!(unchanged.slug, "unslugifiable-project");
+}
+
+// =============================================================================
+// Platform-at-creation Tests
+//
+// Real Sentry accepts `platform` on the create-project request itself
+// (ProjectPostSerializer, src/sentry/core/endpoints/team_projects.py), so a
+// user who picks a platform in the create form does not need a follow-up
+// PATCH. Validation is the same SELECTABLE_PLATFORMS list the manual
+// override above uses, deliberately wider than the VALID_PLATFORMS list
+// auto-detection filters on.
+// =============================================================================
+
+#[actix_web::test]
+async fn test_create_project_sets_platform() {
+    let db = TestDb::new().await;
+
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Created With Platform".to_string(),
+            slug: None,
+            platform: Some("javascript-nextjs".to_string()),
+        },
+    )
+    .await
+    .expect("create with platform must succeed");
+
+    assert_eq!(project.platform, Some("javascript-nextjs".to_string()));
+
+    // Re-read: the returned struct must reflect what was persisted, not just
+    // the input echoed back.
+    let fetched = ProjectService::get_by_id(&db.pool, project.id)
+        .await
+        .expect("get must succeed");
+    assert_eq!(fetched.platform, Some("javascript-nextjs".to_string()));
+}
+
+/// The TOCTOU retry re-issues the INSERT with a freshly generated slug. That
+/// second statement is a separate set of binds, so a platform threaded only
+/// through the first one is silently dropped for exactly the concurrent-create
+/// case. Nothing else covers the retry path's column list.
+#[actix_web::test]
+async fn test_create_preserves_platform_across_slug_retry() {
+    let db = TestDb::new().await;
+
+    // Establish "retry-platform" as taken so the next INSERT collides.
+    ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Retry Platform".to_string(),
+            slug: None,
+            platform: None,
+        },
+    )
+    .await
+    .expect("first create must succeed");
+
+    let project = ProjectService::create_with_stale_slug(
+        &db.pool,
+        "Retry-Platform",
+        "retry-platform",
+        Some("python-django"),
+    )
+    .await
+    .expect("stale-slug create must succeed via retry");
+
+    assert_eq!(project.slug, "retry-platform-1");
+    assert_eq!(
+        project.platform,
+        Some("python-django".to_string()),
+        "platform must survive the retry INSERT, not just the first one"
+    );
+}
+
+/// A bad platform must be rejected *before* the INSERT, not stored and not
+/// silently dropped. The row must not exist afterwards: a project created
+/// with a silently-discarded platform looks successful to the user while
+/// losing their choice.
+#[actix_web::test]
+async fn test_create_project_rejects_invalid_platform() {
+    let db = TestDb::new().await;
+
+    let result = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Invalid Platform At Creation".to_string(),
+            slug: None,
+            platform: Some("not-a-real-platform".to_string()),
+        },
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(rustrak::error::AppError::Validation(_))),
+        "expected a Validation error, got: {result:?}"
+    );
+
+    let projects = ProjectService::list(&db.pool)
+        .await
+        .expect("list must succeed");
+    assert!(
+        !projects
+            .iter()
+            .any(|p| p.name == "Invalid Platform At Creation"),
+        "rejected create must not have persisted a row"
+    );
+}
+
 #[actix_web::test]
 async fn test_update_project_platform_overwrites_existing_value() {
     let db = TestDb::new().await;
@@ -367,6 +625,7 @@ async fn test_update_project_platform_overwrites_existing_value() {
         CreateProject {
             name: "Overwrite Platform Project".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -379,6 +638,7 @@ async fn test_update_project_platform_overwrites_existing_value() {
         project.id,
         UpdateProject {
             name: None,
+            slug: None,
             platform: Some("javascript".to_string()),
         },
     )
@@ -392,6 +652,7 @@ async fn test_update_project_platform_overwrites_existing_value() {
         project.id,
         UpdateProject {
             name: None,
+            slug: None,
             platform: Some("ruby".to_string()),
         },
     )

--- a/apps/server/tests/integration/projects_api_test.rs
+++ b/apps/server/tests/integration/projects_api_test.rs
@@ -661,3 +661,108 @@ async fn test_update_project_platform_overwrites_existing_value() {
 
     assert_eq!(updated.platform, Some("ruby".to_string()));
 }
+
+// =============================================================================
+// User-Chosen Slug on Create
+//
+// A slug the caller supplied and a slug derived from the name get opposite
+// treatment on collision. These pin both halves: silently de-duplicating a
+// slug the user typed would store something they never asked for, and
+// conflicting on a derived one would break the ordinary create path.
+// =============================================================================
+
+#[actix_web::test]
+async fn test_create_project_with_taken_user_slug_conflicts() {
+    let db = TestDb::new().await;
+
+    ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "First Project".to_string(),
+            slug: Some("shared-slug".to_string()),
+            platform: None,
+        },
+    )
+    .await
+    .expect("first create must succeed");
+
+    let result = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Second Project".to_string(),
+            slug: Some("shared-slug".to_string()),
+            platform: None,
+        },
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(rustrak::error::AppError::Conflict(_))),
+        "a slug the user typed must conflict, not be de-duplicated, got: {result:?}"
+    );
+
+    // And nothing was written under a renamed slug.
+    let projects = ProjectService::list(&db.pool)
+        .await
+        .expect("list must succeed");
+    assert_eq!(
+        projects
+            .iter()
+            .filter(|p| p.slug.starts_with("shared-slug"))
+            .count(),
+        1,
+        "the rejected create must not have inserted a de-duplicated row"
+    );
+}
+
+#[actix_web::test]
+async fn test_create_project_derived_slug_still_dedupes() {
+    let db = TestDb::new().await;
+
+    let first = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Derived Project".to_string(),
+            slug: None,
+            platform: None,
+        },
+    )
+    .await
+    .expect("first create must succeed");
+    assert_eq!(first.slug, "derived-project");
+
+    // A different name (so the UNIQUE on name passes) that slugifies to the
+    // same base. Nobody chose this slug, so appending a counter is correct.
+    let second = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Derived  Project".to_string(),
+            slug: None,
+            platform: None,
+        },
+    )
+    .await
+    .expect("a derived slug must de-duplicate, not conflict");
+
+    assert_eq!(second.slug, "derived-project-1");
+}
+
+#[actix_web::test]
+async fn test_create_project_rejects_unslugifiable_user_slug() {
+    let db = TestDb::new().await;
+
+    let result = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "Punctuation Project".to_string(),
+            slug: Some("!!!".to_string()),
+            platform: None,
+        },
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(rustrak::error::AppError::Validation(_))),
+        "a slug that slugifies to nothing must be a Validation error, got: {result:?}"
+    );
+}

--- a/apps/server/tests/integration/rate_limit_test.rs
+++ b/apps/server/tests/integration/rate_limit_test.rs
@@ -59,6 +59,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool, name: &str) -> (i32, St
         rustrak::models::CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/releases_api_test.rs
+++ b/apps/server/tests/integration/releases_api_test.rs
@@ -65,6 +65,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool, name: &str) -> rustrak:
         CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/sessions_api_test.rs
+++ b/apps/server/tests/integration/sessions_api_test.rs
@@ -124,6 +124,7 @@ async fn create_project(pool: &DbPool, name: &str) -> i32 {
         rustrak::models::CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/sourcemaps_api_test.rs
+++ b/apps/server/tests/integration/sourcemaps_api_test.rs
@@ -616,6 +616,7 @@ async fn test_assemble_before_upload_returns_not_found_with_missing_chunks() {
         CreateProject {
             name: "my-proj-assemble-missing".to_string(),
             slug: Some("my-proj-assemble-missing".to_string()),
+            platform: None,
         },
     )
     .await
@@ -671,6 +672,7 @@ async fn test_assemble_after_upload_enqueues_job_returns_created() {
         CreateProject {
             name: "assemble-after-upload".to_string(),
             slug: Some("assemble-after-upload".to_string()),
+            platform: None,
         },
     )
     .await
@@ -743,6 +745,7 @@ async fn test_assemble_idempotent_same_bundle_twice() {
         CreateProject {
             name: "assemble-idempotent".to_string(),
             slug: Some("assemble-idempotent".to_string()),
+            platform: None,
         },
     )
     .await
@@ -914,6 +917,7 @@ async fn test_assemble_checksum_mismatch_enqueues_job() {
         CreateProject {
             name: "assemble-checksum-mismatch".to_string(),
             slug: Some("assemble-checksum-mismatch".to_string()),
+            platform: None,
         },
     )
     .await
@@ -975,6 +979,7 @@ async fn test_assemble_failed_job_returns_400_on_retry() {
         CreateProject {
             name: "assemble-failed-retry".to_string(),
             slug: Some("assemble-failed-retry".to_string()),
+            platform: None,
         },
     )
     .await
@@ -1046,6 +1051,7 @@ async fn test_list_source_maps_returns_paginated_list() {
         CreateProject {
             name: "list-sourcemaps-proj".to_string(),
             slug: Some("list-sourcemaps-proj".to_string()),
+            platform: None,
         },
     )
     .await
@@ -1169,6 +1175,7 @@ async fn test_list_source_maps_scoped_to_project() {
         CreateProject {
             name: "sourcemaps-scope-a".to_string(),
             slug: Some("sourcemaps-scope-a".to_string()),
+            platform: None,
         },
     )
     .await
@@ -1179,6 +1186,7 @@ async fn test_list_source_maps_scoped_to_project() {
         CreateProject {
             name: "sourcemaps-scope-b".to_string(),
             slug: Some("sourcemaps-scope-b".to_string()),
+            platform: None,
         },
     )
     .await
@@ -1316,6 +1324,7 @@ async fn test_assemble_bundle_finds_manifest_json() {
         CreateProject {
             name: "manifest-extraction".to_string(),
             slug: Some("manifest-extraction".to_string()),
+            platform: None,
         },
     )
     .await
@@ -1371,6 +1380,7 @@ async fn test_assemble_bundle_rejects_oversized_bundle() {
         CreateProject {
             name: "bundle-size-limit".to_string(),
             slug: Some("bundle-size-limit".to_string()),
+            platform: None,
         },
     )
     .await
@@ -1449,6 +1459,7 @@ async fn test_assemble_state_column_decodable_in_postgres() {
         CreateProject {
             name: "pg-state-decode".to_string(),
             slug: Some("pg-state-decode".to_string()),
+            platform: None,
         },
     )
     .await
@@ -1712,6 +1723,7 @@ async fn test_assemble_bundle_manifest_path_traversal_rejected() {
         CreateProject {
             name: "traversal-test".to_string(),
             slug: Some("traversal-test".to_string()),
+            platform: None,
         },
     )
     .await
@@ -1792,6 +1804,7 @@ async fn test_assemble_bundle_tilde_prefix_with_debug_id_stores_source_file() {
         CreateProject {
             name: "tilde-prefix-test".to_string(),
             slug: Some("tilde-prefix-test".to_string()),
+            platform: None,
         },
     )
     .await
@@ -1987,6 +2000,7 @@ async fn test_assemble_re_enqueue_error_job_updates_chunks() {
         CreateProject {
             name: "re-enqueue-chunks-test".to_string(),
             slug: Some("re-enqueue-chunks-test".to_string()),
+            platform: None,
         },
     )
     .await
@@ -2083,6 +2097,7 @@ async fn test_assemble_with_numeric_project_id_returns_not_found_or_created() {
         CreateProject {
             name: "numeric-id-test-project".to_string(),
             slug: Some("numeric-id-test-project".to_string()),
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/span_v2_ingest_test.rs
+++ b/apps/server/tests/integration/span_v2_ingest_test.rs
@@ -55,6 +55,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool, name: &str) -> (i32, St
         rustrak::models::CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/spans_api_test.rs
+++ b/apps/server/tests/integration/spans_api_test.rs
@@ -93,6 +93,7 @@ async fn test_list_spans_returns_stored_spans() {
         CreateProject {
             name: "Spans List Test".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -133,6 +134,7 @@ async fn test_list_spans_filters_by_trace_id() {
         CreateProject {
             name: "Spans Filter Test".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -184,6 +186,7 @@ async fn test_list_spans_filters_by_op() {
         CreateProject {
             name: "Spans Op Filter Test".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -227,6 +230,7 @@ async fn test_list_spans_filters_by_status() {
         CreateProject {
             name: "Spans Status Filter Test".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -270,6 +274,7 @@ async fn test_list_spans_returns_401_without_token() {
         CreateProject {
             name: "Spans Auth Test".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/stats_api_test.rs
+++ b/apps/server/tests/integration/stats_api_test.rs
@@ -127,6 +127,7 @@ async fn create_project(pool: &DbPool, name: &str) -> i32 {
         rustrak::models::CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/storage_api_test.rs
+++ b/apps/server/tests/integration/storage_api_test.rs
@@ -216,6 +216,7 @@ async fn execute_cleanup_honors_data_type_filter_from_request_body() {
         CreateProject {
             name: "filter-http".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/team_rbac_test.rs
+++ b/apps/server/tests/integration/team_rbac_test.rs
@@ -118,6 +118,7 @@ async fn seed_project(pool: &DbPool, name: &str) -> rustrak::models::Project {
         CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/integration/transactions_api_test.rs
+++ b/apps/server/tests/integration/transactions_api_test.rs
@@ -63,6 +63,7 @@ async fn create_test_project(pool: &rustrak::db::DbPool, name: &str) -> rustrak:
         CreateProject {
             name: name.to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/unit/gen_ai_aggregation_test.rs
+++ b/apps/server/tests/unit/gen_ai_aggregation_test.rs
@@ -41,6 +41,7 @@ async fn test_list_spans_filters_by_operation_type() {
         CreateProject {
             name: "gen-ai-op-filter".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -91,6 +92,7 @@ async fn test_llm_calls_by_model_counts_and_orders_by_frequency() {
         CreateProject {
             name: "gen-ai-llm-calls".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -135,6 +137,7 @@ async fn test_llm_calls_by_model_excludes_non_ai_client_spans() {
         CreateProject {
             name: "gen-ai-llm-calls-exclude".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -165,6 +168,7 @@ async fn test_tokens_by_model_sums_total_tokens() {
         CreateProject {
             name: "gen-ai-tokens-model".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -205,6 +209,7 @@ async fn test_tool_calls_by_tool_counts() {
         CreateProject {
             name: "gen-ai-tool-calls".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -248,6 +253,7 @@ async fn test_agent_runs_timeseries_counts_agent_spans() {
         CreateProject {
             name: "gen-ai-runs-ts".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -293,6 +299,7 @@ async fn test_agent_duration_timeseries_computes_avg_and_p95() {
         CreateProject {
             name: "gen-ai-duration-ts".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -340,6 +347,7 @@ async fn test_agent_traces_aggregates_per_trace_id() {
         CreateProject {
             name: "gen-ai-traces".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -411,6 +419,7 @@ async fn test_agent_traces_lists_every_agent_in_a_handoff_trace() {
         CreateProject {
             name: "gen-ai-traces-handoff".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -473,6 +482,7 @@ async fn test_agent_traces_excludes_agent_span_usage_from_token_sum() {
         CreateProject {
             name: "gen-ai-traces-no-double-count".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -555,6 +565,7 @@ async fn test_agent_traces_does_not_double_count_root_span_rollup_totals() {
         CreateProject {
             name: "gen-ai-traces-root-rollup".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -624,6 +635,7 @@ async fn test_agent_traces_reports_zero_tokens_for_root_only_trace() {
         CreateProject {
             name: "gen-ai-traces-root-only".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -670,6 +682,7 @@ async fn test_list_spans_response_includes_gen_ai_fields() {
         CreateProject {
             name: "gen-ai-span-response".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -710,6 +723,7 @@ async fn test_list_spans_response_non_ai_span_has_null_gen_ai_fields() {
         CreateProject {
             name: "gen-ai-span-response-null".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/unit/log_test.rs
+++ b/apps/server/tests/unit/log_test.rs
@@ -64,6 +64,7 @@ mod level2 {
             CreateProject {
                 name: "logs-store".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -134,6 +135,7 @@ mod level2 {
             CreateProject {
                 name: "logs-bad-attrs".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -177,6 +179,7 @@ mod level2 {
             CreateProject {
                 name: "logs-list".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -205,6 +208,7 @@ mod level2 {
             CreateProject {
                 name: "logs-filter".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await

--- a/apps/server/tests/unit/span_test.rs
+++ b/apps/server/tests/unit/span_test.rs
@@ -70,6 +70,7 @@ mod level2 {
             CreateProject {
                 name: "span-standalone".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -137,6 +138,7 @@ mod level2 {
             CreateProject {
                 name: "span-missing-id".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -174,6 +176,7 @@ mod level2 {
             CreateProject {
                 name: "span-missing-trace".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -201,6 +204,7 @@ mod level2 {
             CreateProject {
                 name: "span-missing-start".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -242,6 +246,7 @@ mod level2 {
             CreateProject {
                 name: "span-missing-end".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -269,6 +274,7 @@ mod level2 {
             CreateProject {
                 name: "span-bad-timing".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -299,6 +305,7 @@ mod level2 {
             CreateProject {
                 name: "span-bad-json".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -323,6 +330,7 @@ mod level2 {
             CreateProject {
                 name: "span-data-catchall".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -392,6 +400,7 @@ mod level2 {
             CreateProject {
                 name: "span-svc-filter-op".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -440,6 +449,7 @@ mod level2 {
             CreateProject {
                 name: "span-svc-cross-origin".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -499,6 +509,7 @@ mod level2 {
             CreateProject {
                 name: "span-svc-txn-id".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -537,6 +548,7 @@ mod level2 {
             CreateProject {
                 name: "span-gen-ai".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -589,6 +601,7 @@ mod level2 {
             CreateProject {
                 name: "span-not-ai".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await

--- a/apps/server/tests/unit/span_v2_test.rs
+++ b/apps/server/tests/unit/span_v2_test.rs
@@ -211,6 +211,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-real-fixture".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -249,6 +250,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-op-mapping".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -319,6 +321,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-gen-ai".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -375,6 +378,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-tool".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -415,6 +419,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-partial-batch".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -468,6 +473,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-segment".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -522,6 +528,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-mixed-origin".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -585,6 +592,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-bad-json".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -611,6 +619,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-no-timestamps".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -674,6 +683,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-zero-duration".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -726,6 +736,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-sentry-attrs".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -791,6 +802,7 @@ mod level2 {
             CreateProject {
                 name: "span-v2-child-segment".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await

--- a/apps/server/tests/unit/storage_test.rs
+++ b/apps/server/tests/unit/storage_test.rs
@@ -227,6 +227,7 @@ async fn test_preview_cleanup_counts_old_rows_without_mutating() {
         CreateProject {
             name: "preview-proj".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -295,6 +296,7 @@ async fn test_cleanup_counts_and_deletes_old_logs() {
         CreateProject {
             name: "logs-cleanup".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -332,6 +334,7 @@ async fn test_storage_summary_and_by_project_include_logs() {
         CreateProject {
             name: "logs-storage-count".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -363,6 +366,7 @@ async fn test_cleanup_rejects_nonpositive_retention_window() {
         CreateProject {
             name: "retention-guard".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -405,6 +409,7 @@ async fn test_gc_source_maps_keeps_file_that_is_referenced_at_delete_time() {
         CreateProject {
             name: "gc-recheck".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -443,6 +448,7 @@ async fn test_execute_cleanup_deletes_old_cascades_spans_and_removes_empty_issue
         CreateProject {
             name: "execute-proj".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -488,6 +494,7 @@ async fn test_execute_cleanup_decrements_project_event_counters() {
         CreateProject {
             name: "counter-proj".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -537,6 +544,7 @@ async fn test_execute_cleanup_purges_legacy_transaction_events_without_underflow
         CreateProject {
             name: "tx-underflow".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -599,6 +607,7 @@ async fn test_execute_cleanup_deletes_every_old_row_regardless_of_type() {
         CreateProject {
             name: "delete-all".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -656,6 +665,7 @@ async fn test_execute_cleanup_with_only_events_selected_spares_transactions_and_
         CreateProject {
             name: "filter-events-only".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -702,6 +712,7 @@ async fn test_preview_cleanup_respects_filter_without_mutating() {
         CreateProject {
             name: "preview-filter".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -753,6 +764,7 @@ async fn test_execute_cleanup_with_only_logs_selected_spares_events_and_transact
         CreateProject {
             name: "filter-logs-only".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -805,6 +817,7 @@ async fn test_execute_cleanup_scoped_to_project_spares_other_projects() {
         CreateProject {
             name: "scope-a".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -814,6 +827,7 @@ async fn test_execute_cleanup_scoped_to_project_spares_other_projects() {
         CreateProject {
             name: "scope-b".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -852,6 +866,7 @@ async fn test_storage_event_count_reflects_every_stored_event_row() {
         CreateProject {
             name: "mixed-types".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -886,6 +901,7 @@ async fn test_global_summary_counts_rows_across_data_categories() {
         CreateProject {
             name: "summary-proj".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -916,6 +932,7 @@ async fn test_by_project_breaks_down_counts_per_project_with_isolation() {
         CreateProject {
             name: "proj-a".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -925,6 +942,7 @@ async fn test_by_project_breaks_down_counts_per_project_with_isolation() {
         CreateProject {
             name: "proj-b".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -969,6 +987,7 @@ async fn test_preview_source_map_gc_counts_orphans_without_deleting() {
         CreateProject {
             name: "gc-preview".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await
@@ -1003,6 +1022,7 @@ async fn test_gc_source_maps_removes_orphans_from_db_and_disk() {
         CreateProject {
             name: "gc-proj".to_string(),
             slug: None,
+            platform: None,
         },
     )
     .await

--- a/apps/server/tests/unit/transaction_processor_test.rs
+++ b/apps/server/tests/unit/transaction_processor_test.rs
@@ -129,6 +129,7 @@ mod level2 {
             CreateProject {
                 name: "txn-dedicated".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -183,6 +184,7 @@ mod level2 {
             CreateProject {
                 name: "txn-trace-ctx".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -252,6 +254,7 @@ mod level2 {
             CreateProject {
                 name: "txn-source-url".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -296,6 +299,7 @@ mod level2 {
             CreateProject {
                 name: "txn-source-default".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -341,6 +345,7 @@ mod level2 {
             CreateProject {
                 name: "txn-span-extract".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -427,6 +432,7 @@ mod level2 {
             CreateProject {
                 name: "txn-bad-json".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -469,6 +475,7 @@ mod level2 {
             CreateProject {
                 name: "txn-paging".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -517,6 +524,7 @@ mod level2 {
             CreateProject {
                 name: "txn-test".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -577,6 +585,7 @@ mod level2 {
             CreateProject {
                 name: "txn-trait".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -627,6 +636,7 @@ mod level2 {
             CreateProject {
                 name: "sess-fwd".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -691,6 +701,7 @@ mod level2 {
             CreateProject {
                 name: "txn-filter-op".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -739,6 +750,7 @@ mod level2 {
             CreateProject {
                 name: "txn-filter-name".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -782,6 +794,7 @@ mod level2 {
             CreateProject {
                 name: "txn-list-spans".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -838,6 +851,7 @@ mod level2 {
             CreateProject {
                 name: "txn-stats".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -897,6 +911,7 @@ mod level2 {
             CreateProject {
                 name: "txn-stats-paging".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -942,6 +957,7 @@ mod level2 {
             CreateProject {
                 name: "txn-spans-404".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -966,6 +982,7 @@ mod level2 {
             CreateProject {
                 name: "txn-stats-group".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -1015,6 +1032,7 @@ mod level2 {
             CreateProject {
                 name: "txn-stats-tie".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -1057,6 +1075,7 @@ mod level2 {
             CreateProject {
                 name: "txn-no-group".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -1106,6 +1125,7 @@ mod level2 {
             CreateProject {
                 name: "txn-gen-ai-child".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -1181,6 +1201,7 @@ mod level2 {
             CreateProject {
                 name: "txn-ai-root-span".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -1281,6 +1302,7 @@ mod level2 {
             CreateProject {
                 name: "txn-non-ai-root-no-promote".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -1339,6 +1361,7 @@ mod level2 {
             CreateProject {
                 name: "txn-ai-root-span-no-data".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -1405,6 +1428,7 @@ mod level2 {
             CreateProject {
                 name: "txn-agent-runs-widget".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await
@@ -1454,6 +1478,7 @@ mod level2 {
             CreateProject {
                 name: "txn-not-ai-child".to_string(),
                 slug: None,
+                platform: None,
             },
         )
         .await

--- a/apps/webview-ui/CLAUDE.md
+++ b/apps/webview-ui/CLAUDE.md
@@ -230,11 +230,12 @@ const { theme, setTheme } = useTheme();
 | `/` | Redirect to `/projects` |
 | `/auth/login` | Login form |
 | `/projects` | Projects list with pagination |
+| `/projects/new` | Create project: platform grid + name (full page, not a dialog) |
 | `/projects/[id]` | Project detail + issues list |
 | `/projects/[id]/issues/[issueId]` | Issue detail (redirects to latest event) |
 | `/projects/[id]/issues/[issueId]/events/[eventId]` | Event detail with tabs |
 | `/projects/[id]/settings` | Redirect to `/projects/[id]/settings/general` |
-| `/projects/[id]/settings/general` | Name, platform, danger zone |
+| `/projects/[id]/settings/general` | Name, slug, platform, danger zone |
 | `/projects/[id]/settings/client-keys` | DSN + SDK setup example |
 | `/projects/[id]/settings/alerts` | Alert rules for the project |
 | `/projects/[id]/settings/members` | Project membership + roles |

--- a/apps/webview-ui/src/app/(main)/projects/[id]/settings/client-keys/client-keys-settings.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/settings/client-keys/client-keys-settings.tsx
@@ -60,9 +60,16 @@ export function ClientKeysSettings({ project }: ClientKeysSettingsProps) {
     };
   }, [isDark]);
 
-  // Setup instructions follow the project's own platform. Only when it has
-  // none (never set, no event ingested yet) do we fall back to the browser
-  // SDK, which is the safest generic example for a Sentry-compatible server.
+  // Setup instructions follow the project's own platform. Only a project with
+  // no platform at all (never set, no event ingested yet) gets the generic
+  // browser example.
+  //
+  // A project that HAS a platform but no snippet must never get it: snippet
+  // coverage is partial by design, and the platforms it misses are mostly
+  // console and native ones (unreal, playstation, xbox, native...) where a
+  // `@sentry/browser` example is actively misleading. Sentry does the same,
+  // and more strictly: `sdkDocumentation.tsx` renders an explicit "currently
+  // unavailable" error rather than substituting another platform's snippet.
   const snippet = project.platform
     ? PLATFORM_SNIPPETS[project.platform]
     : undefined;
@@ -70,9 +77,14 @@ export function ClientKeysSettings({ project }: ClientKeysSettingsProps) {
     ? PLATFORM_DOCS[project.platform]
     : undefined;
 
+  // Absent for a selected platform we have no snippet for. The DSN section and
+  // the docs link carry the page on their own, which is what Sentry falls back
+  // to for its deprecated platforms (`deprecatedPlatformInfo.tsx`).
   const codeExample = snippet
     ? renderSnippet(snippet.configure, project.dsn)
-    : `import * as Sentry from "@sentry/browser";
+    : project.platform
+      ? undefined
+      : `import * as Sentry from "@sentry/browser";
 
 Sentry.init({
   dsn: "${project.dsn}",
@@ -152,55 +164,65 @@ Sentry.init({
       )}
 
       <SettingSection
-        title={exampleTitle}
-        description="Your DSN is already filled in below."
+        title={codeExample ? exampleTitle : 'Setup'}
+        description={
+          codeExample
+            ? 'Your DSN is already filled in below.'
+            : 'Point the SDK for this platform at the DSN above.'
+        }
       >
         <div className="mt-3">
-          <div className="mb-2 flex justify-end">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => copy(codeExample, setCopiedCode, 'example')}
-              className="h-6 text-xs"
-            >
-              {copiedCode ? (
-                <>
-                  <Check className="mr-1 size-3 text-primary" />
-                  Copied
-                </>
-              ) : (
-                <>
-                  <Copy className="mr-1 size-3" />
-                  Copy
-                </>
-              )}
-            </Button>
-          </div>
-          <div className="overflow-hidden overflow-x-auto rounded-lg border">
-            {Highlighter && highlighterStyle ? (
-              <Highlighter
-                language={codeLanguage}
-                style={highlighterStyle}
-                customStyle={{
-                  margin: 0,
-                  padding: '1rem',
-                  fontSize: '0.75rem',
-                  background: isDark ? '#1e1e1e' : '#ffffff',
-                }}
-              >
-                {codeExample}
-              </Highlighter>
-            ) : highlighterFailed ? (
-              <pre className="overflow-x-auto p-4 font-mono text-xs">
-                {codeExample}
-              </pre>
-            ) : (
-              <div className="flex h-24 animate-pulse items-center justify-center bg-muted p-4">
-                <Loader2 className="size-4 animate-spin text-muted-foreground" />
+          {codeExample && (
+            <>
+              <div className="mb-2 flex justify-end">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => copy(codeExample, setCopiedCode, 'example')}
+                  className="h-6 text-xs"
+                >
+                  {copiedCode ? (
+                    <>
+                      <Check className="mr-1 size-3 text-primary" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="mr-1 size-3" />
+                      Copy
+                    </>
+                  )}
+                </Button>
               </div>
-            )}
-          </div>
-          <p className="mt-3 text-xs text-muted-foreground">
+              <div className="overflow-hidden overflow-x-auto rounded-lg border">
+                {Highlighter && highlighterStyle ? (
+                  <Highlighter
+                    language={codeLanguage}
+                    style={highlighterStyle}
+                    customStyle={{
+                      margin: 0,
+                      padding: '1rem',
+                      fontSize: '0.75rem',
+                      background: isDark ? '#1e1e1e' : '#ffffff',
+                    }}
+                  >
+                    {codeExample}
+                  </Highlighter>
+                ) : highlighterFailed ? (
+                  <pre className="overflow-x-auto p-4 font-mono text-xs">
+                    {codeExample}
+                  </pre>
+                ) : (
+                  <div className="flex h-24 animate-pulse items-center justify-center bg-muted p-4">
+                    <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+          <p
+            className={`text-xs text-muted-foreground${codeExample ? ' mt-3' : ''}`}
+          >
             This server is compatible with all official Sentry SDKs. Check the{' '}
             <a
               href={docsUrl ?? 'https://docs.sentry.io/platforms/'}
@@ -212,7 +234,9 @@ Sentry.init({
                 ? `${platformLabel(project.platform ?? '')} documentation`
                 : 'Sentry documentation'}
             </a>{' '}
-            for the full setup, including options this example leaves out.
+            {codeExample
+              ? 'for the full setup, including options this example leaves out.'
+              : 'for the setup steps for this platform.'}
           </p>
         </div>
       </SettingSection>

--- a/apps/webview-ui/src/app/(main)/projects/[id]/settings/client-keys/client-keys-settings.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/settings/client-keys/client-keys-settings.tsx
@@ -7,6 +7,12 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { copyToClipboard } from '@/lib/clipboard';
+import {
+  PLATFORM_DOCS,
+  PLATFORM_SNIPPETS,
+  renderSnippet,
+} from '@/lib/platform-snippets';
+import { platformLabel } from '@/lib/platforms';
 import { SettingSection } from '../setting-row';
 
 interface ClientKeysSettingsProps {
@@ -20,6 +26,7 @@ export function ClientKeysSettings({ project }: ClientKeysSettingsProps) {
   const { resolvedTheme } = useTheme();
   const [copiedDsn, setCopiedDsn] = useState(false);
   const [copiedCode, setCopiedCode] = useState(false);
+  const [copiedInstall, setCopiedInstall] = useState(false);
   const [Highlighter, setHighlighter] = useState<HighlighterComponent | null>(
     null,
   );
@@ -53,11 +60,27 @@ export function ClientKeysSettings({ project }: ClientKeysSettingsProps) {
     };
   }, [isDark]);
 
-  const codeExample = `import * as Sentry from "@sentry/browser";
+  // Setup instructions follow the project's own platform. Only when it has
+  // none (never set, no event ingested yet) do we fall back to the browser
+  // SDK, which is the safest generic example for a Sentry-compatible server.
+  const snippet = project.platform
+    ? PLATFORM_SNIPPETS[project.platform]
+    : undefined;
+  const docsUrl = project.platform
+    ? PLATFORM_DOCS[project.platform]
+    : undefined;
+
+  const codeExample = snippet
+    ? renderSnippet(snippet.configure, project.dsn)
+    : `import * as Sentry from "@sentry/browser";
 
 Sentry.init({
   dsn: "${project.dsn}",
 });`;
+  const codeLanguage = snippet?.language ?? 'javascript';
+  const exampleTitle = snippet
+    ? `Example (${platformLabel(project.platform ?? '')})`
+    : 'Example (JavaScript)';
 
   const copy = async (
     value: string,
@@ -100,9 +123,37 @@ Sentry.init({
         </div>
       </SettingSection>
 
+      {snippet?.install && (
+        <SettingSection
+          title="Install"
+          description="Add the SDK to your project."
+        >
+          <div className="mt-3 flex items-center gap-2 rounded-lg border bg-muted p-3">
+            <code className="flex-1 overflow-x-auto font-mono text-xs">
+              {snippet.install}
+            </code>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                copy(snippet.install ?? '', setCopiedInstall, 'command')
+              }
+              className="shrink-0"
+              aria-label="Copy install command"
+            >
+              {copiedInstall ? (
+                <Check className="size-4 text-primary" />
+              ) : (
+                <Copy className="size-4" />
+              )}
+            </Button>
+          </div>
+        </SettingSection>
+      )}
+
       <SettingSection
-        title="Example (JavaScript)"
-        description="Minimal setup for a browser app. Every SDK takes this same DSN, see the Sentry docs for yours."
+        title={exampleTitle}
+        description="Your DSN is already filled in below."
       >
         <div className="mt-3">
           <div className="mb-2 flex justify-end">
@@ -128,7 +179,7 @@ Sentry.init({
           <div className="overflow-hidden overflow-x-auto rounded-lg border">
             {Highlighter && highlighterStyle ? (
               <Highlighter
-                language="javascript"
+                language={codeLanguage}
                 style={highlighterStyle}
                 customStyle={{
                   margin: 0,
@@ -152,14 +203,16 @@ Sentry.init({
           <p className="mt-3 text-xs text-muted-foreground">
             This server is compatible with all official Sentry SDKs. Check the{' '}
             <a
-              href="https://docs.sentry.io/platforms/"
+              href={docsUrl ?? 'https://docs.sentry.io/platforms/'}
               target="_blank"
               rel="noopener noreferrer"
               className="text-primary hover:underline"
             >
-              Sentry documentation
+              {docsUrl
+                ? `${platformLabel(project.platform ?? '')} documentation`
+                : 'Sentry documentation'}
             </a>{' '}
-            for platform-specific setup instructions.
+            for the full setup, including options this example leaves out.
           </p>
         </div>
       </SettingSection>

--- a/apps/webview-ui/src/app/(main)/projects/[id]/settings/general/general-settings-form.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/settings/general/general-settings-form.tsx
@@ -29,9 +29,11 @@ export function GeneralSettingsForm({ project }: GeneralSettingsFormProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [name, setName] = useState(project.name);
+  const [slug, setSlug] = useState(project.slug);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
   const hasNameChanges = name !== project.name;
+  const hasSlugChanges = slug !== project.slug;
 
   const handleSaveName = () => {
     if (!hasNameChanges || !name.trim()) return;
@@ -49,6 +51,26 @@ export function GeneralSettingsForm({ project }: GeneralSettingsFormProps) {
         const message =
           err instanceof Error ? err.message : 'Failed to update project';
         toast.error('Failed to update project', { description: message });
+      }
+    });
+  };
+
+  const handleSaveSlug = () => {
+    if (!hasSlugChanges || !slug.trim()) return;
+
+    startTransition(async () => {
+      try {
+        const updated = await updateProject(project.id, { slug: slug.trim() });
+        // The server slugifies the input, so echo back what it actually
+        // stored rather than the raw text: typing "My API" must leave the
+        // field showing "my-api", not a value that was never persisted.
+        setSlug(updated.slug);
+        toast.success('Slug updated');
+        router.refresh();
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to update slug';
+        toast.error('Failed to update slug', { description: message });
       }
     });
   };
@@ -103,6 +125,29 @@ export function GeneralSettingsForm({ project }: GeneralSettingsFormProps) {
             <Button
               onClick={handleSaveName}
               disabled={isPending || !hasNameChanges || !name.trim()}
+              size="sm"
+            >
+              {isPending ? <Loader2 className="size-4 animate-spin" /> : 'Save'}
+            </Button>
+          </div>
+        </SettingRow>
+
+        <SettingRow
+          title="Slug"
+          description="Short identifier for this project. Your DSN and dashboard links use the numeric project ID, so renaming this will not break anything already sending events."
+          htmlFor="project-slug"
+        >
+          <div className="flex items-center gap-2">
+            <Input
+              id="project-slug"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              placeholder="project-slug"
+              disabled={isPending}
+            />
+            <Button
+              onClick={handleSaveSlug}
+              disabled={isPending || !hasSlugChanges || !slug.trim()}
               size="sm"
             >
               {isPending ? <Loader2 className="size-4 animate-spin" /> : 'Save'}

--- a/apps/webview-ui/src/app/(main)/projects/new/create-project-form.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/new/create-project-form.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { PlatformIcon } from 'platformicons';
+import { useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+import { createProject } from '@/actions/projects';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { platformLabel } from '@/lib/platforms';
+import { PlatformGrid } from './platform-grid';
+
+const PROJECT_NAME_MIN_LENGTH = 2;
+const PROJECT_NAME_MAX_LENGTH = 100;
+
+const createProjectFormSchema = z.object({
+  platform: z.string().min(1, 'Choose a platform to continue'),
+  name: z
+    .string()
+    .trim()
+    .min(
+      PROJECT_NAME_MIN_LENGTH,
+      `Name must be at least ${PROJECT_NAME_MIN_LENGTH} characters`,
+    )
+    .max(
+      PROJECT_NAME_MAX_LENGTH,
+      `Name must be at most ${PROJECT_NAME_MAX_LENGTH} characters`,
+    ),
+});
+
+type CreateProjectFormData = z.infer<typeof createProjectFormSchema>;
+
+interface CreateProjectFormProps {
+  /**
+   * Names already in use, so the auto-filled suggestion can avoid one.
+   *
+   * Best-effort only: it is one page of projects, not the whole set, and
+   * another tab can take a name in between. The server is the real authority
+   * and answers with a 409, which is surfaced as a toast.
+   */
+  existingNames: string[];
+}
+
+/**
+ * Suggests a project name for a platform, avoiding names already taken.
+ *
+ * Sentry pre-fills the name field with the raw platform id, which works there
+ * because `name` is unconstrained and only `slug` is de-duplicated. Rustrak
+ * has a UNIQUE constraint on `projects.name`, so a second Next.js project
+ * would collide on the most common path there is. Suffix instead.
+ */
+function suggestName(platformId: string, taken: Set<string>): string {
+  if (!taken.has(platformId)) return platformId;
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${platformId}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return platformId;
+}
+
+export function CreateProjectForm({ existingNames }: CreateProjectFormProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<CreateProjectFormData>({
+    resolver: zodResolver(createProjectFormSchema),
+    defaultValues: { platform: '', name: '' },
+  });
+
+  const platform = form.watch('platform');
+  const taken = new Set(existingNames);
+
+  const handlePlatformChange = (platformId: string) => {
+    form.setValue('platform', platformId, { shouldValidate: true });
+
+    // Only auto-fill while the user has not taken over the field, matching
+    // Sentry's `hasUserModifiedProjectName` guard. `shouldDirty: false` is
+    // what makes `dirtyFields.name` mean "the user typed", not "we filled it".
+    if (!form.formState.dirtyFields.name) {
+      form.setValue('name', suggestName(platformId, taken), {
+        shouldDirty: false,
+        shouldValidate: true,
+      });
+    }
+  };
+
+  const onSubmit = (data: CreateProjectFormData) => {
+    startTransition(async () => {
+      try {
+        const project = await createProject({
+          name: data.name,
+          platform: data.platform,
+        });
+        // Straight into Client Keys: the DSN and the platform's setup snippet
+        // are the only thing left to do, and that page owns them.
+        router.push(`/projects/${project.id}/settings/client-keys`);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to create project';
+        toast.error('Failed to create project', { description: message });
+      }
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start"
+      >
+        <FormField
+          control={form.control}
+          name="platform"
+          render={({ field }) => (
+            <FormItem className="min-w-0">
+              <FormLabel className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+                Platform
+              </FormLabel>
+              <FormControl>
+                <PlatformGrid
+                  value={field.value || null}
+                  onValueChange={handlePlatformChange}
+                  disabled={isPending}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <aside className="rounded-xl border bg-card p-5 lg:sticky lg:top-6">
+          <div className="flex items-center gap-3 border-b pb-4">
+            {platform ? (
+              <>
+                <PlatformIcon platform={platform} size={32} />
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-bold">
+                    {platformLabel(platform)}
+                  </p>
+                  <p className="truncate font-mono text-xs text-muted-foreground">
+                    {platform}
+                  </p>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="size-8 shrink-0 rounded-md border border-dashed" />
+                <p className="text-sm text-muted-foreground">
+                  No platform selected
+                </p>
+              </>
+            )}
+          </div>
+
+          <div className="pt-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+                    Project name
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="my-application"
+                      autoComplete="off"
+                      disabled={isPending}
+                      maxLength={PROJECT_NAME_MAX_LENGTH}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <Button type="submit" disabled={isPending} className="mt-5 w-full">
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Creating...
+              </>
+            ) : (
+              'Create Project'
+            )}
+          </Button>
+
+          <p className="mt-3 text-xs text-muted-foreground">
+            You will get your DSN and setup snippet next.
+          </p>
+        </aside>
+      </form>
+    </Form>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/new/create-project-form.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/new/create-project-form.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Pencil, RotateCcw } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { PlatformIcon } from 'platformicons';
-import { useTransition } from 'react';
+import { useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { platformLabel } from '@/lib/platforms';
+import { cn } from '@/lib/utils';
 import { PlatformGrid } from './platform-grid';
 
 const PROJECT_NAME_MIN_LENGTH = 2;
@@ -38,7 +39,30 @@ const createProjectFormSchema = z.object({
       PROJECT_NAME_MAX_LENGTH,
       `Name must be at most ${PROJECT_NAME_MAX_LENGTH} characters`,
     ),
+  slug: z
+    .string()
+    .trim()
+    .min(1, 'Slug cannot be empty')
+    .regex(
+      /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/,
+      'Use lowercase letters, digits and dashes',
+    ),
 });
+
+/**
+ * Live preview slugifier, ported from Sentry's `utils/slugify`.
+ *
+ * Deliberately does NOT trim leading or trailing hyphens: doing so would make
+ * it impossible to type "my-app", since the hyphen would vanish the moment it
+ * is typed. The server slugifies again and is the real authority.
+ */
+function slugifyPreview(value: string): string {
+  return value
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9_\s-]/g, '')
+    .replace(/[-\s]+/g, '-');
+}
 
 type CreateProjectFormData = z.infer<typeof createProjectFormSchema>;
 
@@ -82,11 +106,25 @@ export function CreateProjectForm({ existingNames }: CreateProjectFormProps) {
 
   const form = useForm<CreateProjectFormData>({
     resolver: zodResolver(createProjectFormSchema),
-    defaultValues: { platform: '', name: '' },
+    defaultValues: { platform: '', name: '', slug: '' },
   });
 
   const platform = form.watch('platform');
   const taken = new Set(existingNames);
+
+  // The slug is generated from the name until the user explicitly takes it
+  // over with the Edit button. An explicit mode rather than a dirty-field
+  // heuristic, because the field is what the button controls: read-only while
+  // it mirrors the name, editable once it stops.
+  const [slugMode, setSlugMode] = useState<'auto' | 'manual'>('auto');
+
+  // In a handler rather than an effect: this is a reaction to the user typing,
+  // not to a render.
+  const syncSlugFromName = (name: string) => {
+    if (slugMode === 'auto') {
+      form.setValue('slug', slugifyPreview(name), { shouldValidate: true });
+    }
+  };
 
   const handlePlatformChange = (platformId: string) => {
     form.setValue('platform', platformId, { shouldValidate: true });
@@ -95,10 +133,12 @@ export function CreateProjectForm({ existingNames }: CreateProjectFormProps) {
     // Sentry's `hasUserModifiedProjectName` guard. `shouldDirty: false` is
     // what makes `dirtyFields.name` mean "the user typed", not "we filled it".
     if (!form.formState.dirtyFields.name) {
-      form.setValue('name', suggestName(platformId, taken), {
+      const suggested = suggestName(platformId, taken);
+      form.setValue('name', suggested, {
         shouldDirty: false,
         shouldValidate: true,
       });
+      syncSlugFromName(suggested);
     }
   };
 
@@ -108,6 +148,10 @@ export function CreateProjectForm({ existingNames }: CreateProjectFormProps) {
         const project = await createProject({
           name: data.name,
           platform: data.platform,
+          // Only sent when the user took the field over. An auto slug is
+          // derived, and the server is allowed to de-duplicate a derived slug
+          // silently. Sending the preview would turn that into a 409.
+          ...(slugMode === 'manual' ? { slug: data.slug } : {}),
         });
         // Straight into Client Keys: the DSN and the platform's setup snippet
         // are the only thing left to do, and that page owns them.
@@ -115,16 +159,47 @@ export function CreateProjectForm({ existingNames }: CreateProjectFormProps) {
       } catch (err) {
         const message =
           err instanceof Error ? err.message : 'Failed to create project';
+
+        // A taken name or slug belongs on its own field, not in a toast the
+        // user has to translate back into an edit. Matched on the message
+        // because a Server Action carries only a string across the boundary,
+        // and in production not even that: #204 replaces this with a real
+        // error code, and this check goes with it.
+        if (message.includes('already exists')) {
+          if (message.includes("slug '")) {
+            setSlugMode('manual'); // so the field they must fix is editable
+            form.setError('slug', { type: 'server', message });
+            return;
+          }
+          if (message.includes("name '")) {
+            form.setError('name', { type: 'server', message });
+            return;
+          }
+        }
+
         toast.error('Failed to create project', { description: message });
       }
     });
   };
 
+  // Rendered in two places (the aside on desktop, the fixed bar on mobile), so
+  // it lives here rather than being written twice.
+  const submitLabel = isPending ? (
+    <>
+      <Loader2 className="mr-2 size-4 animate-spin" />
+      Creating...
+    </>
+  ) : (
+    'Create Project'
+  );
+
   return (
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start"
+        // Bottom padding clears the fixed mobile bar, which would otherwise
+        // cover the last field.
+        className="grid gap-6 pb-24 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start lg:pb-0"
       >
         <FormField
           control={form.control}
@@ -186,6 +261,10 @@ export function CreateProjectForm({ existingNames }: CreateProjectFormProps) {
                       disabled={isPending}
                       maxLength={PROJECT_NAME_MAX_LENGTH}
                       {...field}
+                      onChange={(e) => {
+                        field.onChange(e);
+                        syncSlugFromName(e.target.value);
+                      }}
                     />
                   </FormControl>
                   <FormMessage />
@@ -194,21 +273,134 @@ export function CreateProjectForm({ existingNames }: CreateProjectFormProps) {
             />
           </div>
 
-          <Button type="submit" disabled={isPending} className="mt-5 w-full">
-            {isPending ? (
-              <>
-                <Loader2 className="mr-2 size-4 animate-spin" />
-                Creating...
-              </>
-            ) : (
-              'Create Project'
-            )}
+          <div className="pt-4">
+            <FormField
+              control={form.control}
+              name="slug"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel className="text-xs font-bold uppercase tracking-widest text-muted-foreground">
+                    Slug
+                  </FormLabel>
+                  <div className="flex items-center gap-2">
+                    <FormControl>
+                      <Input
+                        placeholder="my-application"
+                        autoComplete="off"
+                        readOnly={slugMode === 'auto'}
+                        aria-readonly={slugMode === 'auto'}
+                        disabled={isPending}
+                        className={cn(
+                          'font-mono',
+                          slugMode === 'auto' &&
+                            'bg-muted text-muted-foreground',
+                        )}
+                        {...field}
+                        onChange={(e) =>
+                          field.onChange(slugifyPreview(e.target.value))
+                        }
+                      />
+                    </FormControl>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      disabled={isPending}
+                      aria-label={
+                        slugMode === 'auto'
+                          ? 'Edit slug'
+                          : 'Reset slug to follow the name'
+                      }
+                      title={
+                        slugMode === 'auto'
+                          ? 'Edit slug'
+                          : 'Reset slug to follow the name'
+                      }
+                      onClick={() => {
+                        if (slugMode === 'auto') {
+                          setSlugMode('manual');
+                          return;
+                        }
+                        // Back to auto: re-derive immediately, otherwise the
+                        // field would keep a stale hand-typed value until the
+                        // next keystroke in the name.
+                        setSlugMode('auto');
+                        form.setValue(
+                          'slug',
+                          slugifyPreview(form.getValues('name')),
+                          { shouldValidate: true },
+                        );
+                      }}
+                      className="shrink-0"
+                    >
+                      {slugMode === 'auto' ? (
+                        <Pencil className="size-4" />
+                      ) : (
+                        <RotateCcw className="size-4" />
+                      )}
+                    </Button>
+                  </div>
+                  {/* One line, not two: FormMessage falls back to its
+                      children when the field is valid, so the hint and the
+                      error occupy the same slot and the panel never reflows. */}
+                  <FormMessage
+                    className={cn(
+                      'mt-1.5 text-xs',
+                      !fieldState.error && 'text-muted-foreground',
+                    )}
+                  >
+                    {slugMode === 'auto'
+                      ? 'Generated from the name. Edit it to choose your own.'
+                      : 'Yours to choose. A slug already in use is rejected.'}
+                  </FormMessage>
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* Hidden on mobile: the fixed bar below owns the action there, and
+              two live submit buttons would be one too many. */}
+          <Button
+            type="submit"
+            disabled={isPending}
+            className="mt-5 hidden w-full lg:flex"
+          >
+            {submitLabel}
           </Button>
 
-          <p className="mt-3 text-xs text-muted-foreground">
+          <p className="mt-3 hidden text-xs text-muted-foreground lg:block">
             You will get your DSN and setup snippet next.
           </p>
         </aside>
+
+        {/* Mobile action bar. The platform grid is tall, so a button sitting
+            below it is off-screen for most of the time the user spends on this
+            page. Pinning it also keeps the current selection visible while
+            scrolling the list. */}
+        <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 px-4 py-3 backdrop-blur lg:hidden">
+          <div className="mx-auto flex max-w-6xl items-center gap-3">
+            {platform ? (
+              <>
+                <PlatformIcon platform={platform} size={24} />
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                  {platformLabel(platform)}
+                </span>
+              </>
+            ) : (
+              <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+                Pick a platform
+              </span>
+            )}
+            <Button
+              type="submit"
+              disabled={isPending}
+              className="shrink-0"
+              size="sm"
+            >
+              {submitLabel}
+            </Button>
+          </div>
+        </div>
       </form>
     </Form>
   );

--- a/apps/webview-ui/src/app/(main)/projects/new/create-project-form.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/new/create-project-form.tsx
@@ -70,6 +70,12 @@ function suggestName(platformId: string, taken: Set<string>): string {
   return platformId;
 }
 
+/**
+ * Platform grid plus name field, submitting to `createProject`.
+ *
+ * `existingNames` only feeds the suggested default name; the server still has
+ * the final say on collisions.
+ */
 export function CreateProjectForm({ existingNames }: CreateProjectFormProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();

--- a/apps/webview-ui/src/app/(main)/projects/new/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/new/page.tsx
@@ -1,0 +1,49 @@
+import { ArrowLeft } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getProjects } from '@/actions/projects';
+import { CreateProjectForm } from './create-project-form';
+
+export const metadata: Metadata = {
+  title: 'New Project | Rustrak',
+  description: 'Create a new Rustrak project',
+};
+
+export default async function NewProjectPage() {
+  // Only used to suggest a free default name. `projects.name` is UNIQUE, so
+  // the raw platform id Sentry pre-fills would collide on a second Next.js
+  // project. One page is enough for a suggestion; the server still has the
+  // final say and returns a 409 on a genuine collision.
+  let existingNames: string[] = [];
+  try {
+    const { items } = await getProjects({ page: 1, per_page: 100 });
+    existingNames = items.map((p) => p.name);
+  } catch {
+    // A failed lookup only costs a less clever default name, so it must not
+    // block project creation.
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-6 md:px-8 md:py-8">
+      <Link
+        href="/projects"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="size-4" />
+        Back to projects
+      </Link>
+
+      <div className="mt-4 mb-6">
+        <h1 className="text-xl font-extrabold tracking-tight md:text-2xl">
+          Create a new project
+        </h1>
+        <p className="mt-1 text-muted-foreground">
+          Pick the platform you want to monitor. You will get the DSN and a
+          setup snippet right after.
+        </p>
+      </div>
+
+      <CreateProjectForm existingNames={existingNames} />
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/new/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/new/page.tsx
@@ -9,6 +9,11 @@ export const metadata: Metadata = {
   description: 'Create a new Rustrak project',
 };
 
+/**
+ * Create-project page: platform picker plus name, in one form.
+ *
+ * A full page rather than a dialog, matching Sentry's own `/projects/new/`.
+ */
 export default async function NewProjectPage() {
   // Only used to suggest a free default name. `projects.name` is UNIQUE, so
   // the raw platform id Sentry pre-fills would collide on a second Next.js

--- a/apps/webview-ui/src/app/(main)/projects/new/platform-grid.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/new/platform-grid.tsx
@@ -12,6 +12,9 @@ import {
 } from '@/lib/platforms';
 import { cn } from '@/lib/utils';
 
+/** Sentry's generic escape hatch, a real platform id the server accepts. */
+const OTHER_PLATFORM_ID = 'other';
+
 interface PlatformGridProps {
   value: string | null;
   onValueChange: (platformId: string) => void;
@@ -35,12 +38,21 @@ export function PlatformGrid({
   // A non-empty query deliberately searches every platform, ignoring the
   // active tab. Sentry does the same: someone who types "django" while Browser
   // is open should find it rather than be told there are no results.
+  //
+  // `other` is pulled out of the list and pinned as the first card in every
+  // tab: it is the escape hatch, and burying it alphabetically under "O" in a
+  // 127-entry grid hides the one option that always applies.
   const platforms: Platform[] = useMemo(
-    () => (query.trim() ? searchPlatforms(query) : categoryPlatforms(category)),
+    () =>
+      (query.trim()
+        ? searchPlatforms(query)
+        : categoryPlatforms(category)
+      ).filter((p) => p.id !== OTHER_PLATFORM_ID),
     [query, category],
   );
 
   const isSearching = query.trim().length > 0;
+  const otherSelected = value === OTHER_PLATFORM_ID;
 
   return (
     <div className="overflow-hidden rounded-xl border bg-card">
@@ -87,14 +99,68 @@ export function PlatformGrid({
           ))}
         </div>
       </div>
-
       {platforms.length === 0 ? (
-        <p className="px-4 py-16 text-center text-sm text-muted-foreground">
-          Nothing matches &quot;{query.trim()}&quot;.
-        </p>
+        // Sentry's own empty state points at "Other" rather than leaving the
+        // user stuck, since `other` is a real, storable platform id and the
+        // picker otherwise requires a choice.
+        <div className="px-4 py-16 text-center">
+          <p className="text-sm font-medium">
+            No SDK for &quot;{query.trim()}&quot; yet
+          </p>
+          <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+            Try a more generic SDK such as JavaScript, Python or Node, or create
+            a generic project with{' '}
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => {
+                setQuery('');
+                onValueChange(OTHER_PLATFORM_ID);
+              }}
+              className="font-medium text-primary underline-offset-4 hover:underline disabled:opacity-50"
+            >
+              Other
+            </button>
+            .
+          </p>
+        </div>
       ) : (
-        <div className="max-h-[28rem] overflow-y-auto p-3">
+        // The inner scroll area only earns its keep next to the sticky aside on
+        // large screens. On a phone it nests a scroll inside the page scroll,
+        // which fights the thumb; there the grid just flows, which is what
+        // Sentry's own picker does at every width.
+        <div className="overflow-visible p-3 lg:max-h-[28rem] lg:overflow-y-auto">
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-4">
+            {/* Full row rather than a tile: the copy has to be readable to do
+                its job, and a grid cell truncates it. Spanning also stops it
+                reading as "just another platform", which it is not. */}
+            <button
+              type="button"
+              disabled={disabled}
+              aria-pressed={otherSelected}
+              onClick={() => onValueChange(OTHER_PLATFORM_ID)}
+              className={cn(
+                'col-span-full flex items-center gap-3 rounded-lg border border-dashed p-3 text-left transition-all disabled:opacity-50',
+                otherSelected
+                  ? 'border-primary bg-primary/10 ring-1 ring-primary'
+                  : 'border-muted-foreground/30 hover:bg-accent',
+              )}
+            >
+              <PlatformIcon platform={OTHER_PLATFORM_ID} size={28} />
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-medium">
+                  Other platform
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  Your platform is not on the list, or you would rather choose
+                  later. Works with any Sentry SDK.
+                </span>
+              </span>
+              {otherSelected && (
+                <Check className="size-4 shrink-0 text-primary" />
+              )}
+            </button>
+
             {platforms.map((p) => {
               const selected = value === p.id;
               return (
@@ -124,12 +190,12 @@ export function PlatformGrid({
           </div>
         </div>
       )}
-
       <div className="border-t px-4 py-2 text-xs text-muted-foreground">
         {isSearching
           ? `${platforms.length} matching ${platforms.length === 1 ? 'platform' : 'platforms'}`
           : `${platforms.length} platforms · search to look across every category`}
       </div>
+      ;
     </div>
   );
 }

--- a/apps/webview-ui/src/app/(main)/projects/new/platform-grid.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/new/platform-grid.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { Check, Search } from 'lucide-react';
+import { PlatformIcon } from 'platformicons';
+import { useMemo, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import {
+  categoryPlatforms,
+  PLATFORM_CATEGORIES,
+  type Platform,
+  searchPlatforms,
+} from '@/lib/platforms';
+import { cn } from '@/lib/utils';
+
+interface PlatformGridProps {
+  value: string | null;
+  onValueChange: (platformId: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Category tabs + search + icon grid, mirroring Sentry's own create-project
+ * picker rather than the searchable combobox used in project settings. The
+ * combobox is right for changing one field in a settings form; picking a
+ * platform is the primary act of this page, so it gets the room.
+ */
+export function PlatformGrid({
+  value,
+  onValueChange,
+  disabled,
+}: PlatformGridProps) {
+  const [category, setCategory] = useState('popular');
+  const [query, setQuery] = useState('');
+
+  // A non-empty query deliberately searches every platform, ignoring the
+  // active tab. Sentry does the same: someone who types "django" while Browser
+  // is open should find it rather than be told there are no results.
+  const platforms: Platform[] = useMemo(
+    () => (query.trim() ? searchPlatforms(query) : categoryPlatforms(category)),
+    [query, category],
+  );
+
+  const isSearching = query.trim().length > 0;
+
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card">
+      <div className="flex flex-col gap-3 border-b p-3 sm:flex-row-reverse sm:items-center">
+        <div className="relative sm:w-56 sm:shrink-0">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search all platforms"
+            aria-label="Search platforms"
+            disabled={disabled}
+            className="h-9 pl-9"
+          />
+        </div>
+
+        <div
+          className="-mx-1 flex flex-1 gap-1 overflow-x-auto px-1"
+          role="tablist"
+          aria-label="Platform categories"
+        >
+          {PLATFORM_CATEGORIES.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              role="tab"
+              aria-selected={!isSearching && category === c.id}
+              disabled={disabled}
+              onClick={() => {
+                setCategory(c.id);
+                // Changing tab clears the query, otherwise the tab appears to
+                // do nothing while a search is active.
+                setQuery('');
+              }}
+              className={cn(
+                'shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50',
+                !isSearching && category === c.id
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+              )}
+            >
+              {c.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {platforms.length === 0 ? (
+        <p className="px-4 py-16 text-center text-sm text-muted-foreground">
+          Nothing matches &quot;{query.trim()}&quot;.
+        </p>
+      ) : (
+        <div className="max-h-[28rem] overflow-y-auto p-3">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-4">
+            {platforms.map((p) => {
+              const selected = value === p.id;
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  disabled={disabled}
+                  aria-pressed={selected}
+                  onClick={() => onValueChange(p.id)}
+                  className={cn(
+                    'group relative flex items-center gap-3 rounded-lg border p-3 text-left transition-all disabled:opacity-50',
+                    selected
+                      ? 'border-primary bg-primary/10 ring-1 ring-primary'
+                      : 'border-transparent bg-muted/40 hover:bg-accent',
+                  )}
+                >
+                  <PlatformIcon platform={p.id} size={28} />
+                  <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                    {p.name}
+                  </span>
+                  {selected && (
+                    <Check className="size-4 shrink-0 text-primary" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className="border-t px-4 py-2 text-xs text-muted-foreground">
+        {isSearching
+          ? `${platforms.length} matching ${platforms.length === 1 ? 'platform' : 'platforms'}`
+          : `${platforms.length} platforms · search to look across every category`}
+      </div>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/projects-header.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/projects-header.tsx
@@ -1,75 +1,19 @@
-'use client';
-
 import { Plus } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import { useState, useTransition } from 'react';
-import { toast } from 'sonner';
-import { createProject } from '@/actions/projects';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 
-const PROJECT_NAME_MIN_LENGTH = 2;
-const PROJECT_NAME_MAX_LENGTH = 100;
-
+/**
+ * Creation lives at `/projects/new`, not in a dialog.
+ *
+ * Real Sentry uses a full page for this too: `/projects/new/` renders one form
+ * with numbered sections (platform, alert frequency, name + team). A dialog
+ * has no room for the platform grid, and the flow continues into an SDK setup
+ * page afterwards, which a modal cannot lead into.
+ *
+ * No longer a Client Component: with the form moved out, there is no state
+ * left here.
+ */
 export function ProjectsHeader() {
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
-  const [isCreateOpen, setIsCreateOpen] = useState(false);
-  const [newProjectName, setNewProjectName] = useState('');
-  const [validationError, setValidationError] = useState<string | null>(null);
-
-  const trimmedName = newProjectName.trim();
-  const isValidLength =
-    trimmedName.length >= PROJECT_NAME_MIN_LENGTH &&
-    trimmedName.length <= PROJECT_NAME_MAX_LENGTH;
-
-  const handleNameChange = (value: string) => {
-    setNewProjectName(value);
-    setValidationError(null);
-
-    const trimmed = value.trim();
-    if (trimmed.length > 0 && trimmed.length < PROJECT_NAME_MIN_LENGTH) {
-      setValidationError(
-        `Name must be at least ${PROJECT_NAME_MIN_LENGTH} characters`,
-      );
-    } else if (trimmed.length > PROJECT_NAME_MAX_LENGTH) {
-      setValidationError(
-        `Name must be at most ${PROJECT_NAME_MAX_LENGTH} characters`,
-      );
-    }
-  };
-
-  const handleCreate = () => {
-    if (!trimmedName || !isValidLength) return;
-
-    startTransition(async () => {
-      try {
-        await createProject({ name: trimmedName });
-        toast.success('Project created', {
-          description: `"${trimmedName}" has been created successfully.`,
-        });
-        setNewProjectName('');
-        setValidationError(null);
-        setIsCreateOpen(false);
-        router.refresh();
-      } catch (err) {
-        const message =
-          err instanceof Error ? err.message : 'Failed to create project';
-        toast.error('Failed to create project', { description: message });
-      }
-    });
-  };
-
   return (
     <div className="flex items-start justify-between gap-4">
       <div>
@@ -81,58 +25,10 @@ export function ProjectsHeader() {
         </p>
       </div>
 
-      <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
-        <DialogTrigger render={<Button />}>
-          <Plus className="mr-2 size-4" />
-          New Project
-        </DialogTrigger>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Project</DialogTitle>
-            <DialogDescription>
-              Create a new project to start tracking errors.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4 py-4">
-            <div className="space-y-2">
-              <Label htmlFor="name">Project Name</Label>
-              <Input
-                id="name"
-                placeholder="My Application"
-                value={newProjectName}
-                onChange={(e) => handleNameChange(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
-                maxLength={PROJECT_NAME_MAX_LENGTH + 10}
-                aria-invalid={!!validationError}
-                aria-describedby={validationError ? 'name-error' : undefined}
-              />
-              {validationError && (
-                <p id="name-error" className="text-sm text-destructive">
-                  {validationError}
-                </p>
-              )}
-              <p className="text-xs text-muted-foreground">
-                {trimmedName.length}/{PROJECT_NAME_MAX_LENGTH} characters
-              </p>
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsCreateOpen(false)}
-              disabled={isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={handleCreate}
-              disabled={isPending || !trimmedName || !isValidLength}
-            >
-              {isPending ? 'Creating...' : 'Create'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <Button nativeButton={false} render={<Link href="/projects/new" />}>
+        <Plus className="mr-2 size-4" />
+        New Project
+      </Button>
     </div>
   );
 }

--- a/apps/webview-ui/src/app/(main)/projects/projects-list.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/projects-list.tsx
@@ -8,6 +8,7 @@ import {
   FolderOpen,
   Loader2,
   MoreVertical,
+  Plus,
   Trash2,
 } from 'lucide-react';
 import Link from 'next/link';
@@ -176,6 +177,14 @@ export function ProjectsList({
           <p className="text-sm text-muted-foreground/70">
             Create your first project to start tracking errors
           </p>
+          <Button
+            className="mt-4"
+            nativeButton={false}
+            render={<Link href="/projects/new" />}
+          >
+            <Plus className="mr-2 size-4" />
+            New Project
+          </Button>
         </div>
       ) : (
         <div className="flex-1 overflow-hidden flex flex-col border rounded-lg">

--- a/apps/webview-ui/src/lib/platform-snippets.ts
+++ b/apps/webview-ui/src/lib/platform-snippets.ts
@@ -9,10 +9,13 @@
  * The literal `__DSN__` is substituted with the project's real DSN at render
  * time, see `renderSnippet`.
  *
- * Coverage is deliberately partial. A platform with no entry falls back to a
- * plain DSN panel plus a link to the official docs, which is exactly what
- * Sentry itself shows for its `other` platform, so a missing entry is never a
- * broken state.
+ * Coverage is deliberately partial. A platform with no entry renders the DSN
+ * panel plus a link to the official docs and no snippet at all. It must never
+ * borrow another platform's snippet: Sentry is stricter still and renders an
+ * explicit "documentation for this platform is currently unavailable" error
+ * (`sdkDocumentation.tsx`), reserving the DSN-plus-docs panel for platforms it
+ * has deprecated (`deprecatedPlatformInfo.tsx`). A missing entry is a thinner
+ * page, never a wrong one.
  */
 export interface PlatformSnippet {
   /**
@@ -312,12 +315,27 @@ Sentry.init({
   root_source_code_paths: [File.cwd!()]`,
     language: 'elixir',
   },
+  // Flutter is a wizard platform, so its `onboarding.tsx` carries no configure
+  // snippet to extract. Both fields below come from `flutter/sessionReplay.tsx`
+  // instead (install at its `getManualInstallSnippet`, the `appRunner` shape at
+  // its replay snippet), with the replay-specific options dropped.
   'flutter': {
-    configure: `await SentryFlutter.init(
-  (options) {
-    options.dsn = '__DSN__';
-  },
-);`,
+    install: `sentry_flutter: ^9.6.0`,
+    configure: `import 'package:flutter/widgets.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+Future<void> main() async {
+  await SentryFlutter.init(
+    (options) {
+      options.dsn = '__DSN__';
+    },
+    appRunner: () => runApp(
+      SentryWidget(
+        child: MyApp(),
+      ),
+    ),
+  );
+}`,
     language: 'dart',
   },
   'go': {

--- a/apps/webview-ui/src/lib/platform-snippets.ts
+++ b/apps/webview-ui/src/lib/platform-snippets.ts
@@ -1,0 +1,1352 @@
+/**
+ * Per-platform SDK setup snippets.
+ *
+ * Extracted from Sentry's own `static/app/gettingStartedDocs/<id>/` at
+ * commit a32a33a5 and reduced to plain error reporting: no tracing, profiling,
+ * logs, replay or metrics branches. Nothing here is written from memory; every
+ * snippet traces back to a file in that tree.
+ *
+ * The literal `__DSN__` is substituted with the project's real DSN at render
+ * time, see `renderSnippet`.
+ *
+ * Coverage is deliberately partial. A platform with no entry falls back to a
+ * plain DSN panel plus a link to the official docs, which is exactly what
+ * Sentry itself shows for its `other` platform, so a missing entry is never a
+ * broken state.
+ */
+export interface PlatformSnippet {
+  /**
+   * Package-manager command, or a dependency declaration for ecosystems that
+   * install via a manifest (Cargo, pub, Mix, Gradle, SPM).
+   *
+   * Absent for platforms whose only documented install path is Sentry's
+   * `sentry-wizard`. That tool takes `--org` and `--project` slugs and
+   * configures against a Sentry backend, so it cannot set a project up against
+   * Rustrak. Sentry's own "Manual Configuration" section for those platforms
+   * contains no snippet either: it shows the DSN and links to the docs, which
+   * is what we do.
+   */
+  install?: string;
+  /** SDK initialisation, containing the literal `__DSN__`. */
+  configure: string;
+  /** Prism language id for the highlighter. */
+  language: string;
+}
+
+export const PLATFORM_SNIPPETS: Record<string, PlatformSnippet> = {
+  'android': {
+    configure: `import io.sentry.android.core.SentryAndroid;
+import android.app.Application;
+
+public class MyApplication extends Application {
+  public void onCreate() {
+    super.onCreate();
+    SentryAndroid.init(this, options -> {
+      options.setDsn("__DSN__");
+    });
+  }
+}`,
+    language: 'java',
+  },
+  'apple-ios': {
+    configure: `import Sentry
+
+SentrySDK.start { options in
+    options.dsn = "__DSN__"
+}`,
+    language: 'swift',
+  },
+  'apple-macos': {
+    install: `.package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.9.3"),`,
+    configure: `import Sentry
+
+func applicationDidFinishLaunching(_ aNotification: Notification) {
+
+    SentrySDK.start { options in
+        options.dsn = "__DSN__"
+        options.debug = true // Enabling debug when first installing is always helpful
+
+        // Adds IP for users.
+        // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
+        options.sendDefaultPii = true
+    }
+}`,
+    language: 'swift',
+  },
+  'bun': {
+    install: `bun add @sentry/bun`,
+    configure: `import * as Sentry from "@sentry/bun";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'capacitor': {
+    install: `npm install --save @sentry/capacitor @sentry/angular@^7`,
+    configure: `import * as Sentry from '@sentry/capacitor';
+import * as SentryAngular from '@sentry/angular';
+
+Sentry.init({
+  dsn: "__DSN__"
+},
+// Forward the init method from @sentry/angular
+SentryAngular.init
+);`,
+    language: 'javascript',
+  },
+  'cordova': {
+    install: `cordova plugin add sentry-cordova`,
+    configure: `onDeviceReady: function() {
+  var Sentry = cordova.require('sentry-cordova.Sentry');
+  Sentry.init({ dsn: '__DSN__' });
+}`,
+    language: 'javascript',
+  },
+  'dart': {
+    install: `sentry: ^9.6.0`,
+    configure: `import 'package:sentry/sentry.dart';
+
+Future<void> main() async {
+  await Sentry.init((options) {
+    options.dsn = '__DSN__';
+    // Adds request headers and IP for users,
+    // visit: https://docs.sentry.io/platforms/dart/data-management/data-collected/ for more info
+    options.sendDefaultPii = true;
+  });
+}`,
+    language: 'dart',
+  },
+  'deno': {
+    install: `import * as Sentry from "npm:@sentry/deno";`,
+    configure: `import * as Sentry from "npm:@sentry/deno";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'dotnet': {
+    install: `dotnet add package Sentry`,
+    configure: `using Sentry;
+
+SentrySdk.Init(options =>
+{
+    // A Sentry Data Source Name (DSN) is required.
+    options.Dsn = "__DSN__";
+
+    // When debug is enabled, the Sentry client will emit detailed debugging information to the console.
+    options.Debug = true;
+
+    // This option is recommended. It enables Sentry's "Release Health" feature.
+    options.AutoSessionTracking = true;
+});`,
+    language: 'csharp',
+  },
+  'dotnet-aspnet': {
+    install: `Install-Package Sentry.AspNet`,
+    configure: `public class MvcApplication : HttpApplication
+{
+    private IDisposable _sentry;
+
+    protected void Application_Start()
+    {
+        // Initialize Sentry to capture AppDomain unhandled exceptions and more.
+        _sentry = SentrySdk.Init(o =>
+        {
+            o.AddAspNet();
+            o.Dsn = "__DSN__";
+            // When configuring for the first time, to see what the SDK is doing:
+            o.Debug = true;
+        });
+    }
+}`,
+    language: 'csharp',
+  },
+  'dotnet-aspnetcore': {
+    install: `dotnet add package Sentry.AspNetCore`,
+    configure: `public static IHostBuilder CreateHostBuilder(string[] args) =>
+  Host.CreateDefaultBuilder(args)
+      .ConfigureWebHostDefaults(webBuilder =>
+      {
+          // Add the following line:
+          webBuilder.UseSentry(o =>
+          {
+              o.Dsn = "__DSN__";
+              // When configuring for the first time, to see what the SDK is doing:
+              o.Debug = true;
+          });
+      });`,
+    language: 'csharp',
+  },
+  'dotnet-awslambda': {
+    install: `dotnet add package Sentry.AspNetCore`,
+    configure: `public class LambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+{
+    protected override void Init(IWebHostBuilder builder)
+    {
+        builder
+            // Add Sentry
+            .UseSentry(o =>
+            {
+              o.Dsn = "__DSN__";
+              // When configuring for the first time, to see what the SDK is doing:
+              o.Debug = true;
+              // Required in Serverless environments
+              o.FlushOnCompletedRequest = true;
+            });
+    }
+}`,
+    language: 'csharp',
+  },
+  'dotnet-gcpfunctions': {
+    install: `dotnet add package Sentry.Google.Cloud.Functions`,
+    configure: `{
+  "Sentry": {
+    "Dsn": "__DSN__",
+    "SendDefaultPii": true,
+    "Debug": true,
+    "MaxRequestBodySize": "Always"
+  }
+}`,
+    language: 'json',
+  },
+  'dotnet-maui': {
+    install: `dotnet add package Sentry.Maui`,
+    configure: `public static MauiApp CreateMauiApp()
+{
+  var builder = MauiApp.CreateBuilder();
+  builder
+    .UseMauiApp<App>()
+
+    // Add this section anywhere on the builder:
+    .UseSentry(options => {
+      // The DSN is the only required setting.
+      options.Dsn = "__DSN__";
+
+      // Use debug mode if you want to see what the SDK is doing.
+      options.Debug = true;
+  })
+
+  // ... the remainder of your MAUI app setup
+
+  return builder.Build();
+}`,
+    language: 'csharp',
+  },
+  'dotnet-winforms': {
+    install: `dotnet add package Sentry`,
+    configure: `static class Program
+{
+    [STAThread]
+    static void Main()
+    {
+        // Init the Sentry SDK
+        SentrySdk.Init(o =>
+        {
+            // Tells which project in Sentry to send events to:
+            o.Dsn = "__DSN__";
+            // When configuring for the first time, to see what the SDK is doing:
+            o.Debug = true;
+        });
+        // Configure WinForms to throw exceptions so Sentry can capture them.
+        Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
+    }
+}`,
+    language: 'csharp',
+  },
+  'dotnet-wpf': {
+    install: `dotnet add package Sentry`,
+    configure: `using Sentry;
+
+public partial class App : Application
+{
+    public App()
+    {
+        DispatcherUnhandledException += App_DispatcherUnhandledException;
+        SentrySdk.Init(o =>
+        {
+            // Tells which project in Sentry to send events to:
+            o.Dsn = "__DSN__";
+            // When configuring for the first time, to see what the SDK is doing:
+            o.Debug = true;
+        });
+    }
+}`,
+    language: 'csharp',
+  },
+  'dotnet-xamarin': {
+    install: `Install-Package Sentry.Xamarin`,
+    configure: `public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+{
+    protected override void OnCreate(Bundle savedInstanceState)
+    {
+        SentryXamarin.Init(options =>
+        {
+            // Tells which project in Sentry to send events to:
+            options.Dsn = "__DSN__";
+            // When configuring for the first time, to see what the SDK is doing:
+            options.Debug = true;
+            // If you installed Sentry.Xamarin.Forms:
+            options.AddXamarinFormsIntegration();
+        });
+    }
+}`,
+    language: 'csharp',
+  },
+  'electron': {
+    install: `npm install --save @sentry/electron`,
+    configure: `import * as Sentry from "@sentry/electron";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'elixir': {
+    install: `{:sentry, "~> 10.2.0"}`,
+    configure: `config :sentry,
+  dsn: "__DSN__",
+  environment_name: Mix.env(),
+  enable_source_code_context: true,
+  root_source_code_paths: [File.cwd!()]`,
+    language: 'elixir',
+  },
+  'flutter': {
+    configure: `await SentryFlutter.init(
+  (options) {
+    options.dsn = '__DSN__';
+  },
+);`,
+    language: 'dart',
+  },
+  'go': {
+    install: `go get github.com/getsentry/sentry-go`,
+    configure: `package main
+
+import (
+  "log"
+
+  "github.com/getsentry/sentry-go"
+)
+
+func main() {
+  err := sentry.Init(sentry.ClientOptions{
+    Dsn: "__DSN__",
+  })
+  if err != nil {
+    log.Fatalf("sentry.Init: %s", err)
+  }
+}`,
+    language: 'go',
+  },
+  'go-echo': {
+    install: `go get github.com/getsentry/sentry-go/echo`,
+    configure: `import (
+  "fmt"
+  "net/http"
+
+  "github.com/getsentry/sentry-go"
+  sentryecho "github.com/getsentry/sentry-go/echo"
+  "github.com/labstack/echo/v4"
+  "github.com/labstack/echo/v4/middleware"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+  Dsn: "__DSN__",
+}); err != nil {
+  fmt.Printf("Sentry initialization failed: %v\\n", err)
+}`,
+    language: 'go',
+  },
+  'go-fasthttp': {
+    install: `go get github.com/getsentry/sentry-go/fasthttp`,
+    configure: `import (
+  "fmt"
+  "net/http"
+
+  "github.com/getsentry/sentry-go"
+  sentryfasthttp "github.com/getsentry/sentry-go/fasthttp"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+  Dsn: "__DSN__",
+}); err != nil {
+  fmt.Printf("Sentry initialization failed: %v\\n", err)
+}`,
+    language: 'go',
+  },
+  'go-fiber': {
+    install: `go get github.com/getsentry/sentry-go/fiber`,
+    configure: `import (
+  "fmt"
+  "net/http"
+
+  "github.com/getsentry/sentry-go"
+  sentryfiber "github.com/getsentry/sentry-go/fiber"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+  Dsn: "__DSN__",
+}); err != nil {
+  fmt.Printf("Sentry initialization failed: %v\\n", err)
+}`,
+    language: 'go',
+  },
+  'go-gin': {
+    install: `go get github.com/getsentry/sentry-go/gin`,
+    configure: `import (
+  "fmt"
+  "net/http"
+
+  "github.com/getsentry/sentry-go"
+  sentrygin "github.com/getsentry/sentry-go/gin"
+  "github.com/gin-gonic/gin"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+  Dsn: "__DSN__",
+}); err != nil {
+  fmt.Printf("Sentry initialization failed: %v\\n", err)
+}`,
+    language: 'go',
+  },
+  'go-http': {
+    install: `go get github.com/getsentry/sentry-go/http`,
+    configure: `import (
+  "fmt"
+  "net/http"
+
+  "github.com/getsentry/sentry-go"
+  sentryhttp "github.com/getsentry/sentry-go/http"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+  Dsn: "__DSN__",
+}); err != nil {
+  fmt.Printf("Sentry initialization failed: %v\\n", err)
+}`,
+    language: 'go',
+  },
+  'go-iris': {
+    install: `go get github.com/getsentry/sentry-go/iris`,
+    configure: `import (
+  "fmt"
+
+  "github.com/getsentry/sentry-go"
+  sentryiris "github.com/getsentry/sentry-go/iris"
+  "github.com/kataras/iris/v12"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+  Dsn: "__DSN__",
+}); err != nil {
+  fmt.Printf("Sentry initialization failed: %v\\n", err)
+}`,
+    language: 'go',
+  },
+  'go-negroni': {
+    install: `go get github.com/getsentry/sentry-go/negroni`,
+    configure: `import (
+  "fmt"
+  "net/http"
+
+  "github.com/getsentry/sentry-go"
+  sentrynegroni "github.com/getsentry/sentry-go/negroni"
+  "github.com/urfave/negroni"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+  Dsn: "__DSN__",
+}); err != nil {
+  fmt.Printf("Sentry initialization failed: %v\\n", err)
+}`,
+    language: 'go',
+  },
+  'java': {
+    install: `id "io.sentry.jvm.gradle" version "3.12.0"`,
+    configure: `import io.sentry.Sentry;
+
+Sentry.init(options -> {
+  options.setDsn("__DSN__");
+
+  // Add data like request headers and IP for users,
+  // see https://docs.sentry.io/platforms/java/data-management/data-collected/ for more info
+  options.setSendDefaultPii(true);
+  // When first trying Sentry it's good to see what the SDK is doing:
+  options.setDebug(true);
+});`,
+    language: 'java',
+  },
+  'java-log4j2': {
+    install: `id "io.sentry.jvm.gradle" version "3.12.0"`,
+    configure: `<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn" packages="org.apache.logging.log4j.core,io.sentry.log4j2">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <Sentry name="Sentry"
+                dsn=__DSN__>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Sentry"/>
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>`,
+    language: 'xml',
+  },
+  'java-logback': {
+    install: `id "io.sentry.jvm.gradle" version "3.12.0"`,
+    configure: `<configuration>
+  <!-- Configure the Sentry appender -->
+  <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+    <options>
+      <dsn>__DSN__</dsn>
+      <!-- Add data like request headers and IP for users, see https://docs.sentry.io/platforms/java/guides/logback/data-management/data-collected/ for more info -->
+      <sendDefaultPii>true</sendDefaultPii>
+    </options>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="Sentry"/>
+  </root>
+</configuration>`,
+    language: 'xml',
+  },
+  'java-spring': {
+    install: `id "io.sentry.jvm.gradle" version "3.12.0"`,
+    configure: `import io.sentry.spring7.EnableSentry;
+
+@EnableSentry(
+  dsn = "__DSN__",
+  // Add data like request headers and IP for users,
+  // see https://docs.sentry.io/platforms/java/guides/spring/data-management/data-collected/ for more info
+  sendDefaultPii = true
+)
+@Configuration
+class SentryConfiguration {
+}`,
+    language: 'java',
+  },
+  'java-spring-boot': {
+    install: `id "io.sentry.jvm.gradle" version "3.12.0"`,
+    configure: `sentry.dsn=__DSN__
+# Add data like request headers and IP for users,
+# see https://docs.sentry.io/platforms/java/guides/spring-boot/data-management/data-collected/ for more info
+sentry.send-default-pii=true`,
+    language: 'bash',
+  },
+  'javascript': {
+    install: `npm install --save @sentry/browser`,
+    configure: `import * as Sentry from "@sentry/browser";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-angular': {
+    install: `npm install --save @sentry/angular`,
+    configure: `import { bootstrapApplication } from '@angular/platform-browser';
+import * as Sentry from "@sentry/angular";
+
+import { appConfig } from './app/app.config';
+import { AppComponent } from './app/app.component';
+
+Sentry.init({
+  dsn: "__DSN__",
+});
+
+bootstrapApplication(appConfig, AppComponent)
+  .catch((err) => console.error(err));`,
+    language: 'javascript',
+  },
+  'javascript-astro': {
+    install: `npx astro add @sentry/astro`,
+    configure: `import * as Sentry from "@sentry/astro";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-ember': {
+    install: `ember install @sentry/ember`,
+    configure: `import * as Sentry from "@sentry/ember";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-gatsby': {
+    install: `npm install --save @sentry/gatsby`,
+    configure: `import * as Sentry from "@sentry/gatsby";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-nextjs': {
+    configure: `import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-nuxt': {
+    install: `npm install --save @sentry/nuxt`,
+    configure: `import * as Sentry from "@sentry/nuxt";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-react': {
+    install: `npm install --save @sentry/react`,
+    configure: `import * as Sentry from "@sentry/react";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-react-router': {
+    configure: `import * as Sentry from "@sentry/react-router";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-remix': {
+    configure: `import * as Sentry from "@sentry/remix";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-solid': {
+    install: `npm install --save @sentry/solid`,
+    configure: `import * as Sentry from "@sentry/solid";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-solidstart': {
+    install: `npm install --save @sentry/solidstart`,
+    configure: `import * as Sentry from "@sentry/solidstart";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-svelte': {
+    install: `npm install --save @sentry/svelte`,
+    configure: `import "./app.css";
+import App from "./App.svelte";
+
+import * as Sentry from "@sentry/svelte";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-sveltekit': {
+    configure: `import * as Sentry from "@sentry/sveltekit";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'javascript-tanstackstart-react': {
+    install: `npm install --save @sentry/tanstackstart-react`,
+    configure: `import * as Sentry from "@sentry/tanstackstart-react";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'typescript',
+  },
+  'javascript-vue': {
+    install: `npm install --save @sentry/vue`,
+    configure: `import {createApp} from "vue";
+import * as Sentry from "@sentry/vue";
+
+const app = createApp({
+  // ...
+});
+
+Sentry.init({
+  app,
+  dsn: "__DSN__",
+});
+
+app.mount("#app");`,
+    language: 'javascript',
+  },
+  'kotlin': {
+    install: `id "io.sentry.jvm.gradle" version "3.12.0"`,
+    configure: `import io.sentry.Sentry
+
+Sentry.init { options ->
+  options.dsn = "__DSN__"
+  // When first trying Sentry it's good to see what the SDK is doing:
+  options.isDebug = true
+}`,
+    language: 'kotlin',
+  },
+  'node': {
+    install: `npm install @sentry/node --save`,
+    configure: `// Import with \`import * as Sentry from "@sentry/node"\` if you are using ESM
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'node-awslambda': {
+    install: `npm install @sentry/aws-serverless --save`,
+    configure: `NODE_OPTIONS="--import @sentry/aws-serverless/awslambda-auto"
+SENTRY_DSN="__DSN__"`,
+    language: 'bash',
+  },
+  'node-azurefunctions': {
+    install: `npm install @sentry/node --save`,
+    configure: `// Import with \`import * as Sentry from "@sentry/node"\` if you are using ESM
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'node-cloudflare-pages': {
+    install: `npm install @sentry/cloudflare --save`,
+    configure: `import * as Sentry from "@sentry/cloudflare";
+
+export const onRequest = [
+  // Make sure Sentry is the first middleware
+  Sentry.sentryPagesPlugin((context) => ({
+    dsn: "__DSN__",
+  })),
+  // Add more middlewares here
+];`,
+    language: 'javascript',
+  },
+  'node-cloudflare-workers': {
+    install: `npm install @sentry/cloudflare --save`,
+    configure: `import * as Sentry from "@sentry/cloudflare";
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: "__DSN__",
+  }),
+  {
+    async fetch(request, env, ctx) {
+      return new Response('Hello World!');
+    },
+  } satisfies ExportedHandler<Env>,
+);`,
+    language: 'typescript',
+  },
+  'node-connect': {
+    install: `npm install @sentry/node --save`,
+    configure: `// Import with \`import * as Sentry from "@sentry/node"\` if you are using ESM
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'node-express': {
+    install: `npm install @sentry/node --save`,
+    configure: `// Import with \`import * as Sentry from "@sentry/node"\` if you are using ESM
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'node-fastify': {
+    install: `npm install @sentry/node --save`,
+    configure: `// Import with \`import * as Sentry from "@sentry/node"\` if you are using ESM
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'node-gcpfunctions': {
+    install: `npm install @sentry/google-cloud-serverless --save`,
+    configure: `// Import with \`import * as Sentry from "@sentry/google-cloud-serverless"\` if you are using ESM
+const Sentry = require("@sentry/google-cloud-serverless");
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'node-hapi': {
+    install: `npm install @sentry/node --save`,
+    configure: `// Import with \`import * as Sentry from "@sentry/node"\` if you are using ESM
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'node-hono': {
+    install: `npm install @sentry/hono @sentry/cloudflare --save`,
+    configure: `import { Hono } from "hono";
+import { sentry } from "@sentry/hono/cloudflare";
+
+const app = new Hono();
+
+app.use(
+  sentry(app, {
+    dsn: "__DSN__",
+  }),
+);
+
+// Your routes here
+app.get("/", (c) => {
+  return c.text("Hello Hono!");
+});
+
+export default app;`,
+    language: 'javascript',
+  },
+  'node-koa': {
+    install: `npm install @sentry/node --save`,
+    configure: `// Import with \`import * as Sentry from "@sentry/node"\` if you are using ESM
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'node-nestjs': {
+    install: `npm install @sentry/nestjs --save`,
+    configure: `// Import with \`const Sentry = require("@sentry/nestjs");\` if you are using CJS
+import * as Sentry from "@sentry/nestjs"
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'php': {
+    install: `composer require sentry/sentry`,
+    configure: `\\Sentry\\init([
+  'dsn' => '__DSN__',
+]);`,
+    language: 'php',
+  },
+  'php-laravel': {
+    install: `composer require sentry/sentry-laravel`,
+    configure: `php artisan sentry:publish --dsn=__DSN__`,
+    language: 'bash',
+  },
+  'php-symfony': {
+    install: `composer require sentry/sentry-symfony`,
+    configure: `###> sentry/sentry-symfony ###
+SENTRY_DSN="__DSN__"
+###< sentry/sentry-symfony ###`,
+    language: 'bash',
+  },
+  'powershell': {
+    install: `Install-Module -Name Sentry -Repository PSGallery -RequiredVersion 0.0.2 -Force`,
+    configure: `# You need to import the module once in a script.
+Import-Module Sentry
+
+Start-Sentry {
+    $_.Dsn = '__DSN__'
+}`,
+    language: 'bash',
+  },
+  'python': {
+    install: `pip install "sentry-sdk"`,
+    configure: `import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-aiohttp': {
+    install: `pip install "sentry-sdk"`,
+    configure: `from aiohttp import web
+
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-asgi': {
+    install: `pip install "sentry-sdk"`,
+    configure: `import sentry_sdk
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+
+from myapp import asgi_app
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-awslambda': {
+    install: `pip install "sentry-sdk"`,
+    configure: `import sentry_sdk
+from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    integrations=[AwsLambdaIntegration()],
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-bottle': {
+    install: `pip install "sentry-sdk" "bottle"`,
+    configure: `import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-celery': {
+    install: `pip install "sentry-sdk" "celery"`,
+    configure: `import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-chalice': {
+    install: `pip install "sentry-sdk" "chalice"`,
+    configure: `import sentry_sdk
+from chalice import Chalice
+
+from sentry_sdk.integrations.chalice import ChaliceIntegration
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    integrations=[ChaliceIntegration()],
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-django': {
+    install: `pip install "sentry-sdk" "django"`,
+    configure: `import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-falcon': {
+    install: `pip install "sentry-sdk" "falcon"`,
+    configure: `import falcon
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-fastapi': {
+    install: `pip install "sentry-sdk" "fastapi"`,
+    configure: `from fastapi import FastAPI
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-flask': {
+    install: `pip install "sentry-sdk" "flask"`,
+    configure: `import sentry_sdk
+from flask import Flask
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-gcpfunctions': {
+    install: `pip install "sentry-sdk"`,
+    configure: `import sentry_sdk
+from sentry_sdk.integrations.gcp import GcpIntegration
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    integrations=[GcpIntegration()],
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-litestar': {
+    install: `pip install "sentry-sdk" "litestar"`,
+    configure: `import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-pyramid': {
+    install: `pip install "sentry-sdk"`,
+    configure: `from pyramid.config import Configurator
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-quart': {
+    install: `pip install "sentry-sdk" "quart"`,
+    configure: `import sentry_sdk
+from sentry_sdk.integrations.quart import QuartIntegration
+from quart import Quart
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    integrations=[QuartIntegration()],
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-rq': {
+    install: `pip install "sentry-sdk" "rq"`,
+    configure: `import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-sanic': {
+    install: `pip install "sentry-sdk" "sanic"`,
+    configure: `from sanic import Sanic
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-serverless': {
+    install: `pip install "sentry-sdk"`,
+    configure: `import sentry_sdk
+from sentry_sdk.integrations.serverless import serverless_function
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-starlette': {
+    install: `pip install "sentry-sdk" "starlette"`,
+    configure: `from starlette.applications import Starlette
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-tornado': {
+    install: `pip install "sentry-sdk" "tornado"`,
+    configure: `import sentry_sdk
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-tryton': {
+    install: `pip install "sentry-sdk"`,
+    configure: `import sentry_sdk
+from sentry_sdk.integrations.trytond import TrytondWSGIIntegration
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    integrations=[TrytondWSGIIntegration()],
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'python-wsgi': {
+    install: `pip install "sentry-sdk"`,
+    configure: `import sentry_sdk
+from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
+
+from my_wsgi_app import app
+
+sentry_sdk.init(
+    dsn="__DSN__",
+    # Add data like request headers and IP for users,
+    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+    send_default_pii=True,
+)`,
+    language: 'python',
+  },
+  'react-native': {
+    install: `npm install @sentry/react-native@latest`,
+    configure: `import * as Sentry from "@sentry/react-native";
+
+Sentry.init({
+  dsn: "__DSN__",
+});`,
+    language: 'javascript',
+  },
+  'ruby': {
+    install: `gem "sentry-ruby"`,
+    configure: `require 'sentry-ruby'
+
+Sentry.init do |config|
+  config.dsn = '__DSN__'
+
+  # Add data like request headers and IP for users,
+  # see https://docs.sentry.io/platforms/ruby/data-management/data-collected/ for more info
+  config.send_default_pii = true
+end`,
+    language: 'ruby',
+  },
+  'ruby-rack': {
+    install: `gem "sentry-ruby"`,
+    configure: `require 'sentry-ruby'
+
+Sentry.init do |config|
+  config.dsn = '__DSN__'
+
+  # Add data like request headers and IP for users,
+  # see https://docs.sentry.io/platforms/ruby/data-management/data-collected/ for more info
+  config.send_default_pii = true
+end`,
+    language: 'ruby',
+  },
+  'ruby-rails': {
+    install: `gem "sentry-rails"`,
+    configure: `Sentry.init do |config|
+  config.dsn = '__DSN__'
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+
+  # Add data like request headers and IP for users,
+  # see https://docs.sentry.io/platforms/ruby/data-management/data-collected/ for more info
+  config.send_default_pii = true
+end`,
+    language: 'ruby',
+  },
+  'rust': {
+    install: `sentry = "0.42.0"`,
+    configure: `let _guard = sentry::init(("__DSN__", sentry::ClientOptions {
+  release: sentry::release_name!(),
+  // Capture user IPs and potentially sensitive headers when using HTTP server integrations
+  // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
+  send_default_pii: true,
+  ..Default::default()
+}));`,
+    language: 'rust',
+  },
+};
+
+/** Official Sentry documentation URL per platform, from Sentry's own platforms.tsx. */
+export const PLATFORM_DOCS: Record<string, string> = {
+  'android': 'https://docs.sentry.io/platforms/android/',
+  'apple': 'https://docs.sentry.io/platforms/apple/',
+  'apple-ios': 'https://docs.sentry.io/platforms/apple/',
+  'apple-macos': 'https://docs.sentry.io/platforms/apple/',
+  'bun': 'https://docs.sentry.io/platforms/javascript/guides/bun/',
+  'capacitor': 'https://docs.sentry.io/platforms/javascript/guides/capacitor/',
+  'cordova': 'https://docs.sentry.io/platforms/javascript/guides/cordova/',
+  'dart': 'https://docs.sentry.io/platforms/dart/',
+  'deno': 'https://docs.sentry.io/platforms/javascript/guides/deno/',
+  'dotnet': 'https://docs.sentry.io/platforms/dotnet/',
+  'dotnet-aspnet': 'https://docs.sentry.io/platforms/dotnet/guides/aspnet/',
+  'dotnet-aspnetcore': 'https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/',
+  'dotnet-awslambda': 'https://docs.sentry.io/platforms/dotnet/guides/aws-lambda/',
+  'dotnet-gcpfunctions': 'https://docs.sentry.io/platforms/dotnet/guides/google-cloud-functions/',
+  'dotnet-maui': 'https://docs.sentry.io/platforms/dotnet/guides/maui/',
+  'dotnet-uwp': 'https://docs.sentry.io/platforms/dotnet/guides/uwp/',
+  'dotnet-winforms': 'https://docs.sentry.io/platforms/dotnet/guides/winforms/',
+  'dotnet-wpf': 'https://docs.sentry.io/platforms/dotnet/guides/wpf/',
+  'dotnet-xamarin': 'https://docs.sentry.io/platforms/dotnet/guides/xamarin/',
+  'electron': 'https://docs.sentry.io/platforms/javascript/guides/electron/',
+  'elixir': 'https://docs.sentry.io/platforms/elixir/',
+  'flutter': 'https://docs.sentry.io/platforms/flutter/',
+  'ionic': 'https://docs.sentry.io/platforms/javascript/guides/capacitor/',
+  'java': 'https://docs.sentry.io/platforms/java/',
+  'java-log4j2': 'https://docs.sentry.io/platforms/java/guides/log4j2/',
+  'java-logback': 'https://docs.sentry.io/platforms/java/guides/logback/',
+  'java-spring': 'https://docs.sentry.io/platforms/java/guides/spring/',
+  'java-spring-boot': 'https://docs.sentry.io/platforms/java/guides/spring-boot/',
+  'javascript': 'https://docs.sentry.io/platforms/javascript/',
+  'javascript-angular': 'https://docs.sentry.io/platforms/javascript/guides/angular/',
+  'javascript-astro': 'https://docs.sentry.io/platforms/javascript/guides/astro/',
+  'javascript-ember': 'https://docs.sentry.io/platforms/javascript/guides/ember/',
+  'javascript-gatsby': 'https://docs.sentry.io/platforms/javascript/guides/gatsby/',
+  'javascript-nextjs': 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
+  'javascript-nuxt': 'https://docs.sentry.io/platforms/javascript/guides/nuxt/',
+  'javascript-react': 'https://docs.sentry.io/platforms/javascript/guides/react/',
+  'javascript-react-router': 'https://docs.sentry.io/platforms/javascript/guides/react-router/',
+  'javascript-remix': 'https://docs.sentry.io/platforms/javascript/guides/remix/',
+  'javascript-solid': 'https://docs.sentry.io/platforms/javascript/guides/solid/',
+  'javascript-solidstart': 'https://docs.sentry.io/platforms/javascript/guides/solidstart/',
+  'javascript-svelte': 'https://docs.sentry.io/platforms/javascript/guides/svelte/',
+  'javascript-sveltekit': 'https://docs.sentry.io/platforms/javascript/guides/sveltekit/',
+  'javascript-tanstackstart-react': 'https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/',
+  'javascript-vue': 'https://docs.sentry.io/platforms/javascript/guides/vue/',
+  'kotlin': 'https://docs.sentry.io/platforms/kotlin/',
+  'minidump': 'https://docs.sentry.io/platforms/native/minidump/',
+  'native': 'https://docs.sentry.io/platforms/native/',
+  'native-qt': 'https://docs.sentry.io/platforms/native/guides/qt/',
+  'nintendo-switch': 'https://docs.sentry.io/platforms/nintendo-switch/',
+  'node': 'https://docs.sentry.io/platforms/javascript/guides/node',
+  'node-awslambda': 'https://docs.sentry.io/platforms/javascript/guides/aws-lambda/',
+  'node-azurefunctions': 'https://docs.sentry.io/platforms/javascript/guides/azure-functions/',
+  'node-cloudflare-pages': 'https://docs.sentry.io/platforms/javascript/guides/cloudflare/',
+  'node-cloudflare-workers': 'https://docs.sentry.io/platforms/javascript/guides/cloudflare/',
+  'node-connect': 'https://docs.sentry.io/platforms/javascript/guides/connect/',
+  'node-express': 'https://docs.sentry.io/platforms/javascript/guides/express/',
+  'node-fastify': 'https://docs.sentry.io/platforms/javascript/guides/fastify/',
+  'node-gcpfunctions': 'https://docs.sentry.io/platforms/javascript/guides/gcp-functions/',
+  'node-hapi': 'https://docs.sentry.io/platforms/javascript/guides/hapi/',
+  'node-hono': 'https://docs.sentry.io/platforms/javascript/guides/hono/',
+  'node-koa': 'https://docs.sentry.io/platforms/javascript/guides/koa/',
+  'node-nestjs': 'https://docs.sentry.io/platforms/javascript/guides/nestjs/',
+  'other': 'https://docs.sentry.io/platforms/',
+  'php': 'https://docs.sentry.io/platforms/php/',
+  'php-laravel': 'https://docs.sentry.io/platforms/php/guides/laravel/',
+  'php-symfony': 'https://docs.sentry.io/platforms/php/guides/symfony/',
+  'playstation': 'https://docs.sentry.io/platforms/playstation/',
+  'powershell': 'https://docs.sentry.io/platforms/powershell/',
+  'python': 'https://docs.sentry.io/platforms/python/',
+  'python-aiohttp': 'https://docs.sentry.io/platforms/python/guides/aiohttp/',
+  'python-asgi': 'https://docs.sentry.io/platforms/python/guides/asgi/',
+  'python-awslambda': 'https://docs.sentry.io/platforms/python/guides/aws-lambda/',
+  'python-bottle': 'https://docs.sentry.io/platforms/python/guides/bottle/',
+  'python-celery': 'https://docs.sentry.io/platforms/python/guides/celery/',
+  'python-chalice': 'https://docs.sentry.io/platforms/python/guides/chalice/',
+  'python-django': 'https://docs.sentry.io/platforms/python/guides/django/',
+  'python-falcon': 'https://docs.sentry.io/platforms/python/guides/falcon/',
+  'python-fastapi': 'https://docs.sentry.io/platforms/python/guides/fastapi/',
+  'python-flask': 'https://docs.sentry.io/platforms/python/guides/flask/',
+  'python-gcpfunctions': 'https://docs.sentry.io/platforms/python/guides/gcp-functions/',
+  'python-litestar': 'https://docs.sentry.io/platforms/python/integrations/litestar/',
+  'python-pylons': 'https://docs.sentry.io/platforms/python/legacy-sdk/integrations/pylons/',
+  'python-pymongo': 'https://docs.sentry.io/platforms/python/guides/pymongo/',
+  'python-pyramid': 'https://docs.sentry.io/platforms/python/pyramid/',
+  'python-quart': 'https://docs.sentry.io/platforms/python/guides/quart/',
+  'python-rq': 'https://docs.sentry.io/platforms/python/guides/rq/',
+  'python-sanic': 'https://docs.sentry.io/platforms/python/guides/sanic/',
+  'python-serverless': 'https://docs.sentry.io/platforms/python/guides/serverless/',
+  'python-starlette': 'https://docs.sentry.io/platforms/python/guides/starlette/',
+  'python-tornado': 'https://docs.sentry.io/platforms/python/guides/tornado/',
+  'python-tryton': 'https://docs.sentry.io/platforms/python/guides/tryton/',
+  'python-wsgi': 'https://docs.sentry.io/platforms/python/guides/wsgi/',
+  'react-native': 'https://docs.sentry.io/platforms/react-native/',
+  'ruby': 'https://docs.sentry.io/platforms/ruby/',
+  'ruby-rack': 'https://docs.sentry.io/platforms/ruby/guides/rack/',
+  'ruby-rails': 'https://docs.sentry.io/platforms/ruby/guides/rails/',
+  'rust': 'https://docs.sentry.io/platforms/rust/',
+  'unity': 'https://docs.sentry.io/platforms/unity/',
+  'unreal': 'https://docs.sentry.io/platforms/unreal/',
+  'xbox': 'https://docs.sentry.io/platforms/xbox/',
+};
+
+/** Substitutes the project's DSN into a snippet. */
+export function renderSnippet(snippet: string, dsn: string): string {
+  return snippet.split('__DSN__').join(dsn);
+}

--- a/apps/webview-ui/src/lib/platforms.ts
+++ b/apps/webview-ui/src/lib/platforms.ts
@@ -218,3 +218,300 @@ export function languageLabel(language: string): string {
 export function platformLabel(id: string): string {
   return PLATFORMS.find((p) => p.id === id)?.name ?? id;
 }
+
+// ---------------------------------------------------------------------------
+// Picker categories
+//
+// Membership is copied verbatim from Sentry's own
+// `static/app/data/platformPickerCategories.tsx` (@a32a33a5), which is a
+// different file from `platformCategories.tsx` (that one gates per-product
+// features and does NOT drive the picker).
+//
+// Two deliberate divergences from Sentry, both recorded in
+// docs/sentry-compat/project-creation-and-settings.md:
+//
+//  1. Sentry's "All" tab is `createablePlatforms`, the union of every category
+//     EXCEPT gaming. Ours is genuinely every platform in PLATFORMS. Sentry can
+//     afford a narrower All because its picker is not the only way to set a
+//     platform; ours is, and SELECTABLE_PLATFORMS deliberately includes ids
+//     auto-detection can write (`perl`, `cfml`, `as3`, ...). Hiding those would
+//     recreate the exact upstream bug where a detected platform cannot be
+//     re-selected.
+//  2. Sentry appends gaming platforms separately and strips consoles when
+//     self-hosted. Rustrak is always self-hosted and has no console
+//     entitlements to check, so gaming is a plain category.
+// ---------------------------------------------------------------------------
+
+export interface PlatformCategory {
+  id: string;
+  name: string;
+  /**
+   * Platform ids in this category. Ids not present in PLATFORMS are ignored by
+   * `categoryPlatforms`, so this list can never offer something the server
+   * would reject.
+   *
+   * Omitted means "every platform", which is what the `all` tab uses.
+   */
+  platforms?: readonly string[];
+}
+
+/**
+ * Ordered as rendered. `popular` is first and is the default tab.
+ *
+ * Its order is hand-curated by Sentry and is preserved as authored rather than
+ * sorted, unlike every other category.
+ */
+export const PLATFORM_CATEGORIES: readonly PlatformCategory[] = [
+  {
+    id: 'popular',
+    name: 'Popular',
+    platforms: [
+      'javascript-nextjs',
+      'javascript-react',
+      'react-native',
+      'node',
+      'php-laravel',
+      'python-fastapi',
+      'flutter',
+      'python-django',
+      'python',
+      'node-express',
+      'javascript',
+      'php',
+      'ruby-rails',
+      'apple-ios',
+      'node-nestjs',
+      'python-flask',
+      'javascript-vue',
+      'dotnet-aspnetcore',
+      'javascript-nuxt',
+      'dotnet-maui',
+      'javascript-angular',
+      'android',
+      'java-spring-boot',
+      'php-symfony',
+      'node-cloudflare-workers',
+      'electron',
+      'unity',
+      'javascript-remix',
+    ],
+  },
+  {
+    id: 'browser',
+    name: 'Browser',
+    platforms: [
+      'dart',
+      'flutter',
+      'javascript',
+      'javascript-angular',
+      'javascript-astro',
+      'javascript-ember',
+      'javascript-gatsby',
+      'javascript-nextjs',
+      'javascript-nuxt',
+      'javascript-react',
+      'javascript-react-router',
+      'javascript-remix',
+      'javascript-solid',
+      'javascript-solidstart',
+      'javascript-svelte',
+      'javascript-sveltekit',
+      'javascript-tanstackstart-react',
+      'javascript-vue',
+      'react-native',
+      'unity',
+    ],
+  },
+  {
+    id: 'server',
+    name: 'Server',
+    platforms: [
+      'bun',
+      'dart',
+      'deno',
+      'dotnet',
+      'dotnet-aspnet',
+      'dotnet-aspnetcore',
+      'elixir',
+      'go',
+      'go-echo',
+      'go-fasthttp',
+      'go-fiber',
+      'go-gin',
+      'go-http',
+      'go-iris',
+      'go-negroni',
+      'java',
+      'java-log4j2',
+      'java-logback',
+      'java-spring',
+      'java-spring-boot',
+      'kotlin',
+      'native',
+      'node',
+      'node-cloudflare-pages',
+      'node-cloudflare-workers',
+      'node-connect',
+      'node-express',
+      'node-fastify',
+      'node-hapi',
+      'node-hono',
+      'node-koa',
+      'node-nestjs',
+      'php',
+      'php-laravel',
+      'php-symfony',
+      'powershell',
+      'python',
+      'python-aiohttp',
+      'python-asgi',
+      'python-bottle',
+      'python-celery',
+      'python-chalice',
+      'python-django',
+      'python-falcon',
+      'python-fastapi',
+      'python-flask',
+      'python-litestar',
+      'python-pyramid',
+      'python-quart',
+      'python-rq',
+      'python-sanic',
+      'python-starlette',
+      'python-tornado',
+      'python-tryton',
+      'python-wsgi',
+      'ruby',
+      'ruby-rack',
+      'ruby-rails',
+      'rust',
+    ],
+  },
+  {
+    id: 'mobile',
+    name: 'Mobile',
+    platforms: [
+      'android',
+      'apple-ios',
+      'capacitor',
+      'cordova',
+      'dart',
+      'dotnet-maui',
+      'dotnet-xamarin',
+      'flutter',
+      'ionic',
+      'react-native',
+      'unity',
+      'unreal',
+    ],
+  },
+  {
+    id: 'desktop',
+    name: 'Desktop',
+    platforms: [
+      'apple-macos',
+      'dart',
+      'dotnet',
+      'dotnet-maui',
+      'dotnet-winforms',
+      'dotnet-wpf',
+      'electron',
+      'flutter',
+      'godot',
+      'java',
+      'kotlin',
+      'minidump',
+      'native',
+      'native-qt',
+      'unity',
+      'unreal',
+    ],
+  },
+  {
+    id: 'serverless',
+    name: 'Serverless',
+    platforms: [
+      'dotnet-awslambda',
+      'dotnet-gcpfunctions',
+      'node-awslambda',
+      'node-azurefunctions',
+      'node-cloudflare-pages',
+      'node-cloudflare-workers',
+      'node-gcpfunctions',
+      'python-awslambda',
+      'python-gcpfunctions',
+      'python-serverless',
+    ],
+  },
+  {
+    id: 'gaming',
+    name: 'Gaming',
+    platforms: [
+      'godot',
+      'native',
+      'nintendo-switch',
+      'playstation',
+      'unity',
+      'unreal',
+      'xbox',
+    ],
+  },
+  {
+    id: 'all',
+    name: 'All',
+    // No list: resolved from PLATFORMS so it can never fall behind.
+  },
+];
+
+/**
+ * Extra search terms per platform, so a user typing what they call the thing
+ * finds it. Sentry defines exactly one.
+ */
+const PLATFORM_SEARCH_ALIASES: Record<string, string[]> = {
+  native: ['cpp', 'c++'],
+};
+
+const PLATFORMS_BY_ID = new Map(PLATFORMS.map((p) => [p.id, p]));
+
+/**
+ * Platforms in a category, resolved against PLATFORMS.
+ *
+ * `popular` keeps its curated order; every other category is sorted by name,
+ * matching Sentry. `all` is every known platform.
+ */
+export function categoryPlatforms(categoryId: string): Platform[] {
+  const category = PLATFORM_CATEGORIES.find((c) => c.id === categoryId);
+  if (!category) return [];
+
+  if (!category.platforms) {
+    return [...PLATFORMS].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  const resolved = category.platforms
+    .map((id) => PLATFORMS_BY_ID.get(id))
+    .filter((p): p is Platform => p !== undefined);
+
+  return categoryId === 'popular'
+    ? resolved
+    : resolved.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Free-text platform search.
+ *
+ * Deliberately ignores the active category, matching Sentry: a user who types
+ * "django" while the Browser tab is open should still find it, rather than
+ * being told there are no results.
+ */
+export function searchPlatforms(query: string): Platform[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  return PLATFORMS.filter(
+    (p) =>
+      p.id.includes(q) ||
+      p.name.toLowerCase().includes(q) ||
+      (PLATFORM_SEARCH_ALIASES[p.id]?.some((alias) => alias.includes(q)) ??
+        false),
+  ).sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/packages/client/src/schemas/project.ts
+++ b/packages/client/src/schemas/project.ts
@@ -23,6 +23,11 @@ export const projectSchema = z.object({
 export const createProjectSchema = z.object({
   name: z.string().min(1),
   slug: z.string().optional(),
+  /**
+   * Validated server-side against SELECTABLE_PLATFORMS. Omitting it leaves the
+   * project eligible for platform auto-detection from its first event.
+   */
+  platform: z.string().min(1).optional(),
 });
 
 /**
@@ -31,4 +36,9 @@ export const createProjectSchema = z.object({
 export const updateProjectSchema = z.object({
   name: z.string().min(1).optional(),
   platform: z.string().min(1).optional(),
+  /**
+   * Slugified server-side. Unlike on create, a taken slug is a 409 rather than
+   * being silently de-duplicated.
+   */
+  slug: z.string().min(1).optional(),
 });

--- a/packages/client/src/schemas/project.ts
+++ b/packages/client/src/schemas/project.ts
@@ -22,7 +22,12 @@ export const projectSchema = z.object({
  */
 export const createProjectSchema = z.object({
   name: z.string().min(1),
-  slug: z.string().optional(),
+  /**
+   * Slugified server-side. Supplying it means the user chose it, so a taken
+   * slug is a 409. Omitting it derives one from the name and silently
+   * de-duplicates, since nobody chose that value.
+   */
+  slug: z.string().min(1).optional(),
   /**
    * Validated server-side against SELECTABLE_PLATFORMS. Omitting it leaves the
    * project eligible for platform auto-detection from its first event.

--- a/packages/client/src/utils/http.ts
+++ b/packages/client/src/utils/http.ts
@@ -16,9 +16,17 @@ function transformHttpError(error: HTTPError): RustrakError {
   const status = response.status;
 
   let errorMessage = `HTTP ${status} error`;
-  const body = error.data as { error?: string; message?: string } | null;
+  // Two shapes are live: most handlers send `{error: {type, message}}` while
+  // the 429 path sends a flat `{error: "..."}`. Reading only the flat one
+  // turned every structured error into "[object Object]". See #204.
+  const body = error.data as {
+    error?: string | { type?: string; message?: string };
+    message?: string;
+  } | null;
   if (body) {
-    errorMessage = body.error || body.message || errorMessage;
+    const nested =
+      typeof body.error === 'object' ? body.error?.message : body.error;
+    errorMessage = nested || body.message || errorMessage;
   }
 
   switch (status) {

--- a/packages/client/tests/integration/projects.test.ts
+++ b/packages/client/tests/integration/projects.test.ts
@@ -125,6 +125,23 @@ describe('ProjectsResource Integration', () => {
       expect(project.slug).toBeTruthy();
     });
 
+    it('should create project with a platform', async () => {
+      const project = await client.projects.create({
+        name: 'Platform Project',
+        platform: 'javascript-nextjs',
+      });
+
+      expect(project.platform).toBe('javascript-nextjs');
+    });
+
+    it('should leave platform null when omitted', async () => {
+      const project = await client.projects.create({
+        name: 'No Platform Project',
+      });
+
+      expect(project.platform).toBeNull();
+    });
+
     it('should reject empty name', async () => {
       await expect(client.projects.create({ name: '' })).rejects.toThrow(
         ValidationError,
@@ -176,6 +193,14 @@ describe('ProjectsResource Integration', () => {
       });
 
       expect(updated.platform).toBe('python');
+    });
+
+    it('should update project slug', async () => {
+      const updated = await client.projects.update(1, {
+        slug: 'renamed-slug',
+      });
+
+      expect(updated.slug).toBe('renamed-slug');
     });
   });
 

--- a/packages/client/tests/integration/projects.test.ts
+++ b/packages/client/tests/integration/projects.test.ts
@@ -134,6 +134,12 @@ describe('ProjectsResource Integration', () => {
       expect(project.platform).toBe('javascript-nextjs');
     });
 
+    it('should reject an empty platform', async () => {
+      await expect(
+        client.projects.create({ name: 'Empty Platform', platform: '' }),
+      ).rejects.toThrow(ValidationError);
+    });
+
     it('should leave platform null when omitted', async () => {
       const project = await client.projects.create({
         name: 'No Platform Project',

--- a/packages/client/tests/mocks/handlers.ts
+++ b/packages/client/tests/mocks/handlers.ts
@@ -363,7 +363,11 @@ export const handlers = [
 
   http.patch(`${BASE_URL}/api/projects/:id`, async ({ params, request }) => {
     const { id } = params;
-    const body = (await request.json()) as { name?: string; platform?: string };
+    const body = (await request.json()) as {
+      name?: string;
+      platform?: string;
+      slug?: string;
+    };
     const project = mockProjects.find((p) => p.id === Number(id));
 
     if (!project) {

--- a/packages/client/tests/mocks/handlers.ts
+++ b/packages/client/tests/mocks/handlers.ts
@@ -337,7 +337,11 @@ export const handlers = [
   }),
 
   http.post(`${BASE_URL}/api/projects`, async ({ request }) => {
-    const body = (await request.json()) as { name: string; slug?: string };
+    const body = (await request.json()) as {
+      name: string;
+      slug?: string;
+      platform?: string;
+    };
 
     const newProject = {
       id: 3,
@@ -349,7 +353,9 @@ export const handlers = [
       digested_event_count: 0,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
-      platform: null,
+      // Mirrors the server: an omitted platform stays NULL, a supplied one is
+      // persisted and echoed back.
+      platform: body.platform ?? null,
     };
 
     return HttpResponse.json(newProject, { status: 201 });


### PR DESCRIPTION
Creating a project was a dialog with a single name field, and afterwards you
were dropped back on the projects list with no DSN and no way to tell whether
anything had worked. This replaces that with a real page and a proper handoff.

## What changed

**Create is now a page, not a dialog.** `/projects/new` has a platform picker
(category tabs, search that deliberately looks across every category) and a
name field, on `react-hook-form` + `zod` like the rest of the app's forms. Two
columns on `lg`, with a sticky summary panel so the submit button stays on
screen while scrolling a long platform list.

**Creation lands on Client Keys**, which now renders the project's *own*
platform setup rather than a hardcoded `@sentry/browser` example: install
command, configure snippet with the DSN already substituted, and a link to that
platform's official docs. It falls back to the browser example only when a
project has no platform at all.

**Server** accepts `platform` on create and `slug` on update.

## Notes for review

- **`try_insert_with_retry` has two INSERT paths.** The TOCTOU retry re-issues
  the statement with a fresh slug; the platform is bound on both, and there is
  a test that fails if you drop it from the retry.
- **`create` and `update` treat a taken slug differently on purpose.** Create
  de-duplicates silently (`api` -> `api-1`) because the slug is derived from the
  name there. Update returns 409, because the user typed it and storing
  something else would be wrong. A slug-only update previously surfaced the raw
  database error as a 500; the unique-violation mapping only produced a Conflict
  when a `name` was present.
- **The 24 mechanical test-file changes are one `platform: None,` line each**,
  nothing else. Verified per-file, not eyeballed.
- **`platform-snippets.ts` (94 platforms) was extracted from Sentry's own
  `gettingStartedDocs` at `a32a33a5`, not written from memory.** 81 of the 94
  configure snippets trace literally to that source; the other 13 differ only by
  quote style, TSX double-escaping, or dynamic templating, and were checked by
  hand. 7 wizard-only platforms (`javascript-nextjs`, `-remix`, `-sveltekit`,
  `-react-router`, `android`, `apple-ios`, `flutter`) carry **no** install
  command: `sentry-wizard` takes `--org`/`--project` and configures against a
  Sentry backend, so it cannot point a project at Rustrak, and Sentry's own
  Manual Configuration section for those contains no snippet either. 9 more are
  omitted entirely (editor-UI DSN for Godot/Unity, private-repo console SDKs,
  manual build for native, curl for minidump).

## Deliberate divergences from Sentry

- **Name auto-fill de-duplicates client-side** (`javascript-nextjs-2`). Sentry
  pre-fills the raw platform id, which works there because only `slug` is
  unique. `projects.name` is UNIQUE here, so a second Next.js project would 409
  on the most common path there is. The alternative was dropping the
  constraint; that seemed the larger change for the smaller benefit, but it is
  a one-function revert if you disagree.
- **"All" really means all.** Sentry's All tab excludes gaming. Ours is every
  platform, because this picker is the only way to set one and
  `SELECTABLE_PLATFORMS` deliberately includes ids auto-detection can write
  (`perl`, `cfml`, `as3`). Hiding them would recreate the upstream bug where a
  detected platform cannot be re-selected.
- **Not ported: Sentry deletes the project if you press browser-back while it
  is still empty.** That is multi-tenant hygiene; on a self-hosted single-tenant
  instance it is silent data loss with no upside.

## Not covered

`apps/webview-ui` has no test runner, so the platform taxonomy and the snippet
table have no automated coverage. Three invariants are worth knowing since they
fail silently:

1. every id in `SELECTABLE_PLATFORMS` must also be in `PLATFORMS`, or the
   server accepts a platform the picker cannot offer (both are at 119 today);
2. category members and snippet keys must be real platform ids, because
   `categoryPlatforms()` drops unknown ids without erroring;
3. every `configure` snippet must contain `__DSN__`, or it renders a setup
   example pointing at nothing.

## Verification

846 server tests (project suite also re-run against a real Postgres container,
since the slug work added dual-dialect SQL), 411 client tests, `cargo clippy
-D warnings`, `cargo fmt --check`, `tsc --noEmit` and `next build` all clean.
Not exercised in a browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated “New Project” page with searchable platform selection, name suggestions, and a platform preview.
  - Project creation now supports choosing a platform, and project settings now include editable slugs.
  - Platform-specific SDK install instructions, code examples, and documentation links are now shown in client-keys settings.
- **Bug Fixes**
  - Improved slug update behavior: slugification, proper conflict handling (409), and preserving existing values when `null` is sent.
  - Enhanced artifact bundle assemble flow: chunk field validation, re-assemble updating error rows, and accepting numeric project IDs as strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->