### PR TITLE
[5/6] refactor(mcp): consume the client's Result instead of catching exceptions

### DIFF
--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -69,7 +69,7 @@ packages/mcp/
 │   ├── index.ts           # Entry: loadConfig → RustrakClient → server → stdio
 │   ├── server.ts          # createServer(client): McpServer — factory, exported for testing
 │   ├── config.ts          # loadConfig(): validates RUSTRAK_API_URL + RUSTRAK_API_TOKEN
-│   ├── errors.ts          # toMcpError(err): maps client errors → { isError, content }
+│   ├── errors.ts          # mcpJson / mcpDone / mcpRefusal + toMcpError(error)
 │   │
 │   └── tools/
 │       ├── projects.ts    # list_projects, get_project, create_project
@@ -137,12 +137,8 @@ export function registerIssueTools(server: McpServer, client: RustrakClient) {
       },
     },
     async ({ project_id, status }) => {
-      try {
-        const result = await client.issues.list(project_id, { status });
-        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.list(project_id, { status });
+      return mcpJson(result);
     },
   );
 }
@@ -150,27 +146,40 @@ export function registerIssueTools(server: McpServer, client: RustrakClient) {
 
 **CRITICAL**: Always use `server.registerTool()`. All `server.tool()` overloads are deprecated in SDK v1.29.0.
 
-### 3. Error Translation (`toMcpError`)
+### 3. Error Translation (`src/errors.ts`)
 
-Tool handlers never throw. API errors are caught and returned as `isError: true` content so the LLM can see and handle the error.
+Tool handlers never throw and never `catch`. `@rustrak/client` returns
+`Result<T, RustrakError>` rather than throwing, so a failure is a value the
+handler renders, and a `try` around a client call could only hide a
+programming error.
+
+Three renderers, and every one of the 64 call sites goes through one of them:
 
 ```typescript
 // src/errors.ts
-export function toMcpError(err: unknown) {
-  if (err instanceof NotFoundError)
-    return { content: [{ type: 'text' as const, text: `Not found: ${err.message}` }], isError: true };
-  if (err instanceof RateLimitError)
-    return { content: [{ type: 'text' as const, text: `Rate limited. Retry after: ${err.retryAfter ?? '?'}s` }], isError: true };
-  if (err instanceof AuthenticationError)
-    return { content: [{ type: 'text' as const, text: 'Authentication failed. Check RUSTRAK_API_TOKEN.' }], isError: true };
-  return { content: [{ type: 'text' as const, text: `Unexpected error: ${String(err)}` }], isError: true };
+mcpJson(result)              // Result<T>    -> pretty-printed `result.data`, or the failure
+mcpDone(result, 'Deleted.')  // Result<void> -> a fixed confirmation, or the failure
+mcpRefusal('not confirmed')  // no call was made at all (an unconfirmed destructive tool)
+```
+
+`toMcpError(error: RustrakError)` is what the first two delegate to. It
+switches on `kind` over the closed union, so it is total:
+
+```typescript
+switch (error.kind) {
+  case 'not_found':        return mcpError(error.message);  // already reads `Resource not found: X`
+  case 'rate_limited':     return mcpError(`Rate limited. Retry after: ${error.retryAfter ?? '?'}s`);
+  case 'unauthenticated':  return mcpError('Authentication failed. Check RUSTRAK_API_TOKEN.');
+  default:                 return mcpError(`API error: ${error.message}`);
 }
 ```
 
 **Rules:**
 - Never expose stack traces or internal paths in error text
-- Map every known `@rustrak/client` error class explicitly
-- Fall through to `String(err)` for unknown errors
+- Switch on `kind`; there are no error classes to `instanceof` any more
+- `default:` is the catch-all, and it is exhaustive because the union is closed
+- A `Result<void>` failure is a *value*: always go through `mcpDone`, never
+  ignore it, or the tool reports `removed successfully` after a 403
 
 ### 4. Destructive Tool Annotations
 
@@ -248,7 +257,8 @@ it('returns issues', async () => {
 - Annotations go in the second argument: `{ description, inputSchema, annotations? }`
 
 **Error handling:**
-- Every tool handler must have a `try/catch` that calls `toMcpError(err)`
+- Never write `try`/`catch` around a client call: the client returns failures, it does not throw them
+- Every handler ends in `mcpJson(result)` or `mcpDone(result, text)`
 - Never `throw` from a tool handler
 
 **Adding a new tool:**

--- a/packages/mcp/src/errors.ts
+++ b/packages/mcp/src/errors.ts
@@ -1,35 +1,86 @@
-import {
-  AuthenticationError,
-  NotFoundError,
-  RateLimitError,
-  RustrakError,
-} from '@rustrak/client';
+import type { Result, RustrakError } from '@rustrak/client';
 
-type McpErrorResult = {
+/**
+ * What every tool handler returns.
+ *
+ * `isError` is optional and only ever `true`: MCP treats its absence as
+ * success, so there is no `isError: false` to represent.
+ */
+export type McpToolResult = {
   content: Array<{ type: 'text'; text: string }>;
-  isError: true;
+  isError?: true;
 };
 
-function mcpError(text: string): McpErrorResult {
+function mcpError(text: string): McpToolResult {
   return { content: [{ type: 'text' as const, text }], isError: true };
 }
 
-export function toMcpError(err: unknown): McpErrorResult {
-  if (err instanceof NotFoundError) {
-    // No prefix of our own: the server's message already reads
-    // `Resource not found: <detail>`, so adding one produced
-    // `Not found: Resource not found: <detail>`.
-    return mcpError(err.message);
+/**
+ * Turn a client failure into tool output the model can read.
+ *
+ * Takes the `RustrakError` union, not `unknown`: the client returns its
+ * expected failures now instead of throwing them, so there is nothing left to
+ * narrow and the switch below is total. A genuine programming error still
+ * throws, and the MCP SDK turns that into an `isError` result of its own.
+ */
+export function toMcpError(error: RustrakError): McpToolResult {
+  switch (error.kind) {
+    case 'not_found':
+      // No prefix of our own: the server's message already reads
+      // `Resource not found: <detail>`, so adding one produced
+      // `Not found: Resource not found: <detail>`.
+      return mcpError(error.message);
+    case 'rate_limited': {
+      const after = error.retryAfter !== undefined ? error.retryAfter : '?';
+      return mcpError(`Rate limited. Retry after: ${after}s`);
+    }
+    case 'unauthenticated':
+      return mcpError('Authentication failed. Check RUSTRAK_API_TOKEN.');
+    default:
+      return mcpError(`API error: ${error.message}`);
   }
-  if (err instanceof RateLimitError) {
-    const after = err.retryAfter !== undefined ? err.retryAfter : '?';
-    return mcpError(`Rate limited. Retry after: ${after}s`);
+}
+
+/**
+ * Refuse a tool call the tool declined to make.
+ *
+ * The two destructive storage tools guard on `confirm` before touching the
+ * API, so there is no `RustrakError` to hand to {@link toMcpError} and no
+ * `API error:` prefix to justify: nothing failed, the call was never made.
+ */
+export function mcpRefusal(message: string): McpToolResult {
+  return mcpError(message);
+}
+
+/**
+ * Render a successful `Result` as pretty JSON, or its failure as tool output.
+ *
+ * This is the single place a tool decides what a failure looks like, which is
+ * why no tool file needs a `try`/`catch` any more.
+ */
+export function mcpJson<T>(result: Result<T, RustrakError>): McpToolResult {
+  if (!result.success) {
+    return toMcpError(result.error);
   }
-  if (err instanceof AuthenticationError) {
-    return mcpError('Authentication failed. Check RUSTRAK_API_TOKEN.');
+  return {
+    content: [{ type: 'text', text: JSON.stringify(result.data, null, 2) }],
+  };
+}
+
+/**
+ * Render a successful `Result` as a fixed confirmation line.
+ *
+ * For the `Result<void>` calls, where there is no payload to print. Going
+ * through this helper is what keeps those honest: a failed `Result<void>` is a
+ * value, so ignoring it is silent, and a tool that reported "deleted
+ * successfully" after a 403 would be worse than one that threw.
+ */
+export function mcpDone(
+  result: Result<unknown, RustrakError>,
+  text: string,
+): McpToolResult {
+  if (!result.success) {
+    return toMcpError(result.error);
   }
-  if (err instanceof RustrakError) {
-    return mcpError(`API error: ${err.message}`);
-  }
-  return mcpError(`Unexpected error: ${String(err)}`);
+  return { content: [{ type: 'text', text }] };
 }

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpJson } from '../errors.js';
 
 const timeseriesInput = {
   project_id: z.number().int().describe('Project ID'),
@@ -46,17 +46,11 @@ export function registerAgentTools(
       inputSchema: timeseriesInput,
     },
     async ({ project_id, period_hours, interval_hours }) => {
-      try {
-        const result = await client.agents.getRuns(project_id, {
-          period_hours,
-          interval_hours,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.agents.getRuns(project_id, {
+        period_hours,
+        interval_hours,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -68,17 +62,11 @@ export function registerAgentTools(
       inputSchema: timeseriesInput,
     },
     async ({ project_id, period_hours, interval_hours }) => {
-      try {
-        const result = await client.agents.getDuration(project_id, {
-          period_hours,
-          interval_hours,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.agents.getDuration(project_id, {
+        period_hours,
+        interval_hours,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -90,17 +78,11 @@ export function registerAgentTools(
       inputSchema: breakdownInput,
     },
     async ({ project_id, period_hours, limit }) => {
-      try {
-        const result = await client.agents.getModelsByCalls(project_id, {
-          period_hours,
-          limit,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.agents.getModelsByCalls(project_id, {
+        period_hours,
+        limit,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -112,17 +94,11 @@ export function registerAgentTools(
       inputSchema: breakdownInput,
     },
     async ({ project_id, period_hours, limit }) => {
-      try {
-        const result = await client.agents.getModelsByTokens(project_id, {
-          period_hours,
-          limit,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.agents.getModelsByTokens(project_id, {
+        period_hours,
+        limit,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -134,17 +110,11 @@ export function registerAgentTools(
       inputSchema: breakdownInput,
     },
     async ({ project_id, period_hours, limit }) => {
-      try {
-        const result = await client.agents.getTools(project_id, {
-          period_hours,
-          limit,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.agents.getTools(project_id, {
+        period_hours,
+        limit,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -171,17 +141,11 @@ export function registerAgentTools(
       },
     },
     async ({ project_id, page, per_page }) => {
-      try {
-        const result = await client.agents.getTraces(project_id, {
-          page,
-          per_page,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.agents.getTraces(project_id, {
+        page,
+        per_page,
+      });
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/alerts.ts
+++ b/packages/mcp/src/tools/alerts.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpJson } from '../errors.js';
 
 export function registerAlertTools(
   server: McpServer,
@@ -15,14 +15,8 @@ export function registerAlertTools(
       inputSchema: {},
     },
     async () => {
-      try {
-        const result = await client.alertIntegrations.list();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.alertIntegrations.list();
+      return mcpJson(result);
     },
   );
 
@@ -36,14 +30,8 @@ export function registerAlertTools(
       },
     },
     async ({ channel_id }) => {
-      try {
-        const result = await client.alertIntegrations.test(channel_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.alertIntegrations.test(channel_id);
+      return mcpJson(result);
     },
   );
 
@@ -56,14 +44,8 @@ export function registerAlertTools(
       },
     },
     async ({ project_id }) => {
-      try {
-        const result = await client.alertRules.list(project_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.alertRules.list(project_id);
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/events.ts
+++ b/packages/mcp/src/tools/events.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpJson } from '../errors.js';
 
 export function registerEventTools(
   server: McpServer,
@@ -23,17 +23,11 @@ export function registerEventTools(
       },
     },
     async ({ project_id, issue_id, cursor, order }) => {
-      try {
-        const result = await client.events.list(project_id, issue_id, {
-          cursor,
-          order,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.events.list(project_id, issue_id, {
+        cursor,
+        order,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -49,14 +43,8 @@ export function registerEventTools(
       },
     },
     async ({ project_id, issue_id, event_id }) => {
-      try {
-        const result = await client.events.get(project_id, issue_id, event_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.events.get(project_id, issue_id, event_id);
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/health.ts
+++ b/packages/mcp/src/tools/health.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
-import { toMcpError } from '../errors.js';
+import { mcpJson } from '../errors.js';
 
 export function registerHealthTools(
   server: McpServer,
@@ -13,14 +13,8 @@ export function registerHealthTools(
       inputSchema: {},
     },
     async () => {
-      try {
-        const result = await client.health.getVersion();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.health.getVersion();
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/issues.ts
+++ b/packages/mcp/src/tools/issues.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpDone, mcpJson } from '../errors.js';
 
 export function registerIssueTools(
   server: McpServer,
@@ -29,19 +29,13 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, page, per_page, filter, q }) => {
-      try {
-        const result = await client.issues.list(project_id, {
-          page,
-          per_page,
-          filter,
-          q,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.list(project_id, {
+        page,
+        per_page,
+        filter,
+        q,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -55,14 +49,8 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id }) => {
-      try {
-        const result = await client.issues.get(project_id, issue_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.get(project_id, issue_id);
+      return mcpJson(result);
     },
   );
 
@@ -76,16 +64,10 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id }) => {
-      try {
-        const result = await client.issues.updateState(project_id, issue_id, {
-          is_resolved: true,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.updateState(project_id, issue_id, {
+        is_resolved: true,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -99,16 +81,10 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id }) => {
-      try {
-        const result = await client.issues.updateState(project_id, issue_id, {
-          is_resolved: false,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.updateState(project_id, issue_id, {
+        is_resolved: false,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -122,16 +98,10 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id }) => {
-      try {
-        const result = await client.issues.updateState(project_id, issue_id, {
-          is_muted: true,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.updateState(project_id, issue_id, {
+        is_muted: true,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -146,16 +116,8 @@ export function registerIssueTools(
       annotations: { destructiveHint: true },
     },
     async ({ project_id, issue_id }) => {
-      try {
-        await client.issues.delete(project_id, issue_id);
-        return {
-          content: [
-            { type: 'text', text: `Issue ${issue_id} deleted successfully.` },
-          ],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.delete(project_id, issue_id);
+      return mcpDone(result, `Issue ${issue_id} deleted successfully.`);
     },
   );
 
@@ -174,17 +136,11 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id, status, priority }) => {
-      try {
-        const result = await client.issues.updateState(project_id, issue_id, {
-          status,
-          priority,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.updateState(project_id, issue_id, {
+        status,
+        priority,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -205,17 +161,11 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id, assigned_to, assignee_type }) => {
-      try {
-        const result = await client.issues.updateState(project_id, issue_id, {
-          assigned_to,
-          assignee_type,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.updateState(project_id, issue_id, {
+        assigned_to,
+        assignee_type,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -233,18 +183,12 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, ids, status, priority }) => {
-      try {
-        const result = await client.issues.bulkUpdate(project_id, {
-          ids,
-          status,
-          priority,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.bulkUpdate(project_id, {
+        ids,
+        status,
+        priority,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -259,14 +203,8 @@ export function registerIssueTools(
       annotations: { destructiveHint: true },
     },
     async ({ project_id, ids }) => {
-      try {
-        const result = await client.issues.bulkDelete(project_id, { ids });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.bulkDelete(project_id, { ids });
+      return mcpJson(result);
     },
   );
 
@@ -280,14 +218,8 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id }) => {
-      try {
-        const result = await client.issues.getHashes(project_id, issue_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.getHashes(project_id, issue_id);
+      return mcpJson(result);
     },
   );
 
@@ -303,18 +235,12 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id, key }) => {
-      try {
-        const result = await client.issues.getTagValues(
-          project_id,
-          issue_id,
-          key,
-        );
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.getTagValues(
+        project_id,
+        issue_id,
+        key,
+      );
+      return mcpJson(result);
     },
   );
 
@@ -329,14 +255,8 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id }) => {
-      try {
-        const result = await client.issues.getAggregates(project_id, issue_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.getAggregates(project_id, issue_id);
+      return mcpJson(result);
     },
   );
 
@@ -351,18 +271,8 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id, window }) => {
-      try {
-        const result = await client.issues.getStats(
-          project_id,
-          issue_id,
-          window,
-        );
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.getStats(project_id, issue_id, window);
+      return mcpJson(result);
     },
   );
 
@@ -377,14 +287,8 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id }) => {
-      try {
-        const result = await client.issues.getActivity(project_id, issue_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.getActivity(project_id, issue_id);
+      return mcpJson(result);
     },
   );
 
@@ -399,16 +303,10 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id, text }) => {
-      try {
-        const result = await client.issues.addComment(project_id, issue_id, {
-          text,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.addComment(project_id, issue_id, {
+        text,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -423,18 +321,12 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id, enabled }) => {
-      try {
-        const result = await client.issues.setBookmark(
-          project_id,
-          issue_id,
-          enabled,
-        );
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.setBookmark(
+        project_id,
+        issue_id,
+        enabled,
+      );
+      return mcpJson(result);
     },
   );
 
@@ -451,18 +343,12 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id, enabled }) => {
-      try {
-        const result = await client.issues.setSubscription(
-          project_id,
-          issue_id,
-          enabled,
-        );
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.setSubscription(
+        project_id,
+        issue_id,
+        enabled,
+      );
+      return mcpJson(result);
     },
   );
 
@@ -476,14 +362,8 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id }) => {
-      try {
-        const result = await client.issues.markSeen(project_id, issue_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.markSeen(project_id, issue_id);
+      return mcpJson(result);
     },
   );
 
@@ -497,17 +377,8 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id }) => {
-      try {
-        const result = await client.issues.listUserReports(
-          project_id,
-          issue_id,
-        );
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.listUserReports(project_id, issue_id);
+      return mcpJson(result);
     },
   );
 
@@ -525,18 +396,12 @@ export function registerIssueTools(
       },
     },
     async ({ project_id, issue_id, name, email, comments, event_id }) => {
-      try {
-        const result = await client.issues.createUserReport(
-          project_id,
-          issue_id,
-          { name, email, comments, event_id },
-        );
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.issues.createUserReport(
+        project_id,
+        issue_id,
+        { name, email, comments, event_id },
+      );
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/logs.ts
+++ b/packages/mcp/src/tools/logs.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpJson } from '../errors.js';
 
 export function registerLogTools(
   server: McpServer,
@@ -38,19 +38,13 @@ export function registerLogTools(
       },
     },
     async ({ project_id, page, per_page, level, trace_id }) => {
-      try {
-        const result = await client.logs.list(project_id, {
-          page,
-          per_page,
-          level,
-          trace_id,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.logs.list(project_id, {
+        page,
+        per_page,
+        level,
+        trace_id,
+      });
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/projects.ts
+++ b/packages/mcp/src/tools/projects.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpJson } from '../errors.js';
 
 export function registerProjectTools(
   server: McpServer,
@@ -23,14 +23,8 @@ export function registerProjectTools(
       },
     },
     async ({ page, per_page }) => {
-      try {
-        const result = await client.projects.list({ page, per_page });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.projects.list({ page, per_page });
+      return mcpJson(result);
     },
   );
 
@@ -43,14 +37,8 @@ export function registerProjectTools(
       },
     },
     async ({ project_id }) => {
-      try {
-        const result = await client.projects.get(project_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.projects.get(project_id);
+      return mcpJson(result);
     },
   );
 
@@ -67,14 +55,8 @@ export function registerProjectTools(
       },
     },
     async ({ name, slug }) => {
-      try {
-        const result = await client.projects.create({ name, slug });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.projects.create({ name, slug });
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/sessions.ts
+++ b/packages/mcp/src/tools/sessions.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpJson } from '../errors.js';
 
 export function registerSessionTools(
   server: McpServer,
@@ -31,18 +31,12 @@ export function registerSessionTools(
       },
     },
     async ({ project_id, period, page, per_page }) => {
-      try {
-        const result = await client.sessions.stats(project_id, {
-          period,
-          page,
-          per_page,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.sessions.stats(project_id, {
+        period,
+        page,
+        per_page,
+      });
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/spans.ts
+++ b/packages/mcp/src/tools/spans.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpJson } from '../errors.js';
 
 export function registerSpanTools(
   server: McpServer,
@@ -50,21 +50,15 @@ export function registerSpanTools(
       trace_id,
       operation_type,
     }) => {
-      try {
-        const result = await client.spans.list(project_id, {
-          page,
-          per_page,
-          op,
-          status,
-          trace_id,
-          operation_type,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.spans.list(project_id, {
+        page,
+        per_page,
+        op,
+        status,
+        trace_id,
+        operation_type,
+      });
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/stats.ts
+++ b/packages/mcp/src/tools/stats.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpJson } from '../errors.js';
 
 export function registerStatsTools(
   server: McpServer,
@@ -30,18 +30,12 @@ export function registerStatsTools(
       },
     },
     async ({ project_id, period, interval }) => {
-      try {
-        const result = await client.stats.timeseries(
-          project_id,
-          period,
-          interval,
-        );
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.stats.timeseries(
+        project_id,
+        period,
+        interval,
+      );
+      return mcpJson(result);
     },
   );
 
@@ -61,14 +55,8 @@ export function registerStatsTools(
       },
     },
     async ({ project_id, period }) => {
-      try {
-        const result = await client.stats.summary(project_id, period);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.stats.summary(project_id, period);
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/storage.ts
+++ b/packages/mcp/src/tools/storage.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpJson, mcpRefusal } from '../errors.js';
 
 export function registerStorageTools(
   server: McpServer,
@@ -15,14 +15,8 @@ export function registerStorageTools(
       inputSchema: {},
     },
     async () => {
-      try {
-        const result = await client.storage.getSummary();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.storage.getSummary();
+      return mcpJson(result);
     },
   );
 
@@ -34,14 +28,8 @@ export function registerStorageTools(
       inputSchema: {},
     },
     async () => {
-      try {
-        const result = await client.storage.getProjects();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.storage.getProjects();
+      return mcpJson(result);
     },
   );
 
@@ -86,20 +74,14 @@ export function registerStorageTools(
       include_transactions,
       include_logs,
     }) => {
-      try {
-        const result = await client.storage.previewCleanup({
-          older_than_days,
-          project_id,
-          include_events,
-          include_transactions,
-          include_logs,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.storage.previewCleanup({
+        older_than_days,
+        project_id,
+        include_events,
+        include_transactions,
+        include_logs,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -151,26 +133,18 @@ export function registerStorageTools(
       confirm,
     }) => {
       if (confirm !== true) {
-        return toMcpError(
-          new Error(
-            'execute_storage_cleanup is destructive and was not confirmed. Run preview_storage_cleanup first, then call again with confirm=true to proceed.',
-          ),
+        return mcpRefusal(
+          'execute_storage_cleanup is destructive and was not confirmed. Run preview_storage_cleanup first, then call again with confirm=true to proceed.',
         );
       }
-      try {
-        const result = await client.storage.executeCleanup({
-          older_than_days,
-          project_id,
-          include_events,
-          include_transactions,
-          include_logs,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.storage.executeCleanup({
+        older_than_days,
+        project_id,
+        include_events,
+        include_transactions,
+        include_logs,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -182,14 +156,8 @@ export function registerStorageTools(
       inputSchema: {},
     },
     async () => {
-      try {
-        const result = await client.storage.previewGcSourceMaps();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.storage.previewGcSourceMaps();
+      return mcpJson(result);
     },
   );
 
@@ -208,20 +176,12 @@ export function registerStorageTools(
     },
     async ({ confirm }) => {
       if (confirm !== true) {
-        return toMcpError(
-          new Error(
-            'gc_storage_source_maps is destructive and was not confirmed. Run preview_storage_source_maps_gc first, then call again with confirm=true to proceed.',
-          ),
+        return mcpRefusal(
+          'gc_storage_source_maps is destructive and was not confirmed. Run preview_storage_source_maps_gc first, then call again with confirm=true to proceed.',
         );
       }
-      try {
-        const result = await client.storage.gcSourceMaps();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.storage.gcSourceMaps();
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/src/tools/team.ts
+++ b/packages/mcp/src/tools/team.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpDone, mcpJson } from '../errors.js';
 
 /**
  * Team management tools: the global user roster + roles, invitations, and
@@ -26,14 +26,8 @@ export function registerTeamTools(
       inputSchema: {},
     },
     async () => {
-      try {
-        const result = await client.team.list();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.team.list();
+      return mcpJson(result);
     },
   );
 
@@ -50,14 +44,8 @@ export function registerTeamTools(
       },
     },
     async ({ user_id, role }) => {
-      try {
-        await client.team.updateRole(user_id, role);
-        return {
-          content: [{ type: 'text', text: `User ${user_id} is now ${role}.` }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.team.updateRole(user_id, role);
+      return mcpDone(result, `User ${user_id} is now ${role}.`);
     },
   );
 
@@ -72,14 +60,8 @@ export function registerTeamTools(
       annotations: { destructiveHint: true },
     },
     async ({ user_id }) => {
-      try {
-        await client.team.remove(user_id);
-        return {
-          content: [{ type: 'text', text: `User ${user_id} removed.` }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.team.remove(user_id);
+      return mcpDone(result, `User ${user_id} removed.`);
     },
   );
 
@@ -98,14 +80,8 @@ export function registerTeamTools(
       },
     },
     async ({ email, role }) => {
-      try {
-        const result = await client.invitations.create({ email, role });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.invitations.create({ email, role });
+      return mcpJson(result);
     },
   );
 
@@ -117,14 +93,8 @@ export function registerTeamTools(
       inputSchema: {},
     },
     async () => {
-      try {
-        const result = await client.invitations.list();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.invitations.list();
+      return mcpJson(result);
     },
   );
 
@@ -139,14 +109,8 @@ export function registerTeamTools(
       annotations: { destructiveHint: true },
     },
     async ({ token }) => {
-      try {
-        await client.invitations.revoke(token);
-        return {
-          content: [{ type: 'text', text: 'Invitation revoked.' }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.invitations.revoke(token);
+      return mcpDone(result, 'Invitation revoked.');
     },
   );
 
@@ -162,14 +126,8 @@ export function registerTeamTools(
       },
     },
     async ({ project_id }) => {
-      try {
-        const result = await client.members.list(project_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.members.list(project_id);
+      return mcpJson(result);
     },
   );
 
@@ -187,19 +145,11 @@ export function registerTeamTools(
       },
     },
     async ({ project_id, user_id, role }) => {
-      try {
-        await client.members.upsert(project_id, { user_id, role });
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `User ${user_id} is now ${role} on project ${project_id}.`,
-            },
-          ],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.members.upsert(project_id, { user_id, role });
+      return mcpDone(
+        result,
+        `User ${user_id} is now ${role} on project ${project_id}.`,
+      );
     },
   );
 
@@ -218,19 +168,11 @@ export function registerTeamTools(
       annotations: { destructiveHint: true },
     },
     async ({ project_id, user_id }) => {
-      try {
-        await client.members.remove(project_id, user_id);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `User ${user_id} removed from project ${project_id}.`,
-            },
-          ],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.members.remove(project_id, user_id);
+      return mcpDone(
+        result,
+        `User ${user_id} removed from project ${project_id}.`,
+      );
     },
   );
 }

--- a/packages/mcp/src/tools/tokens.ts
+++ b/packages/mcp/src/tools/tokens.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpDone, mcpJson } from '../errors.js';
 
 export function registerTokenTools(
   server: McpServer,
@@ -15,14 +15,8 @@ export function registerTokenTools(
       inputSchema: {},
     },
     async () => {
-      try {
-        const result = await client.tokens.list();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.tokens.list();
+      return mcpJson(result);
     },
   );
 
@@ -36,14 +30,8 @@ export function registerTokenTools(
       },
     },
     async ({ token_id }) => {
-      try {
-        const result = await client.tokens.get(token_id);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.tokens.get(token_id);
+      return mcpJson(result);
     },
   );
 
@@ -60,14 +48,8 @@ export function registerTokenTools(
       },
     },
     async ({ description }) => {
-      try {
-        const result = await client.tokens.create({ description });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.tokens.create({ description });
+      return mcpJson(result);
     },
   );
 
@@ -82,16 +64,8 @@ export function registerTokenTools(
       annotations: { destructiveHint: true },
     },
     async ({ token_id }) => {
-      try {
-        await client.tokens.delete(token_id);
-        return {
-          content: [
-            { type: 'text', text: `Token ${token_id} revoked successfully.` },
-          ],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.tokens.delete(token_id);
+      return mcpDone(result, `Token ${token_id} revoked successfully.`);
     },
   );
 }

--- a/packages/mcp/src/tools/transactions.ts
+++ b/packages/mcp/src/tools/transactions.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { z } from 'zod';
-import { toMcpError } from '../errors.js';
+import { mcpJson } from '../errors.js';
 
 export function registerTransactionTools(
   server: McpServer,
@@ -55,22 +55,16 @@ export function registerTransactionTools(
       environment,
       release,
     }) => {
-      try {
-        const result = await client.transactions.list(project_id, {
-          page,
-          per_page,
-          name,
-          op,
-          status,
-          environment,
-          release,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.transactions.list(project_id, {
+        page,
+        per_page,
+        name,
+        op,
+        status,
+        environment,
+        release,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -85,17 +79,8 @@ export function registerTransactionTools(
       },
     },
     async ({ project_id, transaction_id }) => {
-      try {
-        const result = await client.transactions.get(
-          project_id,
-          transaction_id,
-        );
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.transactions.get(project_id, transaction_id);
+      return mcpJson(result);
     },
   );
 
@@ -122,17 +107,11 @@ export function registerTransactionTools(
       },
     },
     async ({ project_id, page, per_page }) => {
-      try {
-        const result = await client.transactions.getStats(project_id, {
-          page,
-          per_page,
-        });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.transactions.getStats(project_id, {
+        page,
+        per_page,
+      });
+      return mcpJson(result);
     },
   );
 
@@ -147,17 +126,11 @@ export function registerTransactionTools(
       },
     },
     async ({ project_id, transaction_id }) => {
-      try {
-        const result = await client.transactions.getSpans(
-          project_id,
-          transaction_id,
-        );
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (err) {
-        return toMcpError(err);
-      }
+      const result = await client.transactions.getSpans(
+        project_id,
+        transaction_id,
+      );
+      return mcpJson(result);
     },
   );
 }

--- a/packages/mcp/tests/errors.test.ts
+++ b/packages/mcp/tests/errors.test.ts
@@ -1,18 +1,19 @@
 import {
-  AuthenticationError,
-  BadRequestError,
-  NetworkError,
-  NotFoundError,
-  RateLimitError,
-  ServerError,
+  NETWORK_ERROR_MESSAGE,
+  type RustrakError,
+  SERVER_ERROR_MESSAGE,
 } from '@rustrak/client';
 import { describe, expect, it } from 'vitest';
-import { toMcpError } from '../src/errors.js';
+import { mcpDone, mcpJson, mcpRefusal, toMcpError } from '../src/errors.js';
 
 describe('toMcpError', () => {
-  it('returns isError: true for NotFoundError', () => {
-    const err = new NotFoundError('Resource not found: issue-123');
-    const result = toMcpError(err);
+  it('renders not_found without doubling the prefix', () => {
+    const error: RustrakError = {
+      kind: 'not_found',
+      status: 404,
+      message: 'Resource not found: issue-123',
+    };
+    const result = toMcpError(error);
     expect(result.isError).toBe(true);
     expect(result.content[0]?.type).toBe('text');
     // Exactly once. A case-insensitive /not found/ match cannot tell
@@ -23,71 +24,153 @@ describe('toMcpError', () => {
   });
 
   it('does not include stack traces in error output', () => {
-    const err = new NotFoundError('Resource not found: issue-123');
-    const result = toMcpError(err);
+    const result = toMcpError({
+      kind: 'not_found',
+      status: 404,
+      message: 'Resource not found: issue-123',
+    });
     const text = result.content[0]?.text ?? '';
     expect(text).not.toMatch(/at Object\./);
     expect(text).not.toMatch(/\.ts:\d+/);
   });
 
-  it('returns isError: true for RateLimitError with retryAfter', () => {
-    const err = new RateLimitError('Rate limit exceeded', 30);
-    const result = toMcpError(err);
+  it('renders rate_limited with its retryAfter', () => {
+    const result = toMcpError({
+      kind: 'rate_limited',
+      status: 429,
+      message: 'Rate limit exceeded',
+      retryAfter: 30,
+    });
     expect(result.isError).toBe(true);
     expect(result.content[0]?.text).toMatch(/30/);
   });
 
-  it('returns isError: true for RateLimitError without retryAfter', () => {
-    const err = new RateLimitError('Rate limit exceeded');
-    const result = toMcpError(err);
+  it('renders rate_limited without a retryAfter', () => {
+    const result = toMcpError({
+      kind: 'rate_limited',
+      status: 429,
+      message: 'Rate limit exceeded',
+    });
     expect(result.isError).toBe(true);
     expect(result.content[0]?.text).toMatch(/rate limit/i);
+    expect(result.content[0]?.text).toMatch(/\?s/);
   });
 
-  it('returns isError: true for AuthenticationError', () => {
-    const err = new AuthenticationError();
-    const result = toMcpError(err);
+  it('points unauthenticated at the token env var', () => {
+    const result = toMcpError({
+      kind: 'unauthenticated',
+      status: 401,
+      message: 'Unauthorized',
+    });
     expect(result.isError).toBe(true);
     expect(result.content[0]?.text).toMatch(/RUSTRAK_API_TOKEN/);
   });
 
-  it('returns isError: true for generic RustrakError', () => {
-    const err = new BadRequestError('Invalid input');
-    const result = toMcpError(err);
+  it('falls through to the default arm for validation', () => {
+    const result = toMcpError({
+      kind: 'validation',
+      status: 400,
+      message: 'Invalid input',
+    });
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toMatch(/Invalid input/);
+    expect(result.content[0]?.text).toBe('API error: Invalid input');
   });
 
-  it('returns isError: true for ServerError', () => {
-    const err = new ServerError('Internal server error', 500);
-    const result = toMcpError(err);
+  it('renders a 5xx as the redacted message, never the server body', () => {
+    const result = toMcpError({
+      kind: 'server_error',
+      status: 500,
+      message: SERVER_ERROR_MESSAGE,
+    });
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toMatch(/Internal server error/);
+    expect(result.content[0]?.text).toContain(SERVER_ERROR_MESSAGE);
   });
 
-  it('returns isError: true for NetworkError', () => {
-    const err = new NetworkError('Connection refused');
-    const result = toMcpError(err);
+  it('renders a transport failure', () => {
+    const result = toMcpError({
+      kind: 'network',
+      message: NETWORK_ERROR_MESSAGE,
+      reason: 'unreachable',
+    });
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toMatch(/Connection refused/);
+    expect(result.content[0]?.text).toContain(NETWORK_ERROR_MESSAGE);
   });
 
-  it('returns isError: true for unknown errors', () => {
-    const err = new Error('Something unexpected');
-    const result = toMcpError(err);
-    expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toMatch(/Unexpected error/i);
+  it('covers every kind of the closed union', () => {
+    // The union is total, so `toMcpError` must never return an empty or
+    // unlabelled body for any member. Enumerated by hand: adding a kind to
+    // the client without a matching entry here is a compile error, not a
+    // silently untested arm.
+    const errors: RustrakError[] = [
+      { kind: 'validation', status: 400, message: 'v' },
+      { kind: 'unauthenticated', status: 401, message: 'u' },
+      { kind: 'forbidden', status: 403, message: 'f' },
+      { kind: 'not_found', status: 404, message: 'n' },
+      { kind: 'conflict', status: 409, message: 'c' },
+      { kind: 'gone', status: 410, message: 'g' },
+      { kind: 'payload_too_large', status: 413, message: 'p' },
+      { kind: 'rate_limited', status: 429, message: 'r' },
+      { kind: 'client_error', status: 418, message: 'ce' },
+      { kind: 'invalid_request', message: 'ir' },
+      { kind: 'server_error', status: 500, message: SERVER_ERROR_MESSAGE },
+      { kind: 'network', message: NETWORK_ERROR_MESSAGE, reason: 'timeout' },
+      { kind: 'invalid_response', message: 'iresp' },
+    ];
+
+    for (const error of errors) {
+      const result = toMcpError(error);
+      expect(result.isError, error.kind).toBe(true);
+      expect(result.content[0]?.type, error.kind).toBe('text');
+      expect(result.content[0]?.text?.length, error.kind).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('mcpJson', () => {
+  it('prints the data of a successful Result, not the Result', () => {
+    const result = mcpJson({ success: true, data: { id: 7 } });
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0]?.text ?? '')).toEqual({ id: 7 });
   });
 
-  it('returns isError: true for non-Error unknowns', () => {
-    const result = toMcpError('string error');
+  it('renders a failed Result as an error', () => {
+    const result = mcpJson({
+      success: false,
+      error: { kind: 'forbidden', status: 403, message: 'Nope' },
+    });
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toMatch(/Unexpected error/i);
+    expect(result.content[0]?.text).toContain('Nope');
+  });
+});
+
+describe('mcpDone', () => {
+  it('confirms only when the Result succeeded', () => {
+    const result = mcpDone({ success: true, data: undefined }, 'Deleted.');
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]?.text).toBe('Deleted.');
   });
 
-  it('content items have correct type literal', () => {
-    const result = toMcpError(new NotFoundError('Resource not found: x'));
-    // type must be exactly 'text' for MCP content
-    expect(result.content[0]?.type).toBe('text');
+  it('never reports success for a failed void call', () => {
+    // The regression this helper exists to prevent: `Result<void>` failures
+    // are values, so a tool that ignored one would say `deleted successfully`
+    // after a 403.
+    const result = mcpDone(
+      {
+        success: false,
+        error: { kind: 'forbidden', status: 403, message: 'Not allowed' },
+      },
+      'Deleted.',
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).not.toContain('Deleted.');
+    expect(result.content[0]?.text).toContain('Not allowed');
+  });
+});
+
+describe('mcpRefusal', () => {
+  it('reports a tool-side refusal without an API prefix', () => {
+    const result = mcpRefusal('not confirmed');
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toBe('not confirmed');
   });
 });

--- a/packages/mcp/tests/setup.ts
+++ b/packages/mcp/tests/setup.ts
@@ -1,6 +1,30 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { RustrakError } from '@rustrak/client';
 import { createServer } from '../src/server.js';
+
+/**
+ * A successful `Result`, as every mocked client method now resolves to.
+ *
+ * The client stopped throwing in AD-10 phase 3a, so a mock that resolves with
+ * bare data no longer stands in for the real thing: the tools read
+ * `result.data`, and a bare value has none.
+ */
+export function ok<T>(data: T): { success: true; data: T } {
+  return { success: true, data };
+}
+
+/**
+ * A failed `Result`. Use this, not `mockRejectedValue`: an expected failure is
+ * a returned value now, and a mock that rejects only exercises the SDK's own
+ * throw handling rather than the tool's failure path.
+ */
+export function fail(error: RustrakError): {
+  success: false;
+  error: RustrakError;
+} {
+  return { success: false, error };
+}
 
 export type McpTextContent = { type: 'text'; text: string };
 export type McpToolResult = { isError?: boolean; content: McpTextContent[] };

--- a/packages/mcp/tests/tools/agents.test.ts
+++ b/packages/mcp/tests/tools/agents.test.ts
@@ -1,5 +1,6 @@
+import { SERVER_ERROR_MESSAGE } from '@rustrak/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, fail, ok } from '../setup.js';
 
 describe('agent tools', () => {
   let mockClient: any;
@@ -49,7 +50,7 @@ describe('agent tools', () => {
 
   describe('get_agent_runs', () => {
     it('returns a timeseries of agent run counts', async () => {
-      mockClient.agents.getRuns.mockResolvedValue(mockTimeseries);
+      mockClient.agents.getRuns.mockResolvedValue(ok(mockTimeseries));
 
       const result = await callTool({
         name: 'get_agent_runs',
@@ -67,7 +68,7 @@ describe('agent tools', () => {
     });
 
     it('forwards period_hours and interval_hours', async () => {
-      mockClient.agents.getRuns.mockResolvedValue(mockTimeseries);
+      mockClient.agents.getRuns.mockResolvedValue(ok(mockTimeseries));
 
       await callTool({
         name: 'get_agent_runs',
@@ -81,7 +82,13 @@ describe('agent tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.agents.getRuns.mockRejectedValue(new Error('API error'));
+      mockClient.agents.getRuns.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'get_agent_runs',
@@ -94,7 +101,7 @@ describe('agent tools', () => {
 
   describe('get_agent_duration', () => {
     it('returns a timeseries of avg/p95 duration', async () => {
-      mockClient.agents.getDuration.mockResolvedValue(mockDurationSeries);
+      mockClient.agents.getDuration.mockResolvedValue(ok(mockDurationSeries));
 
       const result = await callTool({
         name: 'get_agent_duration',
@@ -108,7 +115,13 @@ describe('agent tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.agents.getDuration.mockRejectedValue(new Error('API error'));
+      mockClient.agents.getDuration.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'get_agent_duration',
@@ -121,7 +134,7 @@ describe('agent tools', () => {
 
   describe('get_agent_models_by_calls', () => {
     it('returns a breakdown of LLM calls by model', async () => {
-      mockClient.agents.getModelsByCalls.mockResolvedValue(mockBreakdown);
+      mockClient.agents.getModelsByCalls.mockResolvedValue(ok(mockBreakdown));
 
       const result = await callTool({
         name: 'get_agent_models_by_calls',
@@ -134,7 +147,7 @@ describe('agent tools', () => {
     });
 
     it('forwards limit and period_hours', async () => {
-      mockClient.agents.getModelsByCalls.mockResolvedValue(mockBreakdown);
+      mockClient.agents.getModelsByCalls.mockResolvedValue(ok(mockBreakdown));
 
       await callTool({
         name: 'get_agent_models_by_calls',
@@ -148,8 +161,12 @@ describe('agent tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.agents.getModelsByCalls.mockRejectedValue(
-        new Error('API error'),
+      mockClient.agents.getModelsByCalls.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
       );
 
       const result = await callTool({
@@ -163,7 +180,7 @@ describe('agent tools', () => {
 
   describe('get_agent_models_by_tokens', () => {
     it('returns a breakdown of tokens by model', async () => {
-      mockClient.agents.getModelsByTokens.mockResolvedValue(mockBreakdown);
+      mockClient.agents.getModelsByTokens.mockResolvedValue(ok(mockBreakdown));
 
       const result = await callTool({
         name: 'get_agent_models_by_tokens',
@@ -178,8 +195,12 @@ describe('agent tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.agents.getModelsByTokens.mockRejectedValue(
-        new Error('API error'),
+      mockClient.agents.getModelsByTokens.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
       );
 
       const result = await callTool({
@@ -193,9 +214,9 @@ describe('agent tools', () => {
 
   describe('get_agent_tools', () => {
     it('returns a breakdown of tool calls by tool', async () => {
-      mockClient.agents.getTools.mockResolvedValue([
-        { label: 'search', value: 4 },
-      ]);
+      mockClient.agents.getTools.mockResolvedValue(
+        ok([{ label: 'search', value: 4 }]),
+      );
 
       const result = await callTool({
         name: 'get_agent_tools',
@@ -208,7 +229,13 @@ describe('agent tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.agents.getTools.mockRejectedValue(new Error('API error'));
+      mockClient.agents.getTools.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'get_agent_tools',
@@ -221,7 +248,7 @@ describe('agent tools', () => {
 
   describe('list_agent_traces', () => {
     it('returns paginated agent traces', async () => {
-      mockClient.agents.getTraces.mockResolvedValue(mockTracesPage);
+      mockClient.agents.getTraces.mockResolvedValue(ok(mockTracesPage));
 
       const result = await callTool({
         name: 'list_agent_traces',
@@ -239,7 +266,7 @@ describe('agent tools', () => {
     });
 
     it('forwards pagination options', async () => {
-      mockClient.agents.getTraces.mockResolvedValue(mockTracesPage);
+      mockClient.agents.getTraces.mockResolvedValue(ok(mockTracesPage));
 
       await callTool({
         name: 'list_agent_traces',
@@ -253,7 +280,13 @@ describe('agent tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.agents.getTraces.mockRejectedValue(new Error('API error'));
+      mockClient.agents.getTraces.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'list_agent_traces',

--- a/packages/mcp/tests/tools/alerts.test.ts
+++ b/packages/mcp/tests/tools/alerts.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, ok } from '../setup.js';
 
 describe('alert tools', () => {
   let mockClient: any;
@@ -35,7 +35,7 @@ describe('alert tools', () => {
           updated_at: '2024-01-01T00:00:00Z',
         },
       ];
-      mockClient.alertIntegrations.list.mockResolvedValue(mockChannels);
+      mockClient.alertIntegrations.list.mockResolvedValue(ok(mockChannels));
 
       const result = await callTool({
         name: 'list_alert_channels',
@@ -52,7 +52,7 @@ describe('alert tools', () => {
   describe('test_alert_channel', () => {
     it('sends a test notification to the channel', async () => {
       const mockResponse = { success: true, message: 'Test notification sent' };
-      mockClient.alertIntegrations.test.mockResolvedValue(mockResponse);
+      mockClient.alertIntegrations.test.mockResolvedValue(ok(mockResponse));
 
       const result = await callTool({
         name: 'test_alert_channel',
@@ -79,7 +79,7 @@ describe('alert tools', () => {
           updated_at: '2024-01-01T00:00:00Z',
         },
       ];
-      mockClient.alertRules.list.mockResolvedValue(mockRules);
+      mockClient.alertRules.list.mockResolvedValue(ok(mockRules));
 
       const result = await callTool({
         name: 'list_alert_rules',

--- a/packages/mcp/tests/tools/events.test.ts
+++ b/packages/mcp/tests/tools/events.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, ok } from '../setup.js';
 
 describe('event tools', () => {
   let mockClient: any;
@@ -35,7 +35,7 @@ describe('event tools', () => {
         next_cursor: null,
         has_more: false,
       };
-      mockClient.events.list.mockResolvedValue(mockData);
+      mockClient.events.list.mockResolvedValue(ok(mockData));
 
       const result = await callTool({
         name: 'list_events',
@@ -61,7 +61,7 @@ describe('event tools', () => {
         platform: 'javascript',
         data: { exception: { values: [{ type: 'TypeError', value: 'oops' }] } },
       };
-      mockClient.events.get.mockResolvedValue(mockEvent);
+      mockClient.events.get.mockResolvedValue(ok(mockEvent));
 
       const result = await callTool({
         name: 'get_event',

--- a/packages/mcp/tests/tools/issues.test.ts
+++ b/packages/mcp/tests/tools/issues.test.ts
@@ -1,6 +1,5 @@
-import { NotFoundError, RateLimitError } from '@rustrak/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, fail, ok } from '../setup.js';
 
 describe('issue tools', () => {
   let mockClient: any;
@@ -62,7 +61,7 @@ describe('issue tools', () => {
         page: 1,
         per_page: 25,
       };
-      mockClient.issues.list.mockResolvedValue(mockData);
+      mockClient.issues.list.mockResolvedValue(ok(mockData));
 
       const result = await callTool({
         name: 'list_issues',
@@ -94,7 +93,7 @@ describe('issue tools', () => {
         last_seen: '2024-01-01T00:00:00Z',
         project_id: 1,
       };
-      mockClient.issues.updateState.mockResolvedValue(mockIssue);
+      mockClient.issues.updateState.mockResolvedValue(ok(mockIssue));
 
       const result = await callTool({
         name: 'resolve_issue',
@@ -112,8 +111,12 @@ describe('issue tools', () => {
 
   describe('error handling', () => {
     it('returns isError: true on 404', async () => {
-      mockClient.issues.get.mockRejectedValue(
-        new NotFoundError('Resource not found: issue-xyz'),
+      mockClient.issues.get.mockResolvedValue(
+        fail({
+          kind: 'not_found',
+          status: 404,
+          message: 'Resource not found: issue-xyz',
+        }),
       );
 
       const result = await callTool({
@@ -126,8 +129,13 @@ describe('issue tools', () => {
     });
 
     it('returns isError: true on 429 rate limit', async () => {
-      mockClient.issues.list.mockRejectedValue(
-        new RateLimitError('Rate limit exceeded', 60),
+      mockClient.issues.list.mockResolvedValue(
+        fail({
+          kind: 'rate_limited',
+          status: 429,
+          message: 'Rate limit exceeded',
+          retryAfter: 60,
+        }),
       );
 
       const result = await callTool({
@@ -140,7 +148,9 @@ describe('issue tools', () => {
     });
 
     it('forwards the q search parameter', async () => {
-      mockClient.issues.list.mockResolvedValue({ items: [], total_count: 0 });
+      mockClient.issues.list.mockResolvedValue(
+        ok({ items: [], total_count: 0 }),
+      );
       await callTool({
         name: 'list_issues',
         arguments: { project_id: 1, q: 'TypeError' },
@@ -156,7 +166,9 @@ describe('issue tools', () => {
 
   describe('issue status & assignment (#165)', () => {
     it('update_issue_status sets canonical status + priority', async () => {
-      mockClient.issues.updateState.mockResolvedValue({ status: 'resolved' });
+      mockClient.issues.updateState.mockResolvedValue(
+        ok({ status: 'resolved' }),
+      );
       const result = await callTool({
         name: 'update_issue_status',
         arguments: {
@@ -174,7 +186,9 @@ describe('issue tools', () => {
     });
 
     it('update_issue_status supports resolvedInNextRelease', async () => {
-      mockClient.issues.updateState.mockResolvedValue({ status: 'resolved' });
+      mockClient.issues.updateState.mockResolvedValue(
+        ok({ status: 'resolved' }),
+      );
       await callTool({
         name: 'update_issue_status',
         arguments: {
@@ -190,7 +204,7 @@ describe('issue tools', () => {
     });
 
     it('assign_issue assigns to a user', async () => {
-      mockClient.issues.updateState.mockResolvedValue({ assigned_to: 7 });
+      mockClient.issues.updateState.mockResolvedValue(ok({ assigned_to: 7 }));
       await callTool({
         name: 'assign_issue',
         arguments: { project_id: 1, issue_id: 'abc', assigned_to: 7 },
@@ -204,7 +218,7 @@ describe('issue tools', () => {
 
   describe('bulk operations (#165)', () => {
     it('bulk_update_issues forwards ids + status', async () => {
-      mockClient.issues.bulkUpdate.mockResolvedValue({ updated: 2 });
+      mockClient.issues.bulkUpdate.mockResolvedValue(ok({ updated: 2 }));
       const result = await callTool({
         name: 'bulk_update_issues',
         arguments: { project_id: 1, ids: ['a', 'b'], status: 'resolved' },
@@ -218,7 +232,7 @@ describe('issue tools', () => {
     });
 
     it('bulk_delete_issues forwards ids', async () => {
-      mockClient.issues.bulkDelete.mockResolvedValue({ deleted: 2 });
+      mockClient.issues.bulkDelete.mockResolvedValue(ok({ deleted: 2 }));
       await callTool({
         name: 'bulk_delete_issues',
         arguments: { project_id: 1, ids: ['a', 'b'] },
@@ -231,7 +245,7 @@ describe('issue tools', () => {
 
   describe('read sub-resources (#165)', () => {
     it('get_issue_hashes', async () => {
-      mockClient.issues.getHashes.mockResolvedValue([{ id: 1 }]);
+      mockClient.issues.getHashes.mockResolvedValue(ok([{ id: 1 }]));
       const result = await callTool({
         name: 'get_issue_hashes',
         arguments: { project_id: 1, issue_id: 'abc' },
@@ -242,7 +256,7 @@ describe('issue tools', () => {
 
     it('get_issue_tag_values forwards key', async () => {
       // Bare list, one entry per value (Sentry-compatible shape).
-      mockClient.issues.getTagValues.mockResolvedValue([]);
+      mockClient.issues.getTagValues.mockResolvedValue(ok([]));
       await callTool({
         name: 'get_issue_tag_values',
         arguments: { project_id: 1, issue_id: 'abc', key: 'browser' },
@@ -255,10 +269,12 @@ describe('issue tools', () => {
     });
 
     it('get_issue_aggregates', async () => {
-      mockClient.issues.getAggregates.mockResolvedValue({
-        user_count: 2,
-        tags: [],
-      });
+      mockClient.issues.getAggregates.mockResolvedValue(
+        ok({
+          user_count: 2,
+          tags: [],
+        }),
+      );
       await callTool({
         name: 'get_issue_aggregates',
         arguments: { project_id: 1, issue_id: 'abc' },
@@ -267,7 +283,7 @@ describe('issue tools', () => {
     });
 
     it('get_issue_stats forwards window', async () => {
-      mockClient.issues.getStats.mockResolvedValue({ data: [] });
+      mockClient.issues.getStats.mockResolvedValue(ok({ data: [] }));
       await callTool({
         name: 'get_issue_stats',
         arguments: { project_id: 1, issue_id: 'abc', window: '30d' },
@@ -276,7 +292,7 @@ describe('issue tools', () => {
     });
 
     it('get_issue_activity', async () => {
-      mockClient.issues.getActivity.mockResolvedValue([]);
+      mockClient.issues.getActivity.mockResolvedValue(ok([]));
       await callTool({
         name: 'get_issue_activity',
         arguments: { project_id: 1, issue_id: 'abc' },
@@ -287,7 +303,7 @@ describe('issue tools', () => {
 
   describe('social tools (#165)', () => {
     it('comment_on_issue', async () => {
-      mockClient.issues.addComment.mockResolvedValue({ type: 'note' });
+      mockClient.issues.addComment.mockResolvedValue(ok({ type: 'note' }));
       await callTool({
         name: 'comment_on_issue',
         arguments: { project_id: 1, issue_id: 'abc', text: 'hi' },
@@ -298,7 +314,9 @@ describe('issue tools', () => {
     });
 
     it('bookmark_issue', async () => {
-      mockClient.issues.setBookmark.mockResolvedValue({ is_bookmarked: true });
+      mockClient.issues.setBookmark.mockResolvedValue(
+        ok({ is_bookmarked: true }),
+      );
       await callTool({
         name: 'bookmark_issue',
         arguments: { project_id: 1, issue_id: 'abc', enabled: true },
@@ -311,9 +329,11 @@ describe('issue tools', () => {
     });
 
     it('subscribe_issue', async () => {
-      mockClient.issues.setSubscription.mockResolvedValue({
-        is_subscribed: false,
-      });
+      mockClient.issues.setSubscription.mockResolvedValue(
+        ok({
+          is_subscribed: false,
+        }),
+      );
       await callTool({
         name: 'subscribe_issue',
         arguments: { project_id: 1, issue_id: 'abc', enabled: false },
@@ -326,7 +346,7 @@ describe('issue tools', () => {
     });
 
     it('mark_issue_seen', async () => {
-      mockClient.issues.markSeen.mockResolvedValue({ has_seen: true });
+      mockClient.issues.markSeen.mockResolvedValue(ok({ has_seen: true }));
       await callTool({
         name: 'mark_issue_seen',
         arguments: { project_id: 1, issue_id: 'abc' },
@@ -335,7 +355,7 @@ describe('issue tools', () => {
     });
 
     it('list_user_reports', async () => {
-      mockClient.issues.listUserReports.mockResolvedValue([]);
+      mockClient.issues.listUserReports.mockResolvedValue(ok([]));
       await callTool({
         name: 'list_user_reports',
         arguments: { project_id: 1, issue_id: 'abc' },
@@ -344,7 +364,7 @@ describe('issue tools', () => {
     });
 
     it('submit_user_report', async () => {
-      mockClient.issues.createUserReport.mockResolvedValue({ id: 'r1' });
+      mockClient.issues.createUserReport.mockResolvedValue(ok({ id: 'r1' }));
       await callTool({
         name: 'submit_user_report',
         arguments: {

--- a/packages/mcp/tests/tools/logs.test.ts
+++ b/packages/mcp/tests/tools/logs.test.ts
@@ -1,5 +1,6 @@
+import { SERVER_ERROR_MESSAGE } from '@rustrak/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, fail, ok } from '../setup.js';
 
 describe('log tools', () => {
   let mockClient: any;
@@ -42,7 +43,7 @@ describe('log tools', () => {
 
   describe('list_logs', () => {
     it('returns a log page for a project', async () => {
-      mockClient.logs.list.mockResolvedValue(mockLogPage);
+      mockClient.logs.list.mockResolvedValue(ok(mockLogPage));
 
       const result = await callTool({
         name: 'list_logs',
@@ -58,7 +59,7 @@ describe('log tools', () => {
     });
 
     it('forwards offset pagination and filters', async () => {
-      mockClient.logs.list.mockResolvedValue(mockLogPage);
+      mockClient.logs.list.mockResolvedValue(ok(mockLogPage));
 
       await callTool({
         name: 'list_logs',
@@ -83,7 +84,13 @@ describe('log tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.logs.list.mockRejectedValue(new Error('API error'));
+      mockClient.logs.list.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'list_logs',
@@ -91,7 +98,7 @@ describe('log tools', () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Unexpected error');
+      expect(result.content[0].text).toContain(SERVER_ERROR_MESSAGE);
     });
   });
 });

--- a/packages/mcp/tests/tools/projects.test.ts
+++ b/packages/mcp/tests/tools/projects.test.ts
@@ -1,6 +1,5 @@
-import { NotFoundError } from '@rustrak/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, fail, ok } from '../setup.js';
 
 describe('project tools', () => {
   let mockClient: any;
@@ -41,7 +40,7 @@ describe('project tools', () => {
         page: 1,
         per_page: 25,
       };
-      mockClient.projects.list.mockResolvedValue(mockData);
+      mockClient.projects.list.mockResolvedValue(ok(mockData));
 
       const result = await callTool({ name: 'list_projects', arguments: {} });
 
@@ -52,8 +51,12 @@ describe('project tools', () => {
     });
 
     it('returns isError on not found', async () => {
-      mockClient.projects.list.mockRejectedValue(
-        new NotFoundError('Resource not found: projects'),
+      mockClient.projects.list.mockResolvedValue(
+        fail({
+          kind: 'not_found',
+          status: 404,
+          message: 'Resource not found: projects',
+        }),
       );
 
       const result = await callTool({ name: 'list_projects', arguments: {} });
@@ -72,7 +75,7 @@ describe('project tools', () => {
         created_at: '2024-01-01T00:00:00Z',
         updated_at: '2024-01-01T00:00:00Z',
       };
-      mockClient.projects.get.mockResolvedValue(mockProject);
+      mockClient.projects.get.mockResolvedValue(ok(mockProject));
 
       const result = await callTool({
         name: 'get_project',
@@ -96,7 +99,7 @@ describe('project tools', () => {
         created_at: '2024-01-01T00:00:00Z',
         updated_at: '2024-01-01T00:00:00Z',
       };
-      mockClient.projects.create.mockResolvedValue(mockProject);
+      mockClient.projects.create.mockResolvedValue(ok(mockProject));
 
       const result = await callTool({
         name: 'create_project',

--- a/packages/mcp/tests/tools/sessions.test.ts
+++ b/packages/mcp/tests/tools/sessions.test.ts
@@ -1,5 +1,6 @@
+import { SERVER_ERROR_MESSAGE } from '@rustrak/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, fail, ok } from '../setup.js';
 
 describe('session tools', () => {
   let mockClient: any;
@@ -42,7 +43,7 @@ describe('session tools', () => {
 
   describe('get_release_health', () => {
     it('returns release health for a project', async () => {
-      mockClient.sessions.stats.mockResolvedValue(mockReleaseHealth);
+      mockClient.sessions.stats.mockResolvedValue(ok(mockReleaseHealth));
 
       const result = await callTool({
         name: 'get_release_health',
@@ -63,7 +64,7 @@ describe('session tools', () => {
     });
 
     it('passes period when provided', async () => {
-      mockClient.sessions.stats.mockResolvedValue(mockReleaseHealth);
+      mockClient.sessions.stats.mockResolvedValue(ok(mockReleaseHealth));
 
       await callTool({
         name: 'get_release_health',
@@ -78,7 +79,7 @@ describe('session tools', () => {
     });
 
     it('passes pagination params when provided', async () => {
-      mockClient.sessions.stats.mockResolvedValue(mockReleaseHealth);
+      mockClient.sessions.stats.mockResolvedValue(ok(mockReleaseHealth));
 
       await callTool({
         name: 'get_release_health',
@@ -93,7 +94,13 @@ describe('session tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.sessions.stats.mockRejectedValue(new Error('API error'));
+      mockClient.sessions.stats.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'get_release_health',
@@ -101,7 +108,7 @@ describe('session tools', () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Unexpected error');
+      expect(result.content[0].text).toContain(SERVER_ERROR_MESSAGE);
     });
   });
 });

--- a/packages/mcp/tests/tools/spans.test.ts
+++ b/packages/mcp/tests/tools/spans.test.ts
@@ -1,5 +1,6 @@
+import { SERVER_ERROR_MESSAGE } from '@rustrak/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, fail, ok } from '../setup.js';
 
 describe('span tools', () => {
   let mockClient: any;
@@ -50,7 +51,7 @@ describe('span tools', () => {
 
   describe('list_spans', () => {
     it('returns a span page for a project', async () => {
-      mockClient.spans.list.mockResolvedValue(mockSpanPage);
+      mockClient.spans.list.mockResolvedValue(ok(mockSpanPage));
 
       const result = await callTool({
         name: 'list_spans',
@@ -65,7 +66,7 @@ describe('span tools', () => {
     });
 
     it('forwards pagination and filters', async () => {
-      mockClient.spans.list.mockResolvedValue(mockSpanPage);
+      mockClient.spans.list.mockResolvedValue(ok(mockSpanPage));
 
       await callTool({
         name: 'list_spans',
@@ -94,7 +95,13 @@ describe('span tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.spans.list.mockRejectedValue(new Error('API error'));
+      mockClient.spans.list.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'list_spans',
@@ -102,7 +109,7 @@ describe('span tools', () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Unexpected error');
+      expect(result.content[0].text).toContain(SERVER_ERROR_MESSAGE);
     });
   });
 });

--- a/packages/mcp/tests/tools/stats.test.ts
+++ b/packages/mcp/tests/tools/stats.test.ts
@@ -1,5 +1,6 @@
+import { SERVER_ERROR_MESSAGE } from '@rustrak/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, fail, ok } from '../setup.js';
 
 describe('stats tools', () => {
   let mockClient: any;
@@ -49,7 +50,7 @@ describe('stats tools', () => {
 
   describe('get_error_volume', () => {
     it('returns event volume split by severity', async () => {
-      mockClient.stats.timeseries.mockResolvedValue(mockTimeseries);
+      mockClient.stats.timeseries.mockResolvedValue(ok(mockTimeseries));
 
       const result = await callTool({
         name: 'get_error_volume',
@@ -71,7 +72,7 @@ describe('stats tools', () => {
     });
 
     it('keeps zero-filled buckets rather than dropping them', async () => {
-      mockClient.stats.timeseries.mockResolvedValue(mockTimeseries);
+      mockClient.stats.timeseries.mockResolvedValue(ok(mockTimeseries));
 
       const result = await callTool({
         name: 'get_error_volume',
@@ -83,7 +84,7 @@ describe('stats tools', () => {
     });
 
     it('passes period and interval when provided', async () => {
-      mockClient.stats.timeseries.mockResolvedValue(mockTimeseries);
+      mockClient.stats.timeseries.mockResolvedValue(ok(mockTimeseries));
 
       await callTool({
         name: 'get_error_volume',
@@ -94,7 +95,13 @@ describe('stats tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.stats.timeseries.mockRejectedValue(new Error('API error'));
+      mockClient.stats.timeseries.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'get_error_volume',
@@ -102,13 +109,13 @@ describe('stats tools', () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Unexpected error');
+      expect(result.content[0].text).toContain(SERVER_ERROR_MESSAGE);
     });
   });
 
   describe('get_project_stats', () => {
     it('returns counters with their previous-period comparison', async () => {
-      mockClient.stats.summary.mockResolvedValue(mockSummary);
+      mockClient.stats.summary.mockResolvedValue(ok(mockSummary));
 
       const result = await callTool({
         name: 'get_project_stats',
@@ -125,12 +132,14 @@ describe('stats tools', () => {
     });
 
     it('omits the period for an all-time request', async () => {
-      mockClient.stats.summary.mockResolvedValue({
-        period_hours: null,
-        events: { current: 5000, previous: null },
-        new_issues: { current: 120, previous: null },
-        open_issues: 40,
-      });
+      mockClient.stats.summary.mockResolvedValue(
+        ok({
+          period_hours: null,
+          events: { current: 5000, previous: null },
+          new_issues: { current: 120, previous: null },
+          open_issues: 40,
+        }),
+      );
 
       const result = await callTool({
         name: 'get_project_stats',
@@ -144,7 +153,13 @@ describe('stats tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.stats.summary.mockRejectedValue(new Error('API error'));
+      mockClient.stats.summary.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'get_project_stats',
@@ -152,7 +167,7 @@ describe('stats tools', () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Unexpected error');
+      expect(result.content[0].text).toContain(SERVER_ERROR_MESSAGE);
     });
   });
 });

--- a/packages/mcp/tests/tools/storage.test.ts
+++ b/packages/mcp/tests/tools/storage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, ok } from '../setup.js';
 
 describe('storage tools', () => {
   let mockClient: any;
@@ -59,7 +59,7 @@ describe('storage tools', () => {
 
   describe('get_storage_summary', () => {
     it('returns the instance-wide storage summary', async () => {
-      mockClient.storage.getSummary.mockResolvedValue(mockSummary);
+      mockClient.storage.getSummary.mockResolvedValue(ok(mockSummary));
 
       const result = await callTool({
         name: 'get_storage_summary',
@@ -75,7 +75,7 @@ describe('storage tools', () => {
 
   describe('get_storage_by_project', () => {
     it('returns the per-project breakdown', async () => {
-      mockClient.storage.getProjects.mockResolvedValue(mockProjects);
+      mockClient.storage.getProjects.mockResolvedValue(ok(mockProjects));
 
       const result = await callTool({
         name: 'get_storage_by_project',
@@ -91,7 +91,7 @@ describe('storage tools', () => {
 
   describe('preview_storage_cleanup', () => {
     it('forwards older_than_days and project scope, returns dry-run counts', async () => {
-      mockClient.storage.previewCleanup.mockResolvedValue(mockCounts);
+      mockClient.storage.previewCleanup.mockResolvedValue(ok(mockCounts));
 
       const result = await callTool({
         name: 'preview_storage_cleanup',
@@ -108,7 +108,7 @@ describe('storage tools', () => {
     });
 
     it('forwards the data-type selection flags', async () => {
-      mockClient.storage.previewCleanup.mockResolvedValue(mockCounts);
+      mockClient.storage.previewCleanup.mockResolvedValue(ok(mockCounts));
 
       await callTool({
         name: 'preview_storage_cleanup',
@@ -143,7 +143,7 @@ describe('storage tools', () => {
     });
 
     it('runs the destructive cleanup when confirm is true', async () => {
-      mockClient.storage.executeCleanup.mockResolvedValue(mockCounts);
+      mockClient.storage.executeCleanup.mockResolvedValue(ok(mockCounts));
 
       const result = await callTool({
         name: 'execute_storage_cleanup',
@@ -160,7 +160,7 @@ describe('storage tools', () => {
     });
 
     it('forwards the data-type selection flags when confirmed', async () => {
-      mockClient.storage.executeCleanup.mockResolvedValue(mockCounts);
+      mockClient.storage.executeCleanup.mockResolvedValue(ok(mockCounts));
 
       await callTool({
         name: 'execute_storage_cleanup',
@@ -186,10 +186,12 @@ describe('storage tools', () => {
 
   describe('preview_storage_source_maps_gc', () => {
     it('returns the orphaned files and bytes a GC would reclaim without deleting', async () => {
-      mockClient.storage.previewGcSourceMaps.mockResolvedValue({
-        files_removed: 4,
-        bytes_freed: 81920,
-      });
+      mockClient.storage.previewGcSourceMaps.mockResolvedValue(
+        ok({
+          files_removed: 4,
+          bytes_freed: 81920,
+        }),
+      );
 
       const result = await callTool({
         name: 'preview_storage_source_maps_gc',
@@ -216,10 +218,12 @@ describe('storage tools', () => {
     });
 
     it('returns the orphaned files removed and bytes freed when confirm is true', async () => {
-      mockClient.storage.gcSourceMaps.mockResolvedValue({
-        files_removed: 4,
-        bytes_freed: 81920,
-      });
+      mockClient.storage.gcSourceMaps.mockResolvedValue(
+        ok({
+          files_removed: 4,
+          bytes_freed: 81920,
+        }),
+      );
 
       const result = await callTool({
         name: 'gc_storage_source_maps',

--- a/packages/mcp/tests/tools/team.test.ts
+++ b/packages/mcp/tests/tools/team.test.ts
@@ -1,5 +1,6 @@
+import { SERVER_ERROR_MESSAGE } from '@rustrak/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, fail, ok } from '../setup.js';
 
 describe('team tools', () => {
   let mockClient: any;
@@ -34,9 +35,9 @@ describe('team tools', () => {
 
   describe('list_team_members', () => {
     it('returns the roster', async () => {
-      mockClient.team.list.mockResolvedValue([
-        { id: 1, email: 'a@x.com', role: 'admin', is_active: true },
-      ]);
+      mockClient.team.list.mockResolvedValue(
+        ok([{ id: 1, email: 'a@x.com', role: 'admin', is_active: true }]),
+      );
 
       const result = await callTool({
         name: 'list_team_members',
@@ -51,7 +52,7 @@ describe('team tools', () => {
 
   describe('update_member_role', () => {
     it('updates a global role', async () => {
-      mockClient.team.updateRole.mockResolvedValue(undefined);
+      mockClient.team.updateRole.mockResolvedValue(ok(undefined));
 
       const result = await callTool({
         name: 'update_member_role',
@@ -65,7 +66,7 @@ describe('team tools', () => {
 
   describe('remove_team_member', () => {
     it('removes a user', async () => {
-      mockClient.team.remove.mockResolvedValue(undefined);
+      mockClient.team.remove.mockResolvedValue(ok(undefined));
 
       const result = await callTool({
         name: 'remove_team_member',
@@ -76,16 +77,35 @@ describe('team tools', () => {
       expect(result.content[0]?.text).toMatch(/removed/i);
       expect(mockClient.team.remove).toHaveBeenCalledWith(5);
     });
+
+    it('does not report success when the void call failed', async () => {
+      // A `Result<void>` failure is a value, so it is trivially ignorable.
+      // Reporting `User 5 removed.` after a 403 is the regression.
+      mockClient.team.remove.mockResolvedValue(
+        fail({ kind: 'forbidden', status: 403, message: 'Not allowed' }),
+      );
+
+      const result = await callTool({
+        name: 'remove_team_member',
+        arguments: { user_id: 5 },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).not.toMatch(/removed/i);
+      expect(result.content[0]?.text).toContain('Not allowed');
+    });
   });
 
   describe('create_invitation', () => {
     it('creates an invitation and returns the token', async () => {
-      mockClient.invitations.create.mockResolvedValue({
-        token: 'tok_abc',
-        email: 'b@x.com',
-        role: 'member',
-        status: 'pending',
-      });
+      mockClient.invitations.create.mockResolvedValue(
+        ok({
+          token: 'tok_abc',
+          email: 'b@x.com',
+          role: 'member',
+          status: 'pending',
+        }),
+      );
 
       const result = await callTool({
         name: 'create_invitation',
@@ -104,9 +124,9 @@ describe('team tools', () => {
 
   describe('list_invitations', () => {
     it('lists invitations', async () => {
-      mockClient.invitations.list.mockResolvedValue([
-        { token: 'tok_abc', email: 'b@x.com', status: 'pending' },
-      ]);
+      mockClient.invitations.list.mockResolvedValue(
+        ok([{ token: 'tok_abc', email: 'b@x.com', status: 'pending' }]),
+      );
 
       const result = await callTool({
         name: 'list_invitations',
@@ -121,7 +141,7 @@ describe('team tools', () => {
 
   describe('revoke_invitation', () => {
     it('revokes an invitation by token', async () => {
-      mockClient.invitations.revoke.mockResolvedValue(undefined);
+      mockClient.invitations.revoke.mockResolvedValue(ok(undefined));
 
       const result = await callTool({
         name: 'revoke_invitation',
@@ -135,9 +155,9 @@ describe('team tools', () => {
 
   describe('list_project_members', () => {
     it('lists project members', async () => {
-      mockClient.members.list.mockResolvedValue([
-        { user_id: 2, email: 'c@x.com', role: 'editor' },
-      ]);
+      mockClient.members.list.mockResolvedValue(
+        ok([{ user_id: 2, email: 'c@x.com', role: 'editor' }]),
+      );
 
       const result = await callTool({
         name: 'list_project_members',
@@ -153,7 +173,7 @@ describe('team tools', () => {
 
   describe('set_project_member', () => {
     it('upserts a project member', async () => {
-      mockClient.members.upsert.mockResolvedValue(undefined);
+      mockClient.members.upsert.mockResolvedValue(ok(undefined));
 
       const result = await callTool({
         name: 'set_project_member',
@@ -170,7 +190,7 @@ describe('team tools', () => {
 
   describe('remove_project_member', () => {
     it('removes a project member', async () => {
-      mockClient.members.remove.mockResolvedValue(undefined);
+      mockClient.members.remove.mockResolvedValue(ok(undefined));
 
       const result = await callTool({
         name: 'remove_project_member',
@@ -183,8 +203,14 @@ describe('team tools', () => {
   });
 
   describe('error handling', () => {
-    it('returns isError when the client throws', async () => {
-      mockClient.team.list.mockRejectedValue(new Error('boom'));
+    it('returns isError when the client reports a failure', async () => {
+      mockClient.team.list.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'list_team_members',

--- a/packages/mcp/tests/tools/tokens.test.ts
+++ b/packages/mcp/tests/tools/tokens.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, ok } from '../setup.js';
 
 describe('token tools', () => {
   let mockClient: any;
@@ -39,7 +39,7 @@ describe('token tools', () => {
           created_at: '2024-01-01T00:00:00Z',
         },
       ];
-      mockClient.tokens.list.mockResolvedValue(mockTokens);
+      mockClient.tokens.list.mockResolvedValue(ok(mockTokens));
 
       const result = await callTool({ name: 'list_tokens', arguments: {} });
 
@@ -58,7 +58,7 @@ describe('token tools', () => {
         description: 'CI token',
         created_at: '2024-01-01T00:00:00Z',
       };
-      mockClient.tokens.get.mockResolvedValue(mockToken);
+      mockClient.tokens.get.mockResolvedValue(ok(mockToken));
 
       const result = await callTool({
         name: 'get_token',
@@ -82,7 +82,7 @@ describe('token tools', () => {
         token_prefix: 'full',
         created_at: '2024-01-01T00:00:00Z',
       };
-      mockClient.tokens.create.mockResolvedValue(mockCreated);
+      mockClient.tokens.create.mockResolvedValue(ok(mockCreated));
 
       const result = await callTool({
         name: 'create_token',
@@ -100,7 +100,7 @@ describe('token tools', () => {
 
   describe('revoke_token', () => {
     it('revokes (deletes) a token by ID', async () => {
-      mockClient.tokens.delete.mockResolvedValue(undefined);
+      mockClient.tokens.delete.mockResolvedValue(ok(undefined));
 
       const result = await callTool({
         name: 'revoke_token',

--- a/packages/mcp/tests/tools/transactions.test.ts
+++ b/packages/mcp/tests/tools/transactions.test.ts
@@ -1,5 +1,6 @@
+import { SERVER_ERROR_MESSAGE } from '@rustrak/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createTestEnv } from '../setup.js';
+import { createTestEnv, fail, ok } from '../setup.js';
 
 describe('transaction tools', () => {
   let mockClient: any;
@@ -91,7 +92,7 @@ describe('transaction tools', () => {
 
   describe('list_transactions', () => {
     it('returns a transaction page for a project', async () => {
-      mockClient.transactions.list.mockResolvedValue(mockTransactionPage);
+      mockClient.transactions.list.mockResolvedValue(ok(mockTransactionPage));
 
       const result = await callTool({
         name: 'list_transactions',
@@ -110,7 +111,7 @@ describe('transaction tools', () => {
     });
 
     it('forwards offset pagination and filters', async () => {
-      mockClient.transactions.list.mockResolvedValue(mockTransactionPage);
+      mockClient.transactions.list.mockResolvedValue(ok(mockTransactionPage));
 
       await callTool({
         name: 'list_transactions',
@@ -137,7 +138,13 @@ describe('transaction tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.transactions.list.mockRejectedValue(new Error('API error'));
+      mockClient.transactions.list.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'list_transactions',
@@ -145,13 +152,13 @@ describe('transaction tools', () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Unexpected error');
+      expect(result.content[0].text).toContain(SERVER_ERROR_MESSAGE);
     });
   });
 
   describe('get_transaction', () => {
     it('returns full transaction detail', async () => {
-      mockClient.transactions.get.mockResolvedValue(mockTransactionDetail);
+      mockClient.transactions.get.mockResolvedValue(ok(mockTransactionDetail));
 
       const result = await callTool({
         name: 'get_transaction',
@@ -172,7 +179,13 @@ describe('transaction tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.transactions.get.mockRejectedValue(new Error('API error'));
+      mockClient.transactions.get.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
+      );
 
       const result = await callTool({
         name: 'get_transaction',
@@ -180,13 +193,13 @@ describe('transaction tools', () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Unexpected error');
+      expect(result.content[0].text).toContain(SERVER_ERROR_MESSAGE);
     });
   });
 
   describe('get_transaction_stats', () => {
     it('returns aggregate stats per transaction group', async () => {
-      mockClient.transactions.getStats.mockResolvedValue(mockStats);
+      mockClient.transactions.getStats.mockResolvedValue(ok(mockStats));
 
       const result = await callTool({
         name: 'get_transaction_stats',
@@ -205,8 +218,12 @@ describe('transaction tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.transactions.getStats.mockRejectedValue(
-        new Error('API error'),
+      mockClient.transactions.getStats.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
       );
 
       const result = await callTool({
@@ -215,13 +232,13 @@ describe('transaction tools', () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Unexpected error');
+      expect(result.content[0].text).toContain(SERVER_ERROR_MESSAGE);
     });
   });
 
   describe('get_transaction_spans', () => {
     it('returns indexed spans for a transaction', async () => {
-      mockClient.transactions.getSpans.mockResolvedValue(mockSpans);
+      mockClient.transactions.getSpans.mockResolvedValue(ok(mockSpans));
 
       const result = await callTool({
         name: 'get_transaction_spans',
@@ -242,8 +259,12 @@ describe('transaction tools', () => {
     });
 
     it('returns error content on API failure', async () => {
-      mockClient.transactions.getSpans.mockRejectedValue(
-        new Error('API error'),
+      mockClient.transactions.getSpans.mockResolvedValue(
+        fail({
+          kind: 'server_error',
+          status: 500,
+          message: SERVER_ERROR_MESSAGE,
+        }),
       );
 
       const result = await callTool({
@@ -252,7 +273,7 @@ describe('transaction tools', () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Unexpected error');
+      expect(result.content[0].text).toContain(SERVER_ERROR_MESSAGE);
     });
   });
 });


### PR DESCRIPTION

> **Review-only PR — do not merge.** This is one slice of a stack that exists so
> each piece stays under Greptile's 100-file limit. The whole change merges
> through #220, which is the only one that is green on its own.
>
> Stack: #220 (integration) = 1 → 2 → 3 → 4 → 5 → 6

> **CI is still red here** — `webview-ui` is converted in slice 6. `@rustrak/mcp` itself is green from this commit on.

All 64 call sites. Every one was a `try`/`catch` calling `toMcpError(err: unknown)`; there is now no `try` anywhere in `packages/mcp/src`, because the client no longer throws and a catch there could only hide a programming error.

`toMcpError` switches on `kind` over the closed union, so it is total. Three renderers cover every site: `mcpJson`, `mcpDone` and `mcpRefusal`.

Worth a look: the 7 `Result<void>` calls. A failed `Result<void>` is a *value*, so ignoring it is silent — a tool that reported "deleted successfully" after a 403 would be worse than one that threw. They all go through `mcpDone`.

**31 files**, 124 tests.