### PR TITLE
feat(webview): give the failure surfaces a real screen instead of a bare card

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-ad10-p3b-consumers.md
+++ b/_bmad-output/implementation-artifacts/spec-ad10-p3b-consumers.md
@@ -108,9 +108,14 @@ The inventory's four-group split is the useful axis for the 78 webview sites: 62
 - `cd apps/server && cargo test` -- expected: exit 0, unchanged.
 - `pnpm run ci` -- expected: **exit 0**.
 
-**Manual checks:**
-- Stop the API, load a gated page, and confirm the page reports an outage rather than redirecting to login.
-- Create a project with a taken slug and confirm the slug input goes red with the app's own copy.
+**Manual checks:** both performed by Abian on 2026-07-27 against a local stack,
+and both passed. They are recorded here because no suite reaches either: the
+webview tests do not exercise a Server Action against a real API, so these two
+behaviours could regress silently.
+
+- [x] Stop the API, load a gated page, and confirm the page reports an outage rather than redirecting to login. Observed: the gated page stayed on its own URL and rendered the outage surface. The login loop this phase exists to prevent does not occur.
+- [x] Create a project with a taken slug and confirm the slug input goes red with the app's own copy. Observed: "Slug is already taken." on the input.
+- [x] The name variant, which is the fourth acceptance criterion and a different branch: a taken **name** while the slug was auto-derived must mark the name, not the read-only slug input. Observed: "Project name is already taken." on the name. This is the path that reads `applied.marked` to decide whether to switch the slug field to manual, so it is the one that proves the helper's return value is actually consumed rather than merely produced.
 
 ### Review Findings
 

--- a/apps/webview-ui/src/app/(main)/error.tsx
+++ b/apps/webview-ui/src/app/(main)/error.tsx
@@ -16,19 +16,29 @@ export default function MainError({ error, reset }: ErrorProps) {
     console.error('Application error:', error);
   }, [error]);
 
+  // No brand panel here, unlike `app/error.tsx`. This boundary renders *below*
+  // the header, which already carries the Rustrak mark and the navigation, so a
+  // second brand panel would compete with it and strand the user in a screen
+  // that looks like a logout.
   return (
-    <div className="flex-1 flex items-center justify-center p-4">
+    <div className="flex-1 flex items-center justify-center px-6 py-20">
       <div className="max-w-md w-full text-center space-y-6">
         <div className="flex justify-center">
-          <div className="size-16 rounded-full bg-destructive/10 flex items-center justify-center">
-            <AlertTriangle className="size-8 text-destructive" />
+          <div className="size-12 rounded-full bg-destructive/10 flex items-center justify-center">
+            <AlertTriangle
+              className="size-5 text-destructive"
+              aria-hidden="true"
+            />
           </div>
         </div>
 
         <div className="space-y-2">
-          <h1 className="text-2xl font-bold">Something went wrong</h1>
-          <p className="text-muted-foreground">
-            An error occurred while loading this page. Please try again.
+          <h1 className="text-xl font-bold tracking-tight">
+            This page could not be loaded
+          </h1>
+          <p className="text-muted-foreground text-sm leading-relaxed">
+            The failure happened while rendering, not in your data. Everything
+            else in the dashboard is still reachable from the header above.
           </p>
         </div>
 

--- a/apps/webview-ui/src/app/(main)/layout.tsx
+++ b/apps/webview-ui/src/app/(main)/layout.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
 import { getCurrentUser } from '@/actions/auth';
-import { ServiceUnavailable } from '@/components/service-unavailable';
+import { OutageScreen } from '@/components/outage-screen';
 import { UpdateBannerSlot } from '@/components/update-banner-slot';
 import { Header } from './header';
 
@@ -20,14 +20,10 @@ export default async function MainLayout({
     redirect('/auth/login');
   }
 
+  // Returned bare, with no wrapper: this is the one branch that renders no
+  // `Header`, so the screen owns the whole viewport and brings its own brand.
   if (session.state === 'unavailable') {
-    return (
-      <div className="min-h-screen flex flex-col">
-        <main className="flex-1">
-          <ServiceUnavailable error={session.error} />
-        </main>
-      </div>
-    );
+    return <OutageScreen error={session.error} />;
   }
 
   return (

--- a/apps/webview-ui/src/app/error.tsx
+++ b/apps/webview-ui/src/app/error.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import { useEffect } from 'react';
+import { ErrorScreen } from '@/components/error-screen';
 import { Button } from '@/components/ui/button';
 
 interface ErrorProps {
@@ -11,45 +12,31 @@ interface ErrorProps {
 
 export default function GlobalError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    // Log the error to console in development
     console.error('Application error:', error);
   }, [error]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4">
-      <div className="max-w-md w-full text-center space-y-6">
-        <div className="flex justify-center">
-          <div className="size-16 rounded-full bg-destructive/10 flex items-center justify-center">
-            <AlertTriangle className="size-8 text-destructive" />
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <h1 className="text-2xl font-bold">Something went wrong</h1>
-          <p className="text-muted-foreground">
-            An unexpected error occurred. Please try again.
-          </p>
-        </div>
-
-        {error.digest && (
-          <p className="text-xs text-muted-foreground font-mono">
-            Error ID: {error.digest}
-          </p>
-        )}
-
-        <div className="flex justify-center gap-4">
-          <Button onClick={reset} variant="default">
+    <ErrorScreen
+      headline="Something went wrong"
+      description="This page could not be rendered. The failure happened in the dashboard rather than in your data, which is untouched."
+      guidance="If it happens again after a reload, the error ID below is what identifies this specific failure in the logs."
+      detail={error.digest ? `Error ID: ${error.digest}` : null}
+      actions={
+        <>
+          <Button onClick={reset}>
             <RefreshCw className="mr-2 size-4" />
             Try again
           </Button>
           <Button
             variant="outline"
-            onClick={() => (window.location.href = '/projects')}
+            onClick={() => {
+              window.location.href = '/projects';
+            }}
           >
             Go to Projects
           </Button>
-        </div>
-      </div>
-    </div>
+        </>
+      }
+    />
   );
 }

--- a/apps/webview-ui/src/app/not-found.tsx
+++ b/apps/webview-ui/src/app/not-found.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ErrorScreen } from '@/components/error-screen';
+import { Button } from '@/components/ui/button';
+
+export const metadata: Metadata = {
+  title: 'Not found | Rustrak',
+};
+
+/**
+ * The one 404 for every route.
+ *
+ * It covers both an unmatched URL and every `notFound()` raised inside the
+ * app -- a project id that does not exist, a deleted issue, a release with no
+ * rows, or `LoadFailure` turning a `not_found` into the app's 404. Because it
+ * is the only one, it replaces the header for a signed-in reader too, which is
+ * why the action below is not decoration: it is the only way back.
+ */
+export default function NotFound() {
+  return (
+    <ErrorScreen
+      brandStatement="Nothing here"
+      brandDescription="Nothing failed on the way to this page. The server answered normally and simply had nothing at this address."
+      headline="Page not found"
+      description="This address does not match any page in this Rustrak instance."
+      guidance="If you followed a link from inside Rustrak, the project, issue or event it pointed at may have been deleted since."
+      actions={
+        <Button nativeButton={false} render={<Link href="/projects" />}>
+          Go to Projects
+        </Button>
+      }
+    />
+  );
+}

--- a/apps/webview-ui/src/app/page.tsx
+++ b/apps/webview-ui/src/app/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation';
 import { getCurrentUser } from '@/actions/auth';
-import { ServiceUnavailable } from '@/components/service-unavailable';
+import { OutageScreen } from '@/components/outage-screen';
 
 export default async function Home() {
   const session = await getCurrentUser();
@@ -12,7 +12,7 @@ export default async function Home() {
   }
 
   if (session.state === 'unavailable') {
-    return <ServiceUnavailable error={session.error} />;
+    return <OutageScreen error={session.error} />;
   }
 
   redirect('/projects');

--- a/apps/webview-ui/src/components/error-screen.tsx
+++ b/apps/webview-ui/src/components/error-screen.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { RustrakLogoIcon } from '@/components/icons/rustrak-logo';
+import { APP_VERSION } from '@/lib/constants';
+
+/**
+ * The full-viewport failure screen.
+ *
+ * Deliberately the same shape as `/auth/login`: brand panel on the left,
+ * content on the right against `bg-card`. Both are pages the user meets with
+ * no header and no navigation, so they are the two places the app has to
+ * introduce itself rather than assume the chrome already did.
+ *
+ * This is **not** for a failure inside a page that otherwise rendered. A tile
+ * that could not load, or one panel of a release page, keeps the in-place card
+ * in `service-unavailable.tsx`: handing the whole viewport to a failed
+ * sub-request would hide the parts that did load.
+ */
+export function ErrorScreen({
+  headline,
+  description,
+  guidance,
+  detail,
+  actions,
+}: {
+  /** The one-line answer to "what happened", on the content side. */
+  headline: string;
+  /** One sentence saying what went wrong. */
+  description: string;
+  /** What the reader can do, when there is anything useful to say. */
+  guidance?: string | null;
+  /** Monospace footnote: an error id, a version, anything diagnostic. */
+  detail?: ReactNode;
+  /** Buttons. */
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen flex">
+      {/* Left panel, decorative. Hidden below lg, exactly like the login. */}
+      <div className="hidden lg:flex lg:w-1/2 bg-background flex-col justify-between p-12 relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_hsl(var(--card)),_transparent_50%)]" />
+        <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-background to-transparent z-10" />
+
+        <Link href="/" className="relative z-20 flex items-center gap-2 w-fit">
+          <RustrakLogoIcon className="size-8" />
+          <span className="text-lg font-extrabold tracking-tight uppercase">
+            Rustrak
+          </span>
+        </Link>
+
+        {/* Brand furniture, not error copy. The right half carries what went
+            wrong; repeating it here at 7xl would say the same thing twice on
+            every viewport wide enough to show both. */}
+        <div className="relative z-20 max-w-xl">
+          <h2 className="text-6xl xl:text-7xl font-extrabold tracking-tighter leading-[1.05] mb-8 text-balance">
+            Your data is safe
+            <span className="text-primary">.</span>
+          </h2>
+          <p className="text-muted-foreground text-lg font-medium leading-relaxed max-w-md">
+            Nothing has been lost and your session is intact. This screen is
+            about reaching Rustrak, not about what is stored in it.
+          </p>
+        </div>
+
+        <div className="relative z-20 flex justify-between items-end text-xs text-muted-foreground font-mono">
+          <p>v{APP_VERSION}</p>
+          <p>&copy; {new Date().getFullYear()} Rustrak</p>
+        </div>
+      </div>
+
+      {/* Right panel, the actionable half. */}
+      <div className="w-full lg:w-1/2 bg-card flex items-center justify-center p-8 lg:p-12">
+        <div className="w-full max-w-[420px] space-y-8">
+          {/* Brand, for the viewports where the left panel is gone. */}
+          <div className="lg:hidden flex items-center gap-2">
+            <RustrakLogoIcon className="size-8" />
+            <span className="text-lg font-extrabold tracking-tight uppercase">
+              Rustrak
+            </span>
+          </div>
+
+          <div className="space-y-3">
+            <h1 className="text-3xl font-bold tracking-tight">{headline}</h1>
+            <p className="text-muted-foreground leading-relaxed">
+              {description}
+            </p>
+          </div>
+
+          {guidance ? (
+            <p className="text-sm text-muted-foreground border-l-2 border-primary/40 pl-4 leading-relaxed">
+              {guidance}
+            </p>
+          ) : null}
+
+          {actions ? (
+            <div className="flex flex-wrap gap-3">{actions}</div>
+          ) : null}
+
+          {detail ? (
+            <p className="text-xs text-muted-foreground/70 font-mono break-all">
+              {detail}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/components/error-screen.tsx
+++ b/apps/webview-ui/src/components/error-screen.tsx
@@ -22,11 +22,22 @@ export function ErrorScreen({
   guidance,
   detail,
   actions,
+  brandStatement = 'Your data is safe',
+  brandDescription = 'Nothing has been lost and your session is intact. This screen is about reaching Rustrak, not about what is stored in it.',
 }: {
   /** The one-line answer to "what happened", on the content side. */
   headline: string;
   /** One sentence saying what went wrong. */
   description: string;
+  /**
+   * The large line on the brand panel. Defaults to the reassurance an outage
+   * needs; a 404 overrides it, because nothing failed there and telling
+   * someone their data is safe when they simply mistyped a URL is a non
+   * sequitur.
+   */
+  brandStatement?: string;
+  /** The paragraph under {@link brandStatement}. */
+  brandDescription?: string;
   /** What the reader can do, when there is anything useful to say. */
   guidance?: string | null;
   /** Monospace footnote: an error id, a version, anything diagnostic. */
@@ -53,12 +64,11 @@ export function ErrorScreen({
             every viewport wide enough to show both. */}
         <div className="relative z-20 max-w-xl">
           <h2 className="text-6xl xl:text-7xl font-extrabold tracking-tighter leading-[1.05] mb-8 text-balance">
-            Your data is safe
+            {brandStatement}
             <span className="text-primary">.</span>
           </h2>
           <p className="text-muted-foreground text-lg font-medium leading-relaxed max-w-md">
-            Nothing has been lost and your session is intact. This screen is
-            about reaching Rustrak, not about what is stored in it.
+            {brandDescription}
           </p>
         </div>
 

--- a/apps/webview-ui/src/components/outage-screen.tsx
+++ b/apps/webview-ui/src/components/outage-screen.tsx
@@ -1,0 +1,27 @@
+import type { RustrakError } from '@rustrak/client';
+import { ErrorScreen } from '@/components/error-screen';
+import { ReloadButton } from '@/components/reload-button';
+import { describeError, errorGuidance, errorHeadline } from '@/lib/error-copy';
+
+/**
+ * The whole-viewport version of a failed read, for the places that have no
+ * header to sit under: the root auth gate and the layouts below it.
+ *
+ * Its in-place sibling is `ServiceUnavailable`, which is what a single failed
+ * tile or panel renders. The distinction matters: a page that loaded most of
+ * itself must not be replaced by one sub-request's failure.
+ *
+ * Every line comes from `kind`. Only `network` and `server_error` claim the API
+ * is down; a `forbidden` reaching this screen is told to ask an administrator,
+ * not to wait for a server that is already answering.
+ */
+export function OutageScreen({ error }: { error: RustrakError }) {
+  return (
+    <ErrorScreen
+      headline={errorHeadline(error)}
+      description={describeError(error)}
+      guidance={errorGuidance(error)}
+      actions={<ReloadButton />}
+    />
+  );
+}

--- a/apps/webview-ui/src/components/reload-button.tsx
+++ b/apps/webview-ui/src/components/reload-button.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+/**
+ * A reload button for a screen rendered by a Server Component.
+ *
+ * `router.refresh()` is deliberately not used: the surfaces this appears on
+ * failed because the API could not be reached, and a soft refresh re-runs the
+ * same RSC request through the same client. A full document load also drops
+ * whatever stale module state the failed render left behind.
+ */
+export function ReloadButton({ children = 'Reload' }: { children?: string }) {
+  return (
+    <Button onClick={() => window.location.reload()}>
+      <RefreshCw className="mr-2 size-4" />
+      {children}
+    </Button>
+  );
+}

--- a/apps/webview-ui/src/components/service-unavailable.tsx
+++ b/apps/webview-ui/src/components/service-unavailable.tsx
@@ -4,13 +4,17 @@ import { Card, CardContent } from '@/components/ui/card';
 import { describeError, errorGuidance, errorHeadline } from '@/lib/error-copy';
 
 /**
- * What the user is told when a page could not finish a read, and the reason was
- * **not** "you are signed out".
+ * A failed read reported **in place**, inside a page that otherwise rendered.
  *
- * The whole point of this surface is that it is not `/auth/login`. A page that
- * redirects on a network failure sends a signed-in user to a login form that
- * cannot help: logging in issues the same request, which fails the same way,
- * and the user is bounced again.
+ * Its whole-viewport sibling is `OutageScreen`, which the root auth gate uses
+ * because it has no header to sit under. The split is the point: a page that
+ * loaded its header, its nav and three of its four panels must not be replaced
+ * by the fourth panel's failure, and a screen with no chrome at all must not
+ * render a small dashed card floating in an empty viewport.
+ *
+ * The surface is still not `/auth/login`. A page that redirects on a network
+ * failure sends a signed-in user to a login form that cannot help: logging in
+ * issues the same request, which fails the same way, and they bounce again.
  *
  * Every line comes from `kind`. It used to assert an outage unconditionally --
  * heading "Rustrak is not responding", footer "reload once the API is back" --
@@ -30,16 +34,23 @@ export function ServiceUnavailable({
   const guidance = errorGuidance(error);
 
   return (
-    <div className="p-8">
-      <Card className="border-dashed">
-        <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-          <PlugZap className="size-12 text-muted-foreground/50 mb-4" />
-          <p className="font-semibold">{title ?? errorHeadline(error)}</p>
-          <p className="text-muted-foreground mt-1 text-sm max-w-sm">
+    <div className="p-6 md:p-8">
+      <Card className="border-dashed bg-transparent shadow-none">
+        <CardContent className="flex flex-col items-center justify-center px-6 py-14 text-center">
+          <div className="mb-5 flex size-12 items-center justify-center rounded-full bg-muted">
+            <PlugZap
+              className="size-5 text-muted-foreground"
+              aria-hidden="true"
+            />
+          </div>
+          <p className="text-base font-bold tracking-tight">
+            {title ?? errorHeadline(error)}
+          </p>
+          <p className="text-muted-foreground mt-2 text-sm leading-relaxed max-w-sm">
             {describeError(error)}
           </p>
           {guidance ? (
-            <p className="text-muted-foreground/70 mt-4 text-xs max-w-sm">
+            <p className="text-muted-foreground/70 mt-4 text-xs leading-relaxed max-w-sm">
               {guidance}
             </p>
           ) : null}


### PR DESCRIPTION
Merges last, after #220. Split out of it so that PR stays under Greptile's file limit, and because this is presentation rather than contract.

The outage state was the generic dashed card dropped into a `p-8`, floating in an otherwise empty viewport on the two screens that have no header at all.

## Three surfaces, split by whether there is chrome around them

**`ErrorScreen`** — the full-viewport shell, the same split as `/auth/login`: brand panel left, content right on `bg-card`. Used by the root auth gate, `(main)/layout.tsx` and the global `app/error.tsx`. Those are the only places the user meets with no header and no navigation, so the only places the app has to introduce itself rather than assume the chrome already did.

**`ServiceUnavailable`** — stays the in-place card, restyled but not restructured, for a failure inside a page that otherwise rendered: an overview tile, one panel of a release page. Handing the whole viewport to one failed sub-request would hide the parts that did load, which is the opposite of what the `Result` conversion was for.

**`(main)/error.tsx`** — stays centred in the content area with no brand panel, because it renders *below* the header, which already carries the mark. A second brand panel there competes with it and makes a recoverable page error look like a logout.

The left panel carries fixed brand copy rather than the error, so a viewport wide enough to show both halves does not read the same sentence twice.

## Verified in the browser, not just in the type system

Checked against a stopped API in both themes and at 420px wide. Two things were wrong and are fixed:

- the large headline orphaned its last word onto its own line — now shorter copy plus `text-balance`
- the guidance line was `text-muted-foreground/80` on a light `bg-card` and did not read — now full `muted-foreground` with a `primary/40` rule

`pnpm run ci` green, 21/21. **8 files.**