### PR TITLE
Rebuild the changelog and the blog

### DIFF
--- a/apps/docs/src/app/(docs)/blog/[slug]/page.tsx
+++ b/apps/docs/src/app/(docs)/blog/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function BlogPostPage({ params }: PageProps) {
   }
 
   return (
-    <div className="blog-root mx-auto w-full max-w-[72rem] px-4 py-10 sm:px-6 sm:py-14">
+    <div className="blog-root mx-auto w-full max-w-[76rem] px-4 py-10 sm:px-6 sm:py-14">
       {/*
         `overflow-x-clip`, the same backstop the landing's frame carries: a
         grid item's `min-width` is `auto`, so one wide child — a Mermaid
@@ -101,16 +101,23 @@ export default async function BlogPostPage({ params }: PageProps) {
           the two columns now, and the rail marks its active item with a dot
           instead of a bar — see `reading-rail.tsx`.
         */}
-        <div className="grid border-b border-rule lg:grid-cols-[minmax(0,1fr)_16rem]">
-          <article
-            id={BODY_ID}
-            className="blog-prose min-w-0 px-5 py-12 sm:px-9 sm:py-14"
-          >
+        {/*
+          The padding sits on the grid rather than on the two cells, and that
+          is what makes this the same grid as the masthead above it. With the
+          article carrying its own `px-9` the text track was 36px wider than
+          the header's and the rail started 36px further left, so the byline
+          and the contents list did not line up with each other and neither
+          lined up with the title. One padded container and one `gap-x-10`,
+          repeated in both places, and the page is two columns from top to
+          bottom.
+        */}
+        <div className="grid border-b border-rule px-5 sm:px-9 lg:grid-cols-[minmax(0,1fr)_16rem] lg:gap-x-10">
+          <article id={BODY_ID} className="blog-prose min-w-0 py-12 sm:py-14">
             <MDXContent />
             <MermaidFit bodyId={BODY_ID} />
           </article>
 
-          <div className="min-w-0 lg:py-14 lg:pr-9">
+          <div className="min-w-0 lg:py-14">
             <ReadingRail items={toc} bodyId={BODY_ID} />
           </div>
         </div>

--- a/apps/docs/src/app/(docs)/blog/page.tsx
+++ b/apps/docs/src/app/(docs)/blog/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
-import { FeaturedPost, PostRow } from '@/components/blog/post-list';
-import { getPosts } from '@/lib/blog';
+import { PostEntry } from '@/components/blog/post-list';
+import { getPosts, getTagCounts } from '@/lib/blog';
 
 export const metadata: Metadata = {
   title: 'Blog',
@@ -9,42 +9,84 @@ export const metadata: Metadata = {
 };
 
 /**
- * The blog index, drawn in the same ruled frame as the changelog: a header
- * cell, the newest post given its own band, and a row per post after it. The
- * frame is what keeps a three-post blog from looking like an unfinished page —
- * the structure is visible whether or not there is much in it yet.
+ * The blog index, in the same ruled frame as the changelog.
+ *
+ * The frame is what keeps a three-post blog from looking like an unfinished
+ * page, but it only works if the frame is filled, and it was not. The masthead
+ * set a 72px headline in the left half of a 72rem cell with nothing in the
+ * right, then handed the newest post a band three times the height of the two
+ * under it. A wide page with one left-aligned column is not a layout, it is a
+ * narrow page with a large right margin.
+ *
+ * Two changes fix it, and neither is decoration. The header runs title and lead
+ * side by side and closes on a band of the tags actually in use, which is the
+ * only navigation a blog this size can honestly offer. And every post gets the
+ * same block, filled with its own outline: see `post-list.tsx`.
  */
 export default function BlogPage() {
   const posts = getPosts();
-  const [latest, ...rest] = posts;
+  const tags = getTagCounts();
 
   return (
-    <div className="blog-root mx-auto w-full max-w-[72rem] px-4 py-10 sm:px-6 sm:py-14">
+    <div className="blog-root mx-auto w-full max-w-[76rem] px-4 py-10 sm:px-6 sm:py-14">
       <div className="overflow-x-clip border-x border-t border-rule">
-        {/*
-          The masthead is set at the display scale's top size rather than one
-          below it. On a 72rem frame the smaller size left the title sitting in
-          the left third with nothing to the right of it, which is the failure
-          this whole page had: width taken and not used.
-        */}
-        <header className="border-b border-rule px-5 py-14 sm:px-9 sm:py-20">
-          <span className="eyebrow">Blog</span>
-          <h1 className="display-xl mt-6 text-foreground">
-            Notes from building it.
-          </h1>
-          <p className="mt-6 max-w-[56ch] text-[15.5px] leading-relaxed text-muted-foreground">
+        <header className="px-5 py-14 sm:px-9 sm:py-16 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,26rem)] lg:items-end lg:gap-x-12">
+          <div>
+            <span className="eyebrow">Blog</span>
+            {/* `display-lg`, not `display-xl`. At the top size the headline was
+                a poster over a list of three links; a step down puts it in
+                proportion to what is under it, which is the entire point of a
+                masthead. */}
+            {/* No measure cap. The grid track already bounds this, and a `ch`
+                cap on a five-word headline only ever finds a place to break it
+                that the track would not have: at 14ch it set "Notes from
+                building" and left "it." alone on a second line. */}
+            <h1 className="display-lg mt-5 text-foreground">
+              Notes from building it.
+            </h1>
+          </div>
+          <p className="mt-6 max-w-[52ch] text-[15.5px] leading-relaxed text-muted-foreground lg:mt-0">
             Release announcements, and the longer write-ups of how a piece of
             Rustrak actually works once it is finished.
           </p>
         </header>
 
-        {latest ? (
-          <>
-            <FeaturedPost post={latest} />
-            {rest.map((post) => (
-              <PostRow key={post.slug} post={post} />
+        {/*
+          The subjects, with how much has been written about each. It is a
+          reading of the archive rather than a filter: three posts do not need
+          filtering, and a control that narrows a list of three to a list of two
+          is a worse page than the one it replaced. What it does do is say what
+          this blog is about without a paragraph claiming it, and it grows into
+          real navigation on its own as posts accumulate.
+        */}
+        {tags.length > 0 && (
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2.5 border-y border-rule px-5 py-4 sm:px-9">
+            <span className="font-mono text-[10.5px] uppercase tracking-[0.2em] text-muted-foreground/70">
+              Subjects
+            </span>
+            {tags.map(({ tag, count }) => (
+              <span
+                key={tag}
+                className="font-mono text-[12px] text-muted-foreground"
+              >
+                {tag}
+                <span className="ml-1.5 tabular-nums text-muted-foreground/45">
+                  {count}
+                </span>
+              </span>
             ))}
-          </>
+          </div>
+        )}
+
+        {posts.length > 0 ? (
+          posts.map((post, index) => (
+            <PostEntry
+              key={post.slug}
+              post={post}
+              index={index + 1}
+              latest={index === 0}
+            />
+          ))
         ) : (
           <p className="border-b border-rule px-5 py-16 text-center text-[15px] text-muted-foreground sm:px-9">
             No posts yet. Check back soon.

--- a/apps/docs/src/app/(docs)/changelog/page.tsx
+++ b/apps/docs/src/app/(docs)/changelog/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { ChangelogFeed } from '@/components/changelog/changelog-feed';
 import {
   getChunkCount,
+  getPulse,
   getReleaseChunk,
   getReleases,
   RELEASES_PER_CHUNK,
@@ -16,18 +17,31 @@ export const metadata: Metadata = {
 /**
  * The changelog.
  *
- * Two things shape this page. The first is that it grows forever: it rendered
- * every release in full on one URL, which was 604KB of HTML and climbing by a
- * release a fortnight, so only the first chunk is inlined now and the rest is
- * fetched (see `changelog-feed.tsx`). The second is that a changelog is read by
- * scanning, so the whole page is one ruled column with a fixed rhythm —
- * version strip, title, lead, numbered sections — and every entry is that same
- * shape whether it shipped one fix or five features.
+ * Three things shape this page.
+ *
+ * The first is that it grows forever: it rendered every release in full on one
+ * URL, which was 604KB of HTML and climbing by a release a fortnight, so only
+ * the first chunk is inlined now and the rest is fetched (see
+ * `changelog-feed.tsx`).
+ *
+ * The second is that a changelog is read by scanning, so the whole page is one
+ * ruled column with a fixed rhythm (version strip, title, lead, numbered
+ * sections) and every entry is that same shape whether it shipped one fix or
+ * five features.
+ *
+ * The third is the one this redesign added. Forty-one entries down a single
+ * column is an archive with no map, and the page had nothing to offer a reader
+ * on a wide screen except a longer line of text. So the whole history is drawn
+ * across the top as a band of columns (see `release-spectrum.tsx`), which is
+ * both a picture of how the project moved and the index it never had. The
+ * reading column is capped at a measure underneath it, which is what lets the
+ * frame be wide enough to hold that band without the prose paying for it.
  */
 export default function ChangelogPage() {
   const releases = getReleases();
   const first = getReleaseChunk(1);
   const chunkCount = getChunkCount();
+  const pulse = getPulse();
   const latest = releases[0];
 
   /*
@@ -35,7 +49,8 @@ export default function ChangelogPage() {
     thing on the page that scales with the full list, and it is deliberate: at
     roughly 50 bytes an entry the whole map costs less than a single release
     would, and without it a deep link into an unfetched release silently does
-    nothing.
+    nothing. The spectrum reads it too, for the same reason: it can address
+    releases the page has not fetched.
   */
   const chunkByAnchor: Record<string, number> = {};
   releases.forEach((release, index) => {
@@ -44,9 +59,12 @@ export default function ChangelogPage() {
     chunkByAnchor[release.slug] = chunk;
   });
 
+  const changes = pulse.reduce((sum, entry) => sum + entry.total, 0);
+
   const stats = [
     { value: latest?.version ?? '—', label: 'Current release' },
     { value: String(releases.length), label: 'Releases shipped' },
+    { value: String(changes), label: 'Changes logged' },
     {
       value: latest ? formatReleaseDate(latest.date) : '—',
       label: 'Last published',
@@ -54,14 +72,22 @@ export default function ChangelogPage() {
   ];
 
   return (
-    <div className="changelog-root mx-auto w-full max-w-[72rem] px-4 py-10 sm:px-6 sm:py-14">
+    <div className="changelog-root mx-auto w-full max-w-[76rem] px-4 py-10 sm:px-6 sm:py-14">
       <div className="overflow-x-clip border-x border-t border-rule">
-        <header className="border-b border-rule px-5 py-14 sm:px-9 sm:py-20">
-          <span className="eyebrow">Changelog</span>
-          <h1 className="display-xl mt-6 text-foreground">
-            Every release, in order.
-          </h1>
-          <p className="mt-6 max-w-[56ch] text-[15.5px] leading-relaxed text-muted-foreground">
+        {/*
+          Headline and lead sit side by side from `lg`, rather than the lead
+          hanging under a 72px headline in a column a third as wide as the one
+          above it. Two blocks of type at two sizes, closing against the same
+          baseline, is the header the rest of this frame is drawn in.
+        */}
+        <header className="px-5 py-14 sm:px-9 sm:py-16 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,26rem)] lg:items-end lg:gap-x-12">
+          <div>
+            <span className="eyebrow">Changelog</span>
+            <h1 className="display-lg mt-5 max-w-[16ch] text-foreground">
+              Every release, in order.
+            </h1>
+          </div>
+          <p className="mt-6 max-w-[52ch] text-[15.5px] leading-relaxed text-muted-foreground lg:mt-0">
             The server, the dashboard and the client packages ship together
             under one version number. This is what each of those numbers
             carried.
@@ -72,24 +98,21 @@ export default function ChangelogPage() {
           The landing's figure treatment, so the two pages read as one site: a
           short primary rule turns a number into a labelled reading.
 
-          Two up on a phone rather than three stacked, with the date taking the
-          full row it needs. Stacked, the band alone was most of a phone screen
-          and pushed the newest release — the thing the visitor came for —
-          entirely below the fold.
-
-          Each border is written out as a literal class rather than assembled
-          from a variable: Tailwind scans source text, and a class name built
-          from a prefix is never generated.
+          Two up on a phone rather than four stacked, which would have been most
+          of a screen before the visitor reached anything they came for. Each
+          border is written out as a literal class rather than assembled from a
+          variable: Tailwind scans source text, and a class name built from a
+          prefix is never generated.
         */}
-        <dl className="grid grid-cols-2 border-b border-rule sm:grid-cols-3">
+        <dl className="grid grid-cols-2 border-y border-rule sm:grid-cols-4">
           {stats.map((stat, index) => (
             <div
               key={stat.label}
               className={[
                 'border-rule px-5 py-5 sm:px-9 sm:py-6',
-                index === 0 ? 'border-b border-r sm:border-b-0' : '',
-                index === 1 ? 'border-b sm:border-r sm:border-b-0' : '',
-                index === 2 ? 'col-span-2 sm:col-span-1' : '',
+                index < 2 ? 'border-b sm:border-b-0' : '',
+                index % 2 === 0 ? 'border-r' : '',
+                index === 1 ? 'sm:border-r' : '',
               ].join(' ')}
             >
               <div className="border-l-2 border-primary pl-3">
@@ -113,6 +136,7 @@ export default function ChangelogPage() {
           chunkCount={chunkCount}
           total={releases.length}
           perChunk={RELEASES_PER_CHUNK}
+          pulse={pulse}
           chunkByAnchor={chunkByAnchor}
         />
       </div>

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -555,14 +555,43 @@ body:has(.landing-root) {
    one line and was unreadable, and none of it could be reasoned about without
    mentally rendering it first.
 
-   The type is deliberately a step smaller than the docs' prose. A release note
-   is a list of facts being scanned for one of them, not a page being read, and
-   at documentation size a five-section entry runs three screens deep. */
+   The type is a step smaller than the docs' prose. A release note is a list of
+   facts being scanned for one of them, not a page being read, and at
+   documentation size a five-section entry runs three screens deep.
+
+   ── The colour, which is the part that was wrong ───────────────────────────
+
+   This was `--muted-foreground`, and that single declaration was most of why
+   the page was hard to read. `--muted-foreground` is the token for metadata:
+   dates, counts, labels. It is chosen to recede. Painting the body of
+   every release in it meant the actual content of the page was the quietest
+   thing on it, and the effect compounded with the measure: a 95-character line
+   of receding grey is a paragraph the eye slides off rather than reads.
+
+   It now mixes towards the background from `--foreground` instead, the same
+   move `.blog-prose` already makes and for the same reason: a long read set in
+   the full heading colour is harsher than it looks in a screenshot, most of all
+   in dark mode. 80% is a step firmer than the blog's 84% mix because this type
+   is 1.5px smaller and small type needs the contrast back.
+
+   The measure is capped in `release-article.tsx` rather than here, because it
+   is a property of the column the prose sits in and not of the prose. */
 .changelog-prose p,
 .changelog-prose li {
-  font-size: 14.5px;
-  line-height: 1.72;
-  color: var(--muted-foreground);
+  font-size: 15px;
+  line-height: 1.7;
+  color: color-mix(in oklab, var(--foreground) 80%, var(--background));
+}
+
+/* The release's one-line summary, between the title and the first section. It
+   sits a step above the body, larger and in the full foreground, because it
+   is the sentence that decides whether the reader keeps going, and it was
+   previously indistinguishable from the prose underneath it. */
+.changelog-lead {
+  max-width: 58ch;
+  font-size: 16.5px;
+  line-height: 1.6;
+  color: color-mix(in oklab, var(--foreground) 88%, var(--background));
 }
 
 .changelog-prose p + p {

--- a/apps/docs/src/components/blog/post-header.tsx
+++ b/apps/docs/src/components/blog/post-header.tsx
@@ -9,51 +9,73 @@ type PostHeaderProps = {
 /**
  * The head of a post: a way back, what it is about, and who wrote it when.
  *
- * The byline carries the same short primary rule the changelog puts beside a
- * figure, which is doing more than decoration here — it is the mark that says
- * "this block is metadata, not the first paragraph", and without it the author
- * line reads as the opening sentence of the piece.
+ * ── Why it is two tracks ───────────────────────────────────────────────────
+ *
+ * Everything here used to stack down the left: back link, tags, title,
+ * standfirst, byline, one under the next, in the left half of a frame the body
+ * underneath spans in two columns. So the page changed shape at the point where
+ * the reading started, and the whole right side of the masthead was empty.
+ *
+ * It is the body's grid now, one cell early. The title and the standfirst sit
+ * in the text track and the metadata sits in the 16rem track the contents rail
+ * occupies below, which puts the byline directly above the table of contents
+ * and the title directly above the first paragraph. Same two columns, all the
+ * way down.
+ *
+ * The byline keeps the short primary rule the changelog puts beside a figure.
+ * It is doing more than decoration: it is the mark that says "this block is
+ * metadata, not the first paragraph", and without it the author line reads as
+ * the opening sentence of the piece.
  */
 export function PostHeader({ post }: PostHeaderProps) {
   return (
-    <header className="border-b border-rule px-5 py-12 sm:px-9 sm:py-14">
-      <Link
-        href="/blog"
-        className="inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground transition-colors hover:text-primary"
-      >
-        <span aria-hidden>←</span>
-        Blog
-      </Link>
+    <header className="border-b border-rule px-5 py-12 sm:px-9 sm:py-14 lg:grid lg:grid-cols-[minmax(0,1fr)_16rem] lg:gap-x-10">
+      <div className="min-w-0">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground transition-colors hover:text-primary"
+        >
+          <span aria-hidden>←</span>
+          Blog
+        </Link>
 
-      {post.tags.length > 0 && (
-        <div className="mt-8 flex flex-wrap items-center gap-2">
-          {post.tags.map((tag) => (
-            <TagPill key={tag} tag={tag} />
-          ))}
+        <h1 className="display-lg mt-7 max-w-[20ch] text-foreground">
+          {post.title}
+        </h1>
+
+        {post.description && (
+          <p className="mt-5 max-w-[56ch] text-[16px] leading-relaxed text-muted-foreground">
+            {post.description}
+          </p>
+        )}
+      </div>
+
+      {/*
+        Bottom-aligned, so the byline closes on the same line as the standfirst
+        rather than floating at the top of a cell taller than it. On a phone the
+        tracks collapse and it simply follows the text.
+      */}
+      <div className="mt-9 lg:mt-0 lg:flex lg:flex-col lg:justify-end">
+        <div className="border-l-2 border-primary pl-3">
+          <p className="text-[13.5px] font-medium text-foreground">
+            {post.author}
+          </p>
+          <p className="mt-1 font-mono text-[11.5px] tabular-nums text-muted-foreground">
+            <time dateTime={post.date}>{formatDate(post.date)}</time>
+            <span aria-hidden className="px-1.5 text-muted-foreground/50">
+              ·
+            </span>
+            {shortReadingTime(post.readingTime)}
+          </p>
         </div>
-      )}
 
-      <h1 className="display-lg mt-5 max-w-[24ch] text-foreground">
-        {post.title}
-      </h1>
-
-      {post.description && (
-        <p className="mt-5 max-w-[58ch] text-[16px] leading-relaxed text-muted-foreground">
-          {post.description}
-        </p>
-      )}
-
-      <div className="mt-9 border-l-2 border-primary pl-3">
-        <p className="text-[13.5px] font-medium text-foreground">
-          {post.author}
-        </p>
-        <p className="mt-1 font-mono text-[11.5px] tabular-nums text-muted-foreground">
-          <time dateTime={post.date}>{formatDate(post.date)}</time>
-          <span aria-hidden className="px-1.5 text-muted-foreground/50">
-            ·
-          </span>
-          {shortReadingTime(post.readingTime)}
-        </p>
+        {post.tags.length > 0 && (
+          <div className="mt-5 flex flex-wrap items-center gap-2">
+            {post.tags.map((tag) => (
+              <TagPill key={tag} tag={tag} />
+            ))}
+          </div>
+        )}
       </div>
     </header>
   );

--- a/apps/docs/src/components/blog/post-list.tsx
+++ b/apps/docs/src/components/blog/post-list.tsx
@@ -1,129 +1,173 @@
 import Link from 'next/link';
-import {
-  formatDate,
-  formatDateShort,
-  type Post,
-  shortReadingTime,
-} from '@/lib/blog';
+import { formatDateShort, type Post, shortReadingTime } from '@/lib/blog';
 import { TagPill } from './tag-pill';
 
 /**
- * The index of the blog: one post given room, the rest given a line each.
+ * The index of the blog: one entry per post, all the same shape, each showing
+ * what is actually inside it.
  *
- * The split is the point. A list where every entry is the same size makes the
- * reader compare three headlines and pick one, which is work; leading with the
- * newest post and its full standfirst answers "is there anything new here"
- * before they have to. The rows below stay deliberately terse — a date, a
- * title, its tags — because that is all a reader needs to recognise a post
- * they have already read and skip it.
+ * ── What changed, and why ──────────────────────────────────────────────────
+ *
+ * This used to lead with the newest post at three times the size of the others
+ * and give the rest a line each. The argument for that was that a reader should
+ * not have to compare three headlines. The argument against it, which is the
+ * one that won, is that there are three posts: singling one out does not
+ * promote it so much as demote the other two, and the page read as one article
+ * with a couple of related links under it rather than as a body of work.
+ *
+ * So every post is now the same block, and what fills that block is its own
+ * outline. That is the whole idea here. A standfirst tells you what a piece is
+ * about; its section titles tell you what is in it, which is the thing a reader
+ * of a four-thousand-word engineering post actually wants to know before
+ * committing eight minutes. It also solves the layout problem honestly: this
+ * blog has no cover images, so the structure of the writing is the only
+ * material available to fill a wide frame with, and it is better material than
+ * a photograph would be.
  */
-
-function MetaDot() {
-  return (
-    <span aria-hidden className="text-muted-foreground/40">
-      ·
-    </span>
-  );
-}
 
 /**
- * One track for the body and a 16rem track for everything about it.
+ * How many sections to show before the count takes over.
  *
- * The aside is the same width as the contents rail on a post, and starts at
- * the same x. That is the whole reason the wide frame works: a page this wide
- * with one left-aligned column of text is not a layout, it is a narrow page
- * with a large right margin — which is what this looked like when the frame
- * grew and nothing else moved.
+ * Five is roughly where a list stops being a shape the eye takes in at once and
+ * starts being something to read, which would put the index in competition with
+ * the posts it is indexing.
  */
-const TRACKS = 'lg:grid lg:grid-cols-[minmax(0,1fr)_16rem] lg:gap-10';
+const OUTLINE_LIMIT = 5;
 
-export function FeaturedPost({ post }: { post: Post }) {
+export function PostEntry({
+  post,
+  index,
+  latest,
+}: {
+  post: Post;
+  /** One-based, newest first. Drawn as the entry's number in the archive. */
+  index: number;
+  latest: boolean;
+}) {
+  const shown = post.outline.slice(0, OUTLINE_LIMIT);
+  const hidden = post.outline.length - shown.length;
+
   return (
     <Link
       href={`/blog/${post.slug}`}
-      className={`group block border-b border-rule px-5 py-12 transition-colors hover:bg-foreground/[0.015] sm:px-9 sm:py-16 ${TRACKS}`}
-    >
-      <div>
-        <div className="flex flex-wrap items-center gap-2 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
-          <span className="text-primary">Latest</span>
-          <MetaDot />
-          <time dateTime={post.date}>{formatDate(post.date)}</time>
-        </div>
-
-        <h2 className="display-lg mt-5 text-foreground transition-colors group-hover:text-primary">
-          {post.title}
-        </h2>
-
-        {post.description && (
-          <p className="mt-5 max-w-[62ch] text-[15.5px] leading-relaxed text-muted-foreground">
-            {post.description}
-          </p>
-        )}
-      </div>
-
-      <div className="mt-6 flex flex-wrap items-center gap-2 lg:mt-1 lg:flex-col lg:items-start lg:gap-3">
-        <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
-          {shortReadingTime(post.readingTime)}
-        </span>
-        <div className="flex flex-wrap items-center gap-2">
-          {post.tags.map((tag) => (
-            <TagPill key={tag} tag={tag} />
-          ))}
-        </div>
-        <span
-          aria-hidden
-          className="hidden font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground transition-colors group-hover:text-primary lg:mt-2 lg:block"
-        >
-          Read →
-        </span>
-      </div>
-    </Link>
-  );
-}
-
-export function PostRow({ post }: { post: Post }) {
-  return (
-    <Link
-      href={`/blog/${post.slug}`}
-      className="group block border-b border-rule px-5 py-7 transition-colors hover:bg-foreground/[0.015] sm:px-9 sm:py-8 lg:grid lg:grid-cols-[5.5rem_minmax(0,1fr)_16rem] lg:items-baseline lg:gap-10"
+      className="group block border-b border-rule px-5 py-9 transition-colors hover:bg-foreground/[0.015] sm:px-9 sm:py-11 lg:grid lg:grid-cols-[4.5rem_minmax(0,1fr)_16rem] lg:gap-x-10"
     >
       {/*
-        The date column is fixed width and monospaced so every row's title
-        starts at the same x. That single alignment is what turns a stack of
-        links into a list you can run your eye down.
+        The number and the date, in the fixed left track that makes every title
+        on the page start at the same x. The numeral is the archive's count
+        rather than the post's id: it renumbers as posts are added, and that is
+        correct, because what it says is "this is the third most recent piece",
+        not "this is post three".
       */}
-      <div className="flex items-baseline gap-3 font-mono text-[11.5px] tabular-nums text-muted-foreground lg:flex-col lg:gap-1">
-        <time dateTime={post.date}>{formatDateShort(post.date)}</time>
-        <span className="text-muted-foreground/70 lg:hidden">
-          {shortReadingTime(post.readingTime)}
+      <div className="flex items-baseline gap-3 lg:block">
+        <span
+          aria-hidden
+          className="font-mono text-[13px] tabular-nums text-muted-foreground/50"
+        >
+          {String(index).padStart(2, '0')}
         </span>
+        <time
+          dateTime={post.date}
+          className="font-mono text-[11.5px] tabular-nums text-muted-foreground lg:mt-2 lg:block"
+        >
+          {formatDateShort(post.date)}
+        </time>
       </div>
 
       <div className="mt-3 min-w-0 lg:mt-0">
-        <h3 className="text-[17.5px] font-medium leading-snug tracking-[-0.01em] text-foreground transition-colors group-hover:text-primary">
-          {post.title}
-        </h3>
-        {/* The standfirst is what earns the row its width. Without it a wide
-            frame leaves a title stranded in the middle of an empty band; with
-            it the row says enough to decide on, and still stops at two lines
-            so the list keeps its rhythm. */}
+        <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
+          {latest && (
+            <span className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-primary">
+              Latest
+            </span>
+          )}
+          <h2 className="text-[1.25rem] font-medium leading-snug tracking-[-0.015em] text-foreground transition-colors group-hover:text-primary sm:text-[1.375rem]">
+            {post.title}
+          </h2>
+        </div>
+
         {post.description && (
-          <p className="mt-2 line-clamp-2 text-[14px] leading-relaxed text-muted-foreground">
+          <p className="mt-2.5 max-w-[62ch] text-[14.5px] leading-relaxed text-muted-foreground">
             {post.description}
           </p>
         )}
+
+        {/*
+          The outline. Numbered and ruled the way a changelog section is,
+          because it is the same kind of object: a list of what is inside a
+          longer document, being scanned rather than read.
+
+          Deliberately not a set of links to the headings. A reader on the index
+          has not chosen the post yet, and offering to drop them into its fourth
+          section answers a question nobody asked. The job here is to make the
+          post legible enough to choose.
+        */}
+        {shown.length > 0 && (
+          <ol className="mt-5 space-y-1.5">
+            {shown.map((heading, position) => (
+              <li
+                key={heading}
+                className="flex gap-2.5 text-[13px] leading-snug text-muted-foreground"
+              >
+                <span
+                  aria-hidden
+                  className="font-mono tabular-nums text-muted-foreground/45"
+                >
+                  {String(position + 1).padStart(2, '0')}
+                </span>
+                <span className="min-w-0 transition-colors group-hover:text-foreground/75">
+                  {heading}
+                </span>
+              </li>
+            ))}
+            {hidden > 0 && (
+              // The same flex row with the numeral made invisible rather than a
+              // hand-measured indent. A padding guessed at the width of "01"
+              // in mono is right until the type size moves, and it was already
+              // six pixels off.
+              <li className="flex gap-2.5">
+                <span
+                  aria-hidden
+                  className="font-mono text-[13px] tabular-nums text-transparent"
+                >
+                  00
+                </span>
+                <span className="font-mono text-[11.5px] leading-snug text-muted-foreground/60">
+                  +{hidden} more
+                </span>
+              </li>
+            )}
+          </ol>
+        )}
       </div>
 
-      {/* The same track the featured cell and the post rail use. */}
-      <div className="mt-3 flex flex-wrap items-center gap-2 lg:mt-0 lg:flex-col lg:items-start lg:gap-2.5">
-        <span className="hidden font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground lg:block">
+      {/* The same 16rem track the post's contents rail uses, so the index and a
+          post are one grid seen twice rather than two layouts. */}
+      <div className="mt-5 flex flex-wrap items-center gap-2 lg:mt-1 lg:flex-col lg:items-start lg:gap-3">
+        <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
           {shortReadingTime(post.readingTime)}
+          {post.outline.length > 0 && (
+            <>
+              <span aria-hidden className="px-1.5 text-muted-foreground/40">
+                ·
+              </span>
+              {post.outline.length} parts
+            </>
+          )}
         </span>
+
         <div className="flex flex-wrap items-center gap-2">
           {post.tags.map((tag) => (
             <TagPill key={tag} tag={tag} />
           ))}
         </div>
+
+        <span
+          aria-hidden
+          className="hidden font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground transition-colors group-hover:text-primary lg:mt-1 lg:block"
+        >
+          Read →
+        </span>
       </div>
     </Link>
   );

--- a/apps/docs/src/components/changelog/archive-footer.tsx
+++ b/apps/docs/src/components/changelog/archive-footer.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import type { ArchiveStatus } from './use-release-archive';
+
+/**
+ * The end of the feed: either the way to the rest of the archive, or the note
+ * that there is no rest.
+ *
+ * The `noscript` is not ceremony. Everything below the tenth release is fetched
+ * (see `use-release-archive.ts`), so with scripting off this page genuinely is
+ * ten releases and the reader deserves to be told where the other thirty-one
+ * are rather than left to conclude the project started this year.
+ */
+export function ArchiveFooter({
+  loaded,
+  total,
+  nextBatch,
+  status,
+  hasMore,
+  onLoadMore,
+}: {
+  loaded: number;
+  total: number;
+  nextBatch: number;
+  status: ArchiveStatus;
+  hasMore: boolean;
+  onLoadMore: () => void;
+}) {
+  if (!hasMore) {
+    return (
+      <div className="border-b border-rule px-5 py-10 text-center sm:px-9">
+        <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-muted-foreground">
+          The first release
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-b border-rule px-5 py-10 text-center sm:px-9">
+      <button
+        type="button"
+        onClick={onLoadMore}
+        disabled={status === 'loading'}
+        className="inline-flex items-center gap-2 rounded-full border border-rule px-5 py-2.5 font-mono text-[11.5px] uppercase tracking-[0.14em] text-foreground transition-colors hover:border-primary/50 hover:text-primary disabled:cursor-wait disabled:opacity-60"
+      >
+        {status === 'loading' ? (
+          <>
+            <span
+              aria-hidden
+              className="size-1.5 animate-pulse rounded-full bg-primary"
+            />
+            Loading
+          </>
+        ) : status === 'error' ? (
+          'Retry'
+        ) : (
+          `Show ${nextBatch} earlier release${nextBatch === 1 ? '' : 's'}`
+        )}
+      </button>
+
+      <p
+        className="mt-3.5 font-mono text-[11px] tabular-nums text-muted-foreground"
+        aria-live="polite"
+      >
+        {status === 'error'
+          ? 'Could not reach the archive.'
+          : `${loaded} of ${total} releases`}
+      </p>
+
+      <noscript>
+        <p className="mt-3.5 text-[13px] text-muted-foreground">
+          The remaining {total - loaded} releases load on demand and need
+          JavaScript. They are also on{' '}
+          <a
+            className="underline underline-offset-2 hover:text-primary"
+            href="https://github.com/AbianS/rustrak/releases"
+          >
+            GitHub Releases
+          </a>
+          .
+        </p>
+      </noscript>
+    </div>
+  );
+}

--- a/apps/docs/src/components/changelog/changelog-feed.tsx
+++ b/apps/docs/src/components/changelog/changelog-feed.tsx
@@ -1,43 +1,43 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import type { Release, ReleaseChunk } from '@/lib/release';
+import { useRef } from 'react';
+import type { Release, ReleasePulse } from '@/lib/release';
+import { ArchiveFooter } from './archive-footer';
 import { ReleaseArticle } from './release-article';
+import { ReleaseSpectrum } from './release-spectrum';
+import { useActiveRelease } from './use-active-release';
+import { useReleaseArchive } from './use-release-archive';
 
 /**
  * The feed, and the only client code on the page.
  *
- * It exists for one reason: the page ships the ten most recent releases and
- * nothing else, and something has to be able to go and get the rest. Older
- * releases are fetched a chunk at a time from static JSON generated at build
- * time (`app/(docs)/changelog/releases/[chunk]/route.ts`), which keeps the
- * first response the same size in two years as it is today.
+ * It is composition and nothing else. The archive's fetching lives in
+ * `use-release-archive.ts` and the reading position in `use-active-release.ts`.
+ * What is left here is the order the page is drawn in, which is worth being
+ * able to read at a glance:
  *
- * The reveal is therefore a real fetch, not a stack of hidden markup with a
- * button over it. That distinction is the entire exercise — hiding it in CSS
- * would have left all 604KB in the document and only moved the scrollbar.
+ *   spectrum · sentinel · pinned spectrum · releases · footer
+ *
+ * That pairing of the spectrum with the archive is not incidental. The spectrum
+ * can address all forty-one releases while the page holds ten, so every jump it
+ * offers may need a fetch first, the same machinery a deep link needs, which
+ * is why one hook serves both.
  */
-
-const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
 type Props = {
   initial: Release[];
   chunkCount: number;
   total: number;
   perChunk: number;
-  /**
-   * Which chunk every anchor lives in, including the legacy filename anchors,
-   * so a deep link into a release that has not been fetched yet can pull the
-   * chunks it needs instead of landing on the wrong entry.
-   */
+  /** Every release at spectrum resolution, newest first. */
+  pulse: ReleasePulse[];
+  /** Which chunk each anchor lives in. See `use-release-archive.ts`. */
   chunkByAnchor: Record<string, number>;
 };
 
-type Status = 'idle' | 'loading' | 'error';
-
 function YearMarker({ year }: { year: string }) {
   return (
-    <div className="flex items-center gap-4 border-b border-rule bg-foreground/[0.015] px-5 py-3 sm:px-9">
+    <div className="flex items-center gap-4 border-b border-rule bg-foreground/[0.015] px-5 py-2.5 sm:px-9">
       <span className="font-mono text-[11px] uppercase tracking-[0.24em] text-muted-foreground">
         {year}
       </span>
@@ -51,111 +51,82 @@ export function ChangelogFeed({
   chunkCount,
   total,
   perChunk,
+  pulse,
   chunkByAnchor,
 }: Props) {
-  const [releases, setReleases] = useState<Release[]>(initial);
-  const [loadedChunks, setLoadedChunks] = useState(1);
-  const [status, setStatus] = useState<Status>('idle');
-  const [pendingAnchor, setPendingAnchor] = useState<string | null>(null);
+  const { releases, loadedChunks, status, loadThrough, jumpTo } =
+    useReleaseArchive({ initial, chunkByAnchor });
 
-  // Mirrors of the values the async loop reads between awaits. State would be
-  // stale inside the loop and would also make `loadThrough` a new function on
-  // every render, which the hash listener below depends on it not being.
-  const loadedRef = useRef(1);
-  const busyRef = useRef(false);
-  // How far the loop has been asked to go. A ref rather than an argument
-  // because a second caller has to be able to raise it while the first is
-  // still running — see the note in `loadThrough`.
-  const targetRef = useRef(1);
-
-  const loadThrough = useCallback(async (target: number) => {
-    // Raised before the busy check, and never lowered. A request that arrives
-    // mid-flight used to be dropped on the floor: it returned here because the
-    // loop was busy, and the loop it returned to was bounded by the target of
-    // whoever started it. So a deep link into chunk four landing while chunk
-    // two was in the air left `pendingAnchor` set on a release that would
-    // never be fetched, and the page simply never scrolled. Now the running
-    // loop reads this on every pass and carries on to the further target.
-    targetRef.current = Math.max(targetRef.current, target);
-    if (busyRef.current || targetRef.current <= loadedRef.current) return;
-    busyRef.current = true;
-    setStatus('loading');
-
-    try {
-      while (loadedRef.current < targetRef.current) {
-        const chunk = loadedRef.current + 1;
-        const response = await fetch(
-          `${BASE_PATH}/changelog/releases/${chunk}`,
-        );
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const payload = (await response.json()) as ReleaseChunk;
-
-        // Appended per chunk rather than once at the end: a failure on the
-        // third request should keep the two that succeeded on the page.
-        loadedRef.current = chunk;
-        setReleases((current) => [...current, ...payload.releases]);
-        setLoadedChunks(chunk);
-      }
-      setStatus('idle');
-    } catch {
-      setStatus('error');
-    } finally {
-      busyRef.current = false;
-    }
-  }, []);
-
-  /**
-   * Deep links. Every release used to be in the document, so any `#v0-4-1`
-   * shared before today has to keep working — including the ones that point
-   * into a chunk this page has not fetched. The browser has already given up
-   * on an unknown hash by the time this runs, so the chunk is pulled and the
-   * scroll is done by hand once the entry exists.
-   */
-  useEffect(() => {
-    const resolve = () => {
-      const anchor = decodeURIComponent(window.location.hash.slice(1));
-      const chunk = anchor ? chunkByAnchor[anchor] : undefined;
-
-      /*
-        Every path clears the pending anchor, including the ones with nothing
-        to do. The last hash is the only one the reader asked for, and the
-        cases that return here — a release already on the page, an unknown
-        anchor, an empty hash — are all cases the browser has already handled
-        or that mean nothing. Leaving a previous anchor standing through them
-        meant the next chunk to arrive would scroll the page off whatever the
-        reader had just navigated to, back to a release they had abandoned.
-      */
-      if (!chunk || chunk <= loadedRef.current) {
-        setPendingAnchor(null);
-        return;
-      }
-
-      setPendingAnchor(anchor);
-      void loadThrough(chunk);
-    };
-
-    resolve();
-    window.addEventListener('hashchange', resolve);
-    return () => window.removeEventListener('hashchange', resolve);
-  }, [chunkByAnchor, loadThrough]);
-
-  /** Scrolls once the release the hash asked for is actually in the DOM. */
-  useEffect(() => {
-    if (!pendingAnchor) return;
-    const target = document.getElementById(pendingAnchor);
-    if (!target) return;
-    target.scrollIntoView();
-    setPendingAnchor(null);
-  }, [pendingAnchor, releases]);
-
-  const remaining = total - releases.length;
-  const nextBatch = Math.min(perChunk, remaining);
-  const hasMore = loadedChunks < chunkCount;
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const { activeAnchor, pinned } = useActiveRelease(
+    sentinelRef,
+    releases.length,
+    initial[0]?.anchor ?? null,
+  );
 
   let previousYear = '';
 
   return (
     <>
+      <div className="border-b border-rule px-5 pb-6 pt-7 sm:px-9 sm:pb-7">
+        <ReleaseSpectrum
+          pulse={pulse}
+          activeAnchor={activeAnchor}
+          onSelect={jumpTo}
+        />
+      </div>
+      <div ref={sentinelRef} aria-hidden className="h-px" />
+
+      {/*
+        The history, pinned.
+
+        ── Why `fixed` and not `sticky` ───────────────────────────────────────
+
+        `sticky` was the obvious choice and it is the wrong one, because a
+        sticky element keeps its place in normal flow whether it is stuck or
+        not. Hidden, it left fifty-two pixels of blank between the band and the
+        first release; collapsed to nothing, the page jumped by fifty-two pixels
+        at the exact moment it pinned, because that flow space appears above the
+        viewport and everything below it moves down. There is no third option
+        with `sticky`: reserving the space and not reserving it are the only
+        two states, and both are wrong.
+
+        `fixed` reserves nothing, so neither happens.
+
+        What `fixed` costs is the frame: it spans the window rather than the
+        ruled column. The inner wrapper below buys that back by repeating the
+        page's own measure and padding, so the strip's columns land directly
+        under the band's. The full-bleed rule and blur behind it are a gain
+        rather than a compromise. Pinned, it reads as a toolbar under the
+        navbar, which is what it is.
+
+        `pointer-events-none` while hidden keeps an invisible bar from
+        swallowing clicks on the release underneath it.
+      */}
+      <div
+        className={[
+          'fixed inset-x-0 top-[var(--nextra-navbar-height,4rem)] z-20 border-b border-rule bg-background/88 backdrop-blur transition-[opacity,transform] duration-200',
+          pinned
+            ? 'opacity-100'
+            : 'pointer-events-none -translate-y-1 opacity-0',
+        ].join(' ')}
+      >
+        {/* The page's measure, repeated: `max-w-[76rem] px-4 sm:px-6` is the
+            outer container in `page.tsx` and `px-5 sm:px-9` is the padding
+            every band inside the frame uses. Together they put this drawing on
+            the same left edge as the one in the header. */}
+        <div className="mx-auto w-full max-w-[76rem] px-4 sm:px-6">
+          <div className="px-5 sm:px-9">
+            <ReleaseSpectrum
+              pulse={pulse}
+              activeAnchor={activeAnchor}
+              onSelect={jumpTo}
+              variant="strip"
+            />
+          </div>
+        </div>
+      </div>
+
       <div>
         {releases.map((release, index) => {
           const year = release.date.slice(0, 4);
@@ -179,59 +150,14 @@ export function ChangelogFeed({
         })}
       </div>
 
-      {hasMore ? (
-        <div className="border-b border-rule px-5 py-10 text-center sm:px-9">
-          <button
-            type="button"
-            onClick={() => void loadThrough(loadedChunks + 1)}
-            disabled={status === 'loading'}
-            className="inline-flex items-center gap-2 rounded-full border border-rule px-5 py-2.5 font-mono text-[11.5px] uppercase tracking-[0.14em] text-foreground transition-colors hover:border-primary/50 hover:text-primary disabled:cursor-wait disabled:opacity-60"
-          >
-            {status === 'loading' ? (
-              <>
-                <span
-                  aria-hidden
-                  className="size-1.5 animate-pulse rounded-full bg-primary"
-                />
-                Loading
-              </>
-            ) : status === 'error' ? (
-              'Retry'
-            ) : (
-              `Show ${nextBatch} earlier release${nextBatch === 1 ? '' : 's'}`
-            )}
-          </button>
-
-          <p
-            className="mt-3.5 font-mono text-[11px] tabular-nums text-muted-foreground"
-            aria-live="polite"
-          >
-            {status === 'error'
-              ? 'Could not reach the archive.'
-              : `${releases.length} of ${total} releases`}
-          </p>
-
-          <noscript>
-            <p className="mt-3.5 text-[13px] text-muted-foreground">
-              The remaining {remaining} releases load on demand and need
-              JavaScript. They are also on{' '}
-              <a
-                className="underline underline-offset-2 hover:text-primary"
-                href="https://github.com/AbianS/rustrak/releases"
-              >
-                GitHub Releases
-              </a>
-              .
-            </p>
-          </noscript>
-        </div>
-      ) : (
-        <div className="border-b border-rule px-5 py-10 text-center sm:px-9">
-          <p className="font-mono text-[11px] uppercase tracking-[0.24em] text-muted-foreground">
-            The first release
-          </p>
-        </div>
-      )}
+      <ArchiveFooter
+        loaded={releases.length}
+        total={total}
+        nextBatch={Math.min(perChunk, total - releases.length)}
+        status={status}
+        hasMore={loadedChunks < chunkCount}
+        onLoadMore={() => void loadThrough(loadedChunks + 1)}
+      />
     </>
   );
 }

--- a/apps/docs/src/components/changelog/release-article.tsx
+++ b/apps/docs/src/components/changelog/release-article.tsx
@@ -17,6 +17,19 @@ import { cn } from '@/lib/utils';
  * one — the version is monospaced, the title is display type, a section is a
  * numbered rule, and the body is prose. Two levels that differ only in font
  * size collapse into one the moment the page is scrolled quickly.
+ *
+ * ── What the redesign changed, and why ─────────────────────────────────────
+ *
+ * The body used to fill its whole track. In the widest layout that came to
+ * around 95 characters a line, set at 14.5px in `--muted-foreground`. Three
+ * separate reasons for the same complaint, which was that the page was hard to
+ * read on a large monitor. All three are fixed below and in `globals.css`: the
+ * column is capped at a measure, the type went up a step, and the body is no
+ * longer painted in the colour reserved for metadata.
+ *
+ * The right-hand track used to hold the tags, which meant eleven rems of a wide
+ * screen were spent on two words. It holds the release's section index now, and
+ * the tags moved to the left rail where the rest of the metadata already was.
  */
 
 const CHANNEL_LABEL: Record<ReleaseChannel, string> = {
@@ -43,6 +56,31 @@ const KIND_TICK: Record<SectionKind, string> = {
   documented: 'bg-foreground/25',
 };
 
+/**
+ * How far below the top of the viewport an anchored element should land.
+ *
+ * It is the pinned strip's height and *not* the navbar's, which is the part
+ * that is easy to get wrong. This file did, and every jump overshot by 64px.
+ * Nextra already sets `scroll-padding-top: var(--nextra-navbar-height)` on
+ * `html`, and `scroll-padding` on the scroll container adds to `scroll-margin`
+ * on the target rather than replacing it. Counting the navbar here counted it
+ * twice, and a release landed a whole navbar below the bar it was supposed to
+ * sit under, far enough that the reading line was still inside the *previous*
+ * release and the strip named that one instead.
+ *
+ * So this covers only what Nextra does not know about, which is the strip.
+ */
+const ANCHOR_OFFSET = 'scroll-mt-[3.5rem]';
+
+/**
+ * A section's own anchor, namespaced by its release. Section titles repeat
+ * across the archive (a dozen entries have an "Improvements"), so the release
+ * anchor has to be part of it or the index in one entry would jump to another.
+ */
+function sectionId(anchor: string, title: string): string {
+  return `${anchor}--${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+}
+
 function ChannelChip({ channel }: { channel: ReleaseChannel }) {
   return (
     <span
@@ -59,12 +97,17 @@ function ChannelChip({ channel }: { channel: ReleaseChannel }) {
 function Section({
   section,
   index,
+  anchor,
 }: {
   section: Release['sections'][number];
   index: number;
+  anchor: string;
 }) {
   return (
-    <section className="mt-9 first:mt-8">
+    <section
+      id={section.title ? sectionId(anchor, section.title) : undefined}
+      className={cn('mt-10 scroll-mt-[4.5rem] first:mt-8')}
+    >
       {section.title && (
         <div className="flex items-center gap-3">
           <span
@@ -87,7 +130,7 @@ function Section({
         </div>
       )}
       <div
-        className={cn('changelog-prose', section.title && 'mt-3.5 pl-[1.4rem]')}
+        className={cn('changelog-prose', section.title && 'mt-4 pl-[1.4rem]')}
         /* The HTML is this repo's own changelog MDX, parsed by `marked` at
            build time. Nothing user-supplied reaches it: the only inputs are
            files in content/changelog/, which are as trusted as the code. */
@@ -100,10 +143,15 @@ function Section({
 }
 
 export function ReleaseArticle({ release }: { release: Release }) {
+  const titled = release.sections.filter((section) => section.title);
+
   return (
     <article
       id={release.anchor}
-      className="border-b border-rule scroll-mt-[calc(var(--nextra-navbar-height,4rem)+1rem)]"
+      // Read by the feed's observer to work out which release the reader is
+      // inside, which is what lights a column in the spectrum.
+      data-release={release.anchor}
+      className={cn('border-b border-rule', ANCHOR_OFFSET)}
     >
       {/*
         The filename anchor, kept because it is what every link to this page
@@ -113,34 +161,32 @@ export function ReleaseArticle({ release }: { release: Release }) {
       <span
         id={release.slug}
         aria-hidden
-        className="block scroll-mt-[calc(var(--nextra-navbar-height,4rem)+1rem)]"
+        className={cn('block', ANCHOR_OFFSET)}
       />
 
       {/*
-        The same three tracks the blog uses — meta, body, aside — so the two
-        sections of the site are one layout at one width rather than two pages
-        that happen to share a palette.
+        Three tracks: metadata, the document, its index.
 
-        Below `lg` the tracks collapse and the order is set explicitly: the
-        version strip first, then the tags, then the body. In a wide grid the
-        tags belong beside the entry; stacked, they belong under its title,
-        and `order` is what lets one piece of markup be in both places.
+        The middle one is capped at a measure rather than filling the space
+        between the other two. See the header note. The consequence worth
+        naming is that the frame can now be as wide as the composition wants
+        without the prose getting any harder to read, which is what makes the
+        spectrum above it possible at all.
+
+        Below `lg` the tracks collapse into ordinary blocks and the index is
+        dropped: on a phone it would be a list of four links directly above the
+        four things they link to.
       */}
-      <div className="flex flex-col px-5 pb-14 sm:px-9 sm:pb-16 lg:grid lg:grid-cols-[9.5rem_minmax(0,1fr)_12rem] lg:gap-x-10 lg:pt-14">
+      <div className="px-5 pb-14 pt-9 sm:px-9 sm:pb-16 lg:grid lg:grid-cols-[9.5rem_minmax(0,1fr)] lg:gap-x-10 lg:pt-12 xl:grid-cols-[9.5rem_minmax(0,1fr)_11rem]">
         {/*
-          Pinned while the release is on screen. A long entry runs several
-          screens deep, and without this the reader has to scroll back up to
-          find out which version the fix they are reading actually landed in.
-
-          Narrow, it is a bar across the top with a background to scroll under.
-          Wide, it is a block in the left track and needs none of that chrome —
-          it has a column of its own to sit in, so the rule, the tint and the
-          blur all come off and only the pinning survives.
+          Left rail. It no longer pins: the spectrum's strip is pinned across
+          the top of the page and already names the release the reader is in,
+          and two sticky version labels a few pixels apart is one too many.
         */}
-        <div className="sticky top-[var(--nextra-navbar-height,4rem)] z-10 -mx-5 flex items-center gap-2.5 border-b border-rule/70 bg-background/85 px-5 py-3 backdrop-blur sm:-mx-9 sm:px-9 lg:col-start-1 lg:row-start-1 lg:mx-0 lg:block lg:self-start lg:border-0 lg:bg-transparent lg:px-0 lg:py-0 lg:backdrop-blur-none lg:top-[calc(var(--nextra-navbar-height,4rem)+3.5rem)]">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2.5 lg:col-start-1 lg:row-start-1 lg:block lg:self-start">
           <a
             href={`#${release.anchor}`}
-            className="group/anchor font-mono text-[15px] font-medium tracking-tight text-foreground transition-colors hover:text-primary lg:block"
+            className="group/anchor font-mono text-[17px] font-medium tracking-tight text-foreground transition-colors hover:text-primary lg:block"
           >
             {release.version}
             <span
@@ -151,64 +197,103 @@ export function ReleaseArticle({ release }: { release: Release }) {
             </span>
             <span className="sr-only">Permalink to {release.version}</span>
           </a>
-          <span className="lg:mt-2.5 lg:block">
+
+          <span className="lg:mt-3 lg:block">
             <ChannelChip channel={release.channel} />
           </span>
+
           <time
             dateTime={release.date}
-            className="ml-auto font-mono text-[11.5px] tabular-nums text-muted-foreground lg:ml-0 lg:mt-3 lg:block"
+            className="font-mono text-[11.5px] tabular-nums text-muted-foreground lg:mt-3 lg:block"
           >
             {formatReleaseDate(release.date)}
           </time>
-        </div>
 
-        {release.tags.length > 0 && (
-          <ul className="order-1 mt-5 flex flex-wrap items-center gap-x-2 gap-y-1.5 lg:order-none lg:col-start-3 lg:row-start-1 lg:mt-1 lg:flex-col lg:items-start lg:gap-1.5">
-            {release.tags.map((tag) => (
-              <li
-                key={tag}
-                className="rounded-sm bg-foreground/[0.055] px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
-              >
-                {tag}
-              </li>
-            ))}
-          </ul>
-        )}
-
-        <div className="order-2 lg:order-none lg:col-start-2 lg:row-start-1">
-          <h2 className="pt-8 text-[1.6rem] font-medium leading-[1.15] tracking-[-0.025em] text-foreground sm:text-[1.9rem] lg:pt-0">
-            {release.title}
-          </h2>
-          {release.description && (
-            <p className="mt-3 max-w-[62ch] text-[15px] leading-relaxed text-muted-foreground">
-              {release.description}
-            </p>
+          {release.tags.length > 0 && (
+            <ul className="flex w-full flex-wrap items-center gap-1.5 lg:mt-5 lg:w-auto">
+              {release.tags.map((tag) => (
+                <li
+                  key={tag}
+                  className="rounded-sm bg-foreground/[0.055] px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+                >
+                  {tag}
+                </li>
+              ))}
+            </ul>
           )}
-
-          {/*
-            Numbered across the titled sections only. A file that opens with a
-            paragraph produces an untitled lead section, and counting it would
-            make every entry that has one start at 02.
-          */}
-          {(() => {
-            let number = 0;
-            return release.sections.map((section, index) => {
-              if (section.title) number += 1;
-              return (
-                // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-                <Section
-                  // The title is the key wherever there is one. The index is
-                  // reached only by the untitled lead section, of which a
-                  // release has at most one, in a list parsed once from static
-                  // MDX and never reordered.
-                  key={section.title || index}
-                  section={section}
-                  index={number}
-                />
-              );
-            });
-          })()}
         </div>
+
+        <div className="lg:col-start-2 lg:row-start-1">
+          <div className="max-w-[40rem]">
+            <h2 className="mt-7 text-[1.55rem] font-medium leading-[1.2] tracking-[-0.022em] text-foreground sm:text-[1.75rem] lg:mt-0">
+              {release.title}
+            </h2>
+            {release.description && (
+              <p className="changelog-lead mt-3.5">{release.description}</p>
+            )}
+
+            {/*
+              Numbered across the titled sections only. A file that opens with a
+              paragraph produces an untitled lead section, and counting it would
+              make every entry that has one start at 02.
+            */}
+            {(() => {
+              let number = 0;
+              return release.sections.map((section, index) => {
+                if (section.title) number += 1;
+                return (
+                  // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+                  <Section
+                    // The title is the key wherever there is one. The index is
+                    // reached only by the untitled lead section, of which a
+                    // release has at most one, in a list parsed once from static
+                    // MDX and never reordered.
+                    key={section.title || index}
+                    section={section}
+                    index={number}
+                    anchor={release.anchor}
+                  />
+                );
+              });
+            })()}
+          </div>
+        </div>
+
+        {/*
+          The index, and the reason the third track earns its width now. Two
+          sections is the threshold: below it the index would be a link to the
+          only heading in the entry, sitting level with that heading.
+
+          It pins, unlike the left rail, because that is the difference between
+          a list of contents and a way of moving around: a five-section release
+          runs past three screens and the index has to still be there on the
+          third.
+        */}
+        {titled.length > 1 && (
+          <nav
+            aria-label={`Sections of ${release.version}`}
+            className="hidden xl:col-start-3 xl:row-start-1 xl:block xl:self-start xl:sticky xl:top-[calc(var(--nextra-navbar-height,4rem)+4.5rem)]"
+          >
+            <p className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/70">
+              In this release
+            </p>
+            <ul className="mt-3.5 flex flex-col gap-2 border-l border-rule pl-3.5">
+              {titled.map((section, index) => (
+                <li key={section.title}>
+                  <a
+                    href={`#${sectionId(release.anchor, section.title)}`}
+                    className="group/sec flex gap-2 text-[12px] leading-snug text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <span className="font-mono tabular-nums text-muted-foreground/60">
+                      {String(index + 1).padStart(2, '0')}
+                    </span>
+                    <span className="min-w-0">{section.title}</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
       </div>
     </article>
   );

--- a/apps/docs/src/components/changelog/release-spectrum.tsx
+++ b/apps/docs/src/components/changelog/release-spectrum.tsx
@@ -1,0 +1,440 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  formatReleaseDate,
+  type ReleasePulse,
+  type SectionKind,
+} from '@/lib/release';
+import { cn } from '@/lib/utils';
+
+/**
+ * The whole release history, drawn.
+ *
+ * ── What it is ─────────────────────────────────────────────────────────────
+ *
+ * One column per release, oldest on the left. A column's height is how many
+ * changes that release carried and its banding is what kind they were, so the
+ * shape of the project is legible before a word of it is read: the tall lime
+ * columns are the minors that added something, the short amber ones are the
+ * patches that fixed something, and how far apart the axis marks fall is how
+ * fast the thing moved.
+ *
+ * ── Why the page needed it ─────────────────────────────────────────────────
+ *
+ * A changelog with forty-one entries and no map is a scroll with no bottom. The
+ * previous design spent a twelve-rem column on two tag chips and gave a reader
+ * arriving on a wide monitor nothing to navigate with; this is that width spent
+ * on the one thing a changelog reader actually wants, which is to get to a
+ * version. It is a picture and an index at once, and it costs about 5KB of data
+ * because a column only needs five numbers to draw.
+ *
+ * ── The two variants ───────────────────────────────────────────────────────
+ *
+ * `full` sits in the page header at reading size, with a time axis under it.
+ * `strip` is the same drawing at 18px, pinned under the navbar once the header
+ * has gone by. The history becomes the scrollbar, and the lit column is where
+ * you are. That is the whole idea: the navigation is not a widget bolted to the
+ * page, it is the data.
+ *
+ * Every column is a real `<a href="#v0-13-0">`, so the map works before
+ * hydration and a middle click opens a release in a tab. The click handler is
+ * an interception for one case only: a release too old to be on the page yet,
+ * which has to be fetched before it can be scrolled to.
+ */
+
+/**
+ * Bottom to top. `shipped` sits at the base because it is the part of a release
+ * a reader is looking for; stacking fixes under features would bury the signal
+ * under the noise in exactly the releases that have most of both.
+ *
+ * ── Why the greys are so faint ─────────────────────────────────────────────
+ *
+ * They were `foreground/30` and `foreground/15`, and drawn that way the band
+ * came out grey. Nearly every release has an "Improvements" section, so the
+ * grey is the one band present in almost every column, and at 30% on white it
+ * out-weighed the lime beside it. Forty-one columns of mud with some green in
+ * them. Only two things in this drawing are worth a reader's eye, what a
+ * release added and what it fixed, and now only those two carry colour. The
+ * greys are a ground for them to sit on.
+ *
+ * Written as literal classes rather than assembled from the kind, because
+ * Tailwind scans source text and never generates a class built from a variable.
+ */
+const KIND_FILL: Record<SectionKind, string> = {
+  shipped: 'bg-primary',
+  improved: 'bg-foreground/14',
+  // The one colour that needs saying twice. A translucent amber composites
+  // against whatever is behind it, and behind it is white in one theme and
+  // near-black in the other: `amber-500/55` is a clean pale gold on the light
+  // page and a muddy brown on the dark one. The greys and the lime do not have
+  // this problem: the greys are mixed from `--foreground`, which flips with
+  // the theme, and the lime is opaque.
+  fixed: 'bg-amber-500/55 dark:bg-amber-400/75',
+  documented: 'bg-foreground/7',
+};
+
+/**
+ * The same four, as legend chips.
+ *
+ * They are stronger than the bands they stand for, and deliberately. A band is
+ * a shape twenty pixels wide and the eye reads its *area*; a chip is an eight
+ * pixel square, and `foreground/7` at that size is an empty space next to a
+ * number. The chip's job is to say which category the count belongs to, which
+ * it cannot do while being invisible.
+ */
+const KIND_CHIP: Record<SectionKind, string> = {
+  shipped: 'bg-primary',
+  improved: 'bg-foreground/35',
+  fixed: 'bg-amber-500/80 dark:bg-amber-400/90',
+  documented: 'bg-foreground/18',
+};
+
+const KIND_ORDER: SectionKind[] = [
+  'documented',
+  'fixed',
+  'improved',
+  'shipped',
+];
+
+const KIND_LABEL: Record<SectionKind, string> = {
+  shipped: 'Shipped',
+  improved: 'Improved',
+  fixed: 'Fixed',
+  documented: 'Docs',
+};
+
+/**
+ * The shortest column as a fraction of the tallest.
+ *
+ * Purely linear, a two-change patch next to a twenty-two-change minor is nine
+ * percent of the track, two pixels in the strip, which reads as a gap in the
+ * history rather than as a release. The floor buys the small ones a presence
+ * without flattening the difference: across this archive the range still runs
+ * about four to one, which is the ratio that carries the meaning.
+ */
+const MIN_HEIGHT = 0.17;
+
+/**
+ * How close two axis labels may sit, as a fraction of the band.
+ *
+ * A label is a tick, a gap and three or four monospaced characters: call it
+ * 34px, which at a desktop band of roughly 1080px is a little over 3%. The
+ * threshold is set well above that because the labels are positioned at the
+ * *start* of their period, and periods here are wildly uneven: this archive has
+ * two releases in January and seventeen in June, so a purely faithful axis puts
+ * February and March nine pixels apart and then leaves half the band empty.
+ */
+const MIN_MARK_GAP = 0.06;
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+type AxisMark = { index: number; label: string };
+
+/**
+ * The time axis, at whichever resolution the archive actually has.
+ *
+ * Years are the obvious unit and they are the wrong one for most of a project's
+ * life: every release in this changelog is dated 2026, so a year axis is a
+ * single label in the bottom-left corner saying nothing. It falls back to months
+ * when the whole archive fits in one year, which is where the interesting shape
+ * is anyway. Seven month marks across this band show the release cadence going
+ * from one a month to seventeen, which is a fact about the project that the
+ * columns alone cannot tell you.
+ *
+ * Crowded labels are dropped rather than shrunk or rotated. A mark exists to
+ * say roughly where in time the reader is; four of them overlapping says less
+ * than two of them legible.
+ */
+function axisMarks(columns: ReleasePulse[]): AxisMark[] {
+  if (columns.length === 0) return [];
+
+  const byYear =
+    columns[0].date.slice(0, 4) !== columns.at(-1)?.date.slice(0, 4);
+
+  const all: AxisMark[] = [];
+  let previous = '';
+  columns.forEach((entry, index) => {
+    const period = byYear ? entry.date.slice(0, 4) : entry.date.slice(0, 7);
+    if (period === previous) return;
+    previous = period;
+    all.push({
+      index,
+      label: byYear
+        ? period
+        : (MONTHS[Number(period.slice(5, 7)) - 1] ?? period),
+    });
+  });
+
+  // The first mark is always kept: it is the left edge of the whole history,
+  // and dropping it would leave the band starting at nothing.
+  const kept: AxisMark[] = [];
+  let lastKept = Number.NEGATIVE_INFINITY;
+  for (const mark of all) {
+    const position = mark.index / columns.length;
+    if (kept.length === 0 || position - lastKept >= MIN_MARK_GAP) {
+      kept.push(mark);
+      lastKept = position;
+    }
+  }
+  return kept;
+}
+
+type Props = {
+  /** Newest first, as `getPulse()` returns it. Reversed here for drawing. */
+  pulse: ReleasePulse[];
+  activeAnchor: string | null;
+  /**
+   * Called before the browser follows the link. Returning `true` means the
+   * navigation was handled here (the release had to be fetched first) and the
+   * default should be prevented.
+   */
+  onSelect: (anchor: string) => boolean;
+  variant?: 'full' | 'strip';
+};
+
+export function ReleaseSpectrum({
+  pulse,
+  activeAnchor,
+  onSelect,
+  variant = 'full',
+}: Props) {
+  const [hovered, setHovered] = useState<number | null>(null);
+
+  // Time reads left to right. The archive is stored newest first because that
+  // is the order it is read in, so the one reversal lives here.
+  const columns = [...pulse].reverse();
+  const max = Math.max(...columns.map((entry) => entry.total), 1);
+  const strip = variant === 'strip';
+
+  const marks = axisMarks(columns);
+  const shown = hovered === null ? null : columns[hovered];
+
+  return (
+    <div
+      className={cn('relative', strip ? 'py-1.5' : 'pt-1')}
+      onPointerLeave={() => setHovered(null)}
+    >
+      {/*
+        The readout. It replaces the bars' own labels rather than sitting beside
+        them: at 26px a column has no room for a version number, and forty-one
+        tooltips positioned individually is forty-one chances to overflow the
+        frame. One readout in a fixed place also means the eye never has to
+        chase it along the band.
+
+        In the strip it is the left-hand label and shows wherever the reader is
+        even when nothing is hovered, which is what makes the pinned bar answer
+        "which release am I in" without being asked.
+      */}
+      {strip ? (
+        <StripReadout
+          entry={
+            shown ?? columns.find((c) => c.anchor === activeAnchor) ?? null
+          }
+        />
+      ) : (
+        <FullReadout entry={shown} total={pulse.length} />
+      )}
+
+      <nav
+        aria-label={strip ? undefined : 'Release history'}
+        aria-hidden={strip || undefined}
+        className={cn(
+          'flex items-end',
+          // The gap is a hairline on a phone and doubles from `sm`. Forty
+          // columns of gap at 2px is eighty pixels, a quarter of a 330px band.
+          // The separators would be as wide as the things they separate.
+          strip ? 'h-[18px] gap-px' : 'h-24 gap-px sm:h-28 sm:gap-[2px]',
+          // The columns stand on a rule rather than floating on the page. It is
+          // the same hairline the rest of the frame is drawn with, and it is
+          // what makes the band read as a figure with an axis instead of as a
+          // row of shapes that happen to be bottom-aligned.
+          !strip && 'border-b border-rule',
+        )}
+      >
+        {columns.map((entry, index) => {
+          const active = entry.anchor === activeAnchor;
+          const isHovered = hovered === index;
+          const height = MIN_HEIGHT + (1 - MIN_HEIGHT) * (entry.total / max);
+
+          return (
+            <a
+              key={entry.anchor}
+              href={`#${entry.anchor}`}
+              // The strip redraws the nav above it. One tab stop per release is
+              // plenty; two is a keyboard user walking the archive twice.
+              tabIndex={strip ? -1 : undefined}
+              onPointerEnter={() => setHovered(index)}
+              onFocus={() => setHovered(index)}
+              onClick={(event) => {
+                if (onSelect(entry.anchor)) event.preventDefault();
+              }}
+              className={cn(
+                'group/col relative flex h-full min-w-0 flex-1 flex-col justify-end outline-none',
+                // The hit area is the full height of the band, not the height
+                // of the column. A two-change patch is 17% tall and would
+                // otherwise be a four-pixel target at the bottom of the frame.
+                'before:absolute before:inset-x-0 before:inset-y-0 before:content-[""]',
+              )}
+            >
+              <span
+                style={{ height: `${height * 100}%` }}
+                className={cn(
+                  // A hairline between the bands, so a column reads as a stack
+                  // of counts rather than one shape that changes colour twice.
+                  'flex w-full flex-col gap-px overflow-hidden transition-[opacity,filter] duration-200',
+                  strip ? 'rounded-[1px]' : 'rounded-t-[2px]',
+                  // Dimming the rest is what makes one column readable in a row
+                  // of forty-one. Nothing moves and nothing resizes: a band that
+                  // reflows under the pointer cannot be aimed at.
+                  hovered !== null && !isHovered && 'opacity-35',
+                  active && 'ring-1 ring-primary/45 ring-offset-0',
+                )}
+              >
+                {KIND_ORDER.map((kind) => {
+                  const count = entry.counts[kind];
+                  if (count === 0) return null;
+                  return (
+                    <span
+                      key={kind}
+                      style={{ flexGrow: count }}
+                      className={cn('w-full', KIND_FILL[kind])}
+                    />
+                  );
+                })}
+              </span>
+
+              {/* The marker for where the reader is. A cap above the column
+                  rather than a colour change inside it, so it survives a
+                  release whose bands are already lime. */}
+              <span
+                aria-hidden
+                className={cn(
+                  'absolute inset-x-0 -top-1 h-[3px] rounded-full bg-primary transition-opacity duration-200',
+                  active ? 'opacity-100' : 'opacity-0',
+                )}
+              />
+
+              <span className="sr-only">
+                {entry.version}, {entry.title}, {formatReleaseDate(entry.date)},{' '}
+                {entry.total} changes
+              </span>
+            </a>
+          );
+        })}
+      </nav>
+
+      {!strip && (
+        <div aria-hidden className="relative mt-2.5 h-4">
+          {marks.map((mark, index) => (
+            <span
+              key={mark.label}
+              style={{ left: `${(mark.index / columns.length) * 100}%` }}
+              className={cn(
+                'absolute top-0 items-center gap-1.5 font-mono text-[10.5px] tabular-nums text-muted-foreground',
+                // A phone gives the band about 330px, where the 6% minimum gap
+                // is twenty pixels and a three-letter month is twenty-four. The
+                // first mark still anchors the left edge; the rest wait for the
+                // room to be legible in.
+                index === 0 ? 'flex' : 'hidden sm:flex',
+              )}
+            >
+              <span className="h-2 w-px bg-rule" />
+              {mark.label}
+            </span>
+          ))}
+          <span className="absolute right-0 top-0 font-mono text-[10.5px] uppercase tracking-[0.14em] text-muted-foreground">
+            Now
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The header readout. Two lines held at a fixed height, because a block that
+ * grows when the pointer enters the band pushes the band itself down by the
+ * height of the thing that just appeared, and the column under the pointer is
+ * then a different column.
+ */
+function FullReadout({
+  entry,
+  total,
+}: {
+  entry: ReleasePulse | null;
+  total: number;
+}) {
+  return (
+    <div className="mb-3 flex h-9 flex-wrap items-baseline gap-x-3 gap-y-1">
+      {entry ? (
+        <>
+          <span className="font-mono text-[15px] font-medium tracking-tight text-foreground">
+            {entry.version}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[13.5px] text-muted-foreground">
+            {entry.title}
+          </span>
+          <span className="flex shrink-0 items-center gap-2.5">
+            {KIND_ORDER.slice()
+              .reverse()
+              .map((kind) =>
+                entry.counts[kind] === 0 ? null : (
+                  <span
+                    key={kind}
+                    className="flex items-center gap-1.5 font-mono text-[11px] tabular-nums text-muted-foreground"
+                  >
+                    <span
+                      aria-hidden
+                      className={cn('size-2 rounded-[1px]', KIND_CHIP[kind])}
+                    />
+                    {entry.counts[kind]}
+                    <span className="sr-only">{KIND_LABEL[kind]}</span>
+                  </span>
+                ),
+              )}
+          </span>
+          <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
+            {formatReleaseDate(entry.date)}
+          </span>
+        </>
+      ) : (
+        <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          {total} releases
+          <span className="mx-2 text-rule">/</span>
+          <span className="normal-case tracking-normal">
+            hover the band to read one, click to jump
+          </span>
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** The pinned bar's label: whichever release is under the pointer, or failing
+ *  that whichever one the reader is currently inside. */
+function StripReadout({ entry }: { entry: ReleasePulse | null }) {
+  return (
+    <div className="mb-1.5 flex items-baseline gap-2.5 overflow-hidden">
+      <span className="shrink-0 font-mono text-[12px] font-medium tracking-tight text-foreground">
+        {entry?.version ?? '—'}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-[11.5px] text-muted-foreground">
+        {entry?.title ?? 'Changelog'}
+      </span>
+    </div>
+  );
+}

--- a/apps/docs/src/components/changelog/use-active-release.ts
+++ b/apps/docs/src/components/changelog/use-active-release.ts
@@ -1,0 +1,153 @@
+'use client';
+
+import { type RefObject, useEffect, useState } from 'react';
+
+/**
+ * Which release the reader is currently inside, and whether the pinned strip
+ * should be showing.
+ *
+ * ── Why a thin band and not the viewport ───────────────────────────────────
+ *
+ * A release entry runs several screens deep, so at any moment most of the
+ * viewport belongs to one of them and "the most visible article" is a tie
+ * between whichever two happen to share the fold. The marker would sit on the
+ * wrong release for half of every scroll. What is wanted is the release under
+ * the top edge of the reading area, and a 5%-tall observation band just below
+ * the navbar selects exactly that, because only one article can cross a line.
+ *
+ * ── Why the sentinel gets its own observer ─────────────────────────────────
+ *
+ * It was in the one above, sharing the band, and that was a bug rather than an
+ * economy. An `IntersectionObserver` only calls back when an element *crosses*
+ * a boundary, and the boundary is the root rect after `rootMargin`, not the
+ * viewport. So the sentinel's last callback fired as it left the band's top
+ * edge, 15% of the way down the screen, and the test it was being put through
+ * ("is it above the viewport?") was false at exactly the moment it was asked.
+ * Nothing crossed anything after that, so no further callback ever came and the
+ * strip never appeared at all.
+ *
+ * Two observers, each with the boundary it actually cares about, and each
+ * comparing against `rootBounds` rather than against zero, which is the same
+ * mistake stated in general form, since `rootBounds` *is* where the crossing
+ * happens.
+ */
+
+/**
+ * The strip's own height, so the crossing boundary can be its bottom edge.
+ *
+ * Hardcoded rather than measured: the strip is `position: fixed` and hidden
+ * when this matters, so reading its box would mean measuring an element that is
+ * deliberately not participating in layout, and a `ResizeObserver` for a bar of
+ * fixed content is more machinery than a number. It is a readout line, an 18px
+ * band and its padding. See `release-spectrum.tsx`. Being a few pixels out
+ * moves when the strip appears by a few pixels and nothing else.
+ */
+const STRIP_HEIGHT = 55;
+
+function navbarHeight(): number {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(
+    '--nextra-navbar-height',
+  );
+  return Number.parseFloat(raw) || 64;
+}
+
+export function useActiveRelease(
+  sentinelRef: RefObject<HTMLElement | null>,
+  /** Re-runs the observation when the set of rendered articles changes. */
+  count: number,
+  initialAnchor: string | null,
+) {
+  const [activeAnchor, setActiveAnchor] = useState<string | null>(
+    initialAnchor,
+  );
+  const [pinned, setPinned] = useState(false);
+
+  /** The strip, driven by the sentinel that sits under the header band. */
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        // Above the boundary, not merely outside it: the sentinel is also
+        // "not intersecting" while it is still below the fold, which is the
+        // whole of a first page load.
+        const boundary = entry.rootBounds?.top ?? 0;
+        setPinned(
+          !entry.isIntersecting && entry.boundingClientRect.top < boundary,
+        );
+      },
+      // The boundary is the strip's own bottom edge, so the band is pinned at
+      // the moment the header's copy of it would have scrolled underneath, so
+      // the two never overlap and nothing is on screen twice.
+      { rootMargin: `-${navbarHeight() + STRIP_HEIGHT}px 0px 0px 0px` },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [sentinelRef]);
+
+  /** The marker, driven by whichever article crosses the reading line. */
+  useEffect(() => {
+    const articles = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-release]'),
+    );
+    if (!articles.length) return;
+
+    /*
+      DOM order is release order, newest first, and the band is tall enough
+      that two articles can cross it at once, one ending in it and one
+      starting. The winner is the one that started last, which is the *higher*
+      index, because that is the release filling the screen below the line.
+
+      This was the lower index and it was visibly wrong: landing on a release
+      via the spectrum put its top a few pixels under the band, so the entry
+      above it was still clipping the band's upper edge, and the strip named
+      the release the reader had just jumped away from.
+    */
+    const order = new Map(
+      articles.map((node, index) => [node.dataset.release ?? '', index]),
+    );
+    const crossing = new Set<string>();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const anchor = (entry.target as HTMLElement).dataset.release ?? '';
+          if (entry.isIntersecting) crossing.add(anchor);
+          else crossing.delete(anchor);
+        }
+
+        let best: string | null = null;
+        let bestIndex = Number.NEGATIVE_INFINITY;
+        for (const anchor of crossing) {
+          const index = order.get(anchor) ?? Number.NEGATIVE_INFINITY;
+          if (index > bestIndex) {
+            bestIndex = index;
+            best = anchor;
+          }
+        }
+
+        // Held rather than cleared when nothing crosses. The band is empty
+        // between two articles and at both ends of the page, and blanking the
+        // marker there makes it flicker on an ordinary scroll.
+        if (best) setActiveAnchor(best);
+      },
+      /*
+        The band sits at a fifth of the way down rather than at a seventh, and
+        the extra is not cosmetic. An anchored release lands with its top just
+        under the pinned strip, around 120px, so a line drawn any higher than
+        that is still inside the entry above it, and the strip would name the
+        release the reader had just left. A fifth of the viewport clears 120px
+        on anything 600px tall or more, and below that the tie-break above
+        catches it.
+      */
+      { rootMargin: '-20% 0px -75% 0px' },
+    );
+
+    for (const article of articles) observer.observe(article);
+    return () => observer.disconnect();
+  }, [count]);
+
+  return { activeAnchor, pinned };
+}

--- a/apps/docs/src/components/changelog/use-release-archive.ts
+++ b/apps/docs/src/components/changelog/use-release-archive.ts
@@ -1,0 +1,161 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Release, ReleaseChunk } from '@/lib/release';
+
+/**
+ * The archive: which releases are on the page, and how to go and get the rest.
+ *
+ * It exists for one reason. The page ships the ten most recent releases and
+ * nothing else, because rendering every release on one URL was 604KB of HTML
+ * growing by a release a fortnight. Older ones are fetched a chunk at a time
+ * from static JSON generated at build time (`changelog/releases/[chunk]`),
+ * which keeps the first response the same size in two years as it is today.
+ *
+ * So the reveal is a real fetch, not a stack of hidden markup with a button
+ * over it. That distinction is the entire exercise: hiding it in CSS would
+ * have left all 604KB in the document and only moved the scrollbar.
+ *
+ * Split out of `changelog-feed.tsx` when the spectrum landed: two consumers
+ * need to jump to a release that may not be loaded (a deep link and a click on
+ * the spectrum), and the component that renders the feed should not also be the
+ * place that owns a fetch loop and two effects' worth of scroll restoration.
+ */
+
+const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+export type ArchiveStatus = 'idle' | 'loading' | 'error';
+
+type Options = {
+  initial: Release[];
+  /**
+   * Which chunk every anchor lives in, including the legacy filename anchors,
+   * so a deep link into a release that has not been fetched yet can pull the
+   * chunks it needs instead of landing on the wrong entry.
+   */
+  chunkByAnchor: Record<string, number>;
+};
+
+export function useReleaseArchive({ initial, chunkByAnchor }: Options) {
+  const [releases, setReleases] = useState<Release[]>(initial);
+  const [loadedChunks, setLoadedChunks] = useState(1);
+  const [status, setStatus] = useState<ArchiveStatus>('idle');
+  const [pendingAnchor, setPendingAnchor] = useState<string | null>(null);
+
+  // Mirrors of the values the async loop reads between awaits. State would be
+  // stale inside the loop and would also make `loadThrough` a new function on
+  // every render, which the hash listener below depends on it not being.
+  const loadedRef = useRef(1);
+  const busyRef = useRef(false);
+  // How far the loop has been asked to go. A ref rather than an argument
+  // because a second caller has to be able to raise it while the first is
+  // still running. See the note in `loadThrough`.
+  const targetRef = useRef(1);
+
+  const loadThrough = useCallback(async (target: number) => {
+    // Raised before the busy check, and never lowered. A request that arrives
+    // mid-flight used to be dropped on the floor: it returned here because the
+    // loop was busy, and the loop it returned to was bounded by the target of
+    // whoever started it. So a deep link into chunk four landing while chunk
+    // two was in the air left `pendingAnchor` set on a release that would
+    // never be fetched, and the page simply never scrolled. Now the running
+    // loop reads this on every pass and carries on to the further target.
+    targetRef.current = Math.max(targetRef.current, target);
+    if (busyRef.current || targetRef.current <= loadedRef.current) return;
+    busyRef.current = true;
+    setStatus('loading');
+
+    try {
+      while (loadedRef.current < targetRef.current) {
+        const chunk = loadedRef.current + 1;
+        const response = await fetch(
+          `${BASE_PATH}/changelog/releases/${chunk}`,
+        );
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const payload = (await response.json()) as ReleaseChunk;
+
+        // Appended per chunk rather than once at the end: a failure on the
+        // third request should keep the two that succeeded on the page.
+        loadedRef.current = chunk;
+        setReleases((current) => [...current, ...payload.releases]);
+        setLoadedChunks(chunk);
+      }
+      setStatus('idle');
+    } catch {
+      setStatus('error');
+    } finally {
+      busyRef.current = false;
+    }
+  }, []);
+
+  /**
+   * A jump from the spectrum.
+   *
+   * Returns whether it took over the navigation. For a release already on the
+   * page it returns `false` and the browser follows the `href` itself, which is
+   * the better outcome in every way: native scroll, a real history entry, and a
+   * hash the reader can copy out of the address bar. Only an unfetched release
+   * is handled here, because there is nothing for the browser to scroll to yet.
+   */
+  const jumpTo = useCallback(
+    (anchor: string) => {
+      const chunk = chunkByAnchor[anchor];
+      if (!chunk || chunk <= loadedRef.current) return false;
+
+      // The hash is still written, so the address bar and the back button
+      // behave as if the browser had done it. `pendingAnchor` does the scroll
+      // once the release exists.
+      window.history.pushState(null, '', `#${anchor}`);
+      setPendingAnchor(anchor);
+      void loadThrough(chunk);
+      return true;
+    },
+    [chunkByAnchor, loadThrough],
+  );
+
+  /**
+   * Deep links. Every release used to be in the document, so any `#v0-4-1`
+   * shared before today has to keep working, including the ones that point
+   * into a chunk this page has not fetched. The browser has already given up
+   * on an unknown hash by the time this runs, so the chunk is pulled and the
+   * scroll is done by hand once the entry exists.
+   */
+  useEffect(() => {
+    const resolve = () => {
+      const anchor = decodeURIComponent(window.location.hash.slice(1));
+      const chunk = anchor ? chunkByAnchor[anchor] : undefined;
+
+      /*
+        Every path clears the pending anchor, including the ones with nothing
+        to do. The last hash is the only one the reader asked for, and the
+        cases that return here (a release already on the page, an unknown
+        anchor, an empty hash) are all cases the browser has already handled
+        or that mean nothing. Leaving a previous anchor standing through them
+        meant the next chunk to arrive would scroll the page off whatever the
+        reader had just navigated to, back to a release they had abandoned.
+      */
+      if (!chunk || chunk <= loadedRef.current) {
+        setPendingAnchor(null);
+        return;
+      }
+
+      setPendingAnchor(anchor);
+      void loadThrough(chunk);
+    };
+
+    resolve();
+    window.addEventListener('hashchange', resolve);
+    return () => window.removeEventListener('hashchange', resolve);
+  }, [chunkByAnchor, loadThrough]);
+
+  /** Scrolls once the release the hash asked for is actually in the DOM. */
+  useEffect(() => {
+    if (!pendingAnchor) return;
+    const target = document.getElementById(pendingAnchor);
+    if (!target) return;
+    target.scrollIntoView();
+    setPendingAnchor(null);
+  }, [pendingAnchor, releases]);
+
+  return { releases, loadedChunks, status, loadThrough, jumpTo };
+}

--- a/apps/docs/src/lib/blog.ts
+++ b/apps/docs/src/lib/blog.ts
@@ -13,6 +13,18 @@ export type Post = {
   image?: string;
   readingTime: string;
   draft: boolean;
+  /**
+   * The post's level-two headings, in order.
+   *
+   * This is what the index is built on. A blog of long technical write-ups is
+   * badly served by a two-line standfirst, because the thing a reader is
+   * deciding is whether the piece covers what they came for, and the section
+   * titles answer that far better than a summary of them does. It is also the
+   * only material this blog has to fill a wide frame with: there are no cover
+   * images and there never will be, so the structure of the writing is the
+   * illustration.
+   */
+  outline: string[];
 };
 
 const POSTS_DIR = path.join(process.cwd(), 'content/blog');
@@ -26,48 +38,39 @@ function safeDate(s: string): Date | null {
   return Number.isNaN(d.getTime()) ? null : d;
 }
 
-export function getPosts(): Post[] {
-  ensurePostsDir();
-  // Runs once at build over a directory of a few files. Fusing the filter
-  // into the map saves one small array and costs the reader the shape of
-  // what this does.
-  // react-doctor-disable-next-line react-doctor/js-combine-iterations
-  return fs
-    .readdirSync(POSTS_DIR)
-    .filter((f) => f.endsWith('.mdx'))
-    .map((filename) => {
-      const raw = fs.readFileSync(path.join(POSTS_DIR, filename), 'utf-8');
-      const { data, content } = matter(raw);
-      return {
-        slug: filename.replace(/\.mdx$/, ''),
-        title: data.title ?? 'Untitled',
-        description: data.description ?? '',
-        date:
-          data.date instanceof Date
-            ? data.date.toISOString().split('T')[0]
-            : String(data.date ?? new Date().toISOString().split('T')[0]),
-        author: data.author ?? 'Rustrak Team',
-        tags: Array.isArray(data.tags) ? data.tags : [],
-        image: data.image,
-        readingTime: readingTime(content).text,
-        draft: data.draft ?? false,
-      };
-    })
-    .filter((p) => process.env.NODE_ENV === 'development' || !p.draft)
-    .sort(
-      (a, b) =>
-        (safeDate(b.date)?.getTime() ?? 0) - (safeDate(a.date)?.getTime() ?? 0),
-    );
+/**
+ * The `##` headings, skipping anything inside a fenced block.
+ *
+ * The fence tracking is not defensive padding. These posts are about writing
+ * Rust and configuring servers, so they are full of shell and TOML, and `##` is
+ * a comment in both. Without it the source-maps post would list a comment out
+ * of a config sample as one of its sections.
+ */
+function readOutline(body: string): string[] {
+  const headings: string[] = [];
+  let fenced = false;
+
+  for (const line of body.split('\n')) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      fenced = !fenced;
+      continue;
+    }
+    if (fenced) continue;
+    const match = /^##\s+(.+?)\s*$/.exec(line);
+    // `###` and deeper are excluded by the `\s` after the second hash, which
+    // is what keeps this an outline rather than a transcript of every heading.
+    if (match) headings.push(match[1]);
+  }
+
+  return headings;
 }
 
-export function getPost(slug: string): { post: Post; content: string } | null {
-  ensurePostsDir();
-  const filePath = path.join(POSTS_DIR, `${slug}.mdx`);
-  if (!fs.existsSync(filePath)) return null;
-  const raw = fs.readFileSync(filePath, 'utf-8');
+function readPost(filename: string): Post {
+  const raw = fs.readFileSync(path.join(POSTS_DIR, filename), 'utf-8');
   const { data, content } = matter(raw);
-  const post: Post = {
-    slug,
+
+  return {
+    slug: filename.replace(/\.mdx$/, ''),
     title: data.title ?? 'Untitled',
     description: data.description ?? '',
     date:
@@ -79,8 +82,51 @@ export function getPost(slug: string): { post: Post; content: string } | null {
     image: data.image,
     readingTime: readingTime(content).text,
     draft: data.draft ?? false,
+    outline: readOutline(content),
   };
-  return { post, content };
+}
+
+export function getPosts(): Post[] {
+  ensurePostsDir();
+  // Runs once at build over a directory of a few files. Fusing the filter
+  // into the map saves one small array and costs the reader the shape of
+  // what this does.
+  // react-doctor-disable-next-line react-doctor/js-combine-iterations
+  return fs
+    .readdirSync(POSTS_DIR)
+    .filter((f) => f.endsWith('.mdx'))
+    .map(readPost)
+    .filter((p) => process.env.NODE_ENV === 'development' || !p.draft)
+    .sort(
+      (a, b) =>
+        (safeDate(b.date)?.getTime() ?? 0) - (safeDate(a.date)?.getTime() ?? 0),
+    );
+}
+
+export function getPost(slug: string): { post: Post; content: string } | null {
+  ensurePostsDir();
+  const filePath = path.join(POSTS_DIR, `${slug}.mdx`);
+  if (!fs.existsSync(filePath)) return null;
+  const { content } = matter(fs.readFileSync(filePath, 'utf-8'));
+  return { post: readPost(`${slug}.mdx`), content };
+}
+
+/**
+ * Every tag in use, most-used first, with how many posts carry it.
+ *
+ * The index header used to be a title in the left half of a 72rem frame and
+ * nothing in the right, which is the same "width taken and not used" failure
+ * the changelog had. This fills it with the one piece of navigation a blog
+ * this size can honestly offer.
+ */
+export function getTagCounts(): { tag: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const post of getPosts()) {
+    for (const tag of post.tags) counts.set(tag, (counts.get(tag) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
 }
 
 /**

--- a/apps/docs/src/lib/changelog.ts
+++ b/apps/docs/src/lib/changelog.ts
@@ -8,6 +8,7 @@ import {
   type Release,
   type ReleaseChannel,
   type ReleaseChunk,
+  type ReleasePulse,
   type ReleaseSection,
   type SectionKind,
   safeDate,
@@ -39,6 +40,7 @@ export type {
   Release,
   ReleaseChannel,
   ReleaseChunk,
+  ReleasePulse,
   ReleaseSection,
   SectionKind,
 };
@@ -202,4 +204,63 @@ export function getReleaseChunk(chunk: number): ReleaseChunk {
 
 export function getChunkCount(): number {
   return Math.max(1, Math.ceil(getReleases().length / RELEASES_PER_CHUNK));
+}
+
+/**
+ * How many discrete changes a section describes.
+ *
+ * Counting list items is the honest measure for this content: every entry in
+ * `content/changelog/` is written as a heading and a list of the things that
+ * landed under it, so one `<li>` is one change. The paragraph fallback covers
+ * the handful of sections written as prose: v0.10.2 is two sentences and no
+ * list, and scoring it zero would drop a real release out of the spectrum
+ * entirely.
+ *
+ * Nested items are counted too, and that is deliberate rather than overlooked:
+ * a sub-item is still something that shipped, and excluding it would need the
+ * HTML parsed into a tree to find out which items are nested. This is a
+ * magnitude, not an inventory.
+ */
+function countChanges(html: string): number {
+  const items = html.match(/<li[\s>]/g)?.length ?? 0;
+  if (items > 0) return items;
+  return html.match(/<p[\s>]/g)?.length ?? 0;
+}
+
+function pulseOf(release: Release): ReleasePulse {
+  const counts: Record<SectionKind, number> = {
+    shipped: 0,
+    improved: 0,
+    fixed: 0,
+    documented: 0,
+  };
+
+  let total = 0;
+  for (const section of release.sections) {
+    const changes = countChanges(section.html);
+    counts[section.kind] += changes;
+    total += changes;
+  }
+
+  return {
+    anchor: release.anchor,
+    version: release.version,
+    title: release.title,
+    date: release.date,
+    channel: release.channel,
+    counts,
+    // Floored at one so a release can never draw as nothing. An entry with
+    // neither a list nor a paragraph is malformed, but the spectrum is a map of
+    // the history and a missing column reads as a missing release.
+    total: Math.max(1, total),
+  };
+}
+
+/**
+ * The whole history, at the resolution the spectrum draws it. Newest first,
+ * matching `getReleases()`; the spectrum reverses it, because time reads left
+ * to right and the archive reads top to bottom.
+ */
+export function getPulse(): ReleasePulse[] {
+  return getReleases().map(pulseOf);
 }

--- a/apps/docs/src/lib/release.ts
+++ b/apps/docs/src/lib/release.ts
@@ -40,6 +40,34 @@ export type ReleaseChunk = {
   hasMore: boolean;
 };
 
+/**
+ * One release reduced to what the spectrum needs to draw it.
+ *
+ * The page ships ten releases and fetches the rest, but the spectrum has to
+ * show the whole history from the first paint. A navigator that only knows
+ * about the part of the archive already on screen is not a navigator. So every
+ * release contributes this instead of its body: roughly 130 bytes, against the
+ * ~15KB of a full entry. Forty-one of them cost less than a third of one
+ * release, which is the same bargain the anchor map in `page.tsx` already
+ * takes.
+ */
+export type ReleasePulse = {
+  anchor: string;
+  version: string;
+  title: string;
+  /** ISO `YYYY-MM-DD`. */
+  date: string;
+  channel: ReleaseChannel;
+  /**
+   * Changes per kind. The counts are what give a column its height and its
+   * banding, so a reader can see that v0.12.3 was twenty-two changes of mostly
+   * new work and v0.10.2 was a two-line fix without opening either.
+   */
+  counts: Record<SectionKind, number>;
+  /** The sum, precomputed because every consumer wants it. */
+  total: number;
+};
+
 export function parseVersion(value: string): [number, number, number] | null {
   const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(value);
   return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;


### PR DESCRIPTION
Both sections had the same problem stated two ways: hard to read, and a 72rem frame with everything in the left half of it. A wide page with one left-aligned column is not a layout, it is a narrow page with a large right margin.

## The changelog

**Reading**, which was the actual complaint. Three separate causes, all in the release body:

- the column filled its track, about 95 characters a line
- the type was 14.5px
- every paragraph was painted in `--muted-foreground`, the token meant for dates and labels, so the content of the page was the quietest thing on it

The column is capped at a measure now, the type is 15px, and the body mixes from `--foreground`.

**Navigation**, which the page never had. Forty-one entries down one column with no map is a scroll with no bottom.

The whole history is drawn across the header as one column per release: height is how many changes it carried, banding is what kind they were. It costs about 5KB, because a column only needs five numbers, and it doubles as the index since every column is a real anchor and clicking one fetches the chunk it lives in. Scrolled past, it re-pins under the navbar at 18px with the current release lit, so the history is also the scroll position.

The right-hand track used to hold two tag chips in eleven rems. It holds the release's section index now, and the tags moved to the left rail.

The time axis picks its own resolution: years when the archive spans several, months when it fits in one. Every release here is dated 2026, so a year axis was a single label in the corner saying nothing; seven month marks show the cadence going from one release a month to seventeen.

## The blog

The index gave the newest post a band three times the height of the two under it. The argument for that split was that a reader should not have to compare three headlines. The argument against it, which wins, is that there are three posts: singling one out demotes the other two, and the page read as one article with a couple of related links beneath it.

Every post is the same block now, and what fills it is the post's own outline. A standfirst says what a piece is about; its section titles say what is in it, which is what a reader deciding whether to spend eight minutes actually wants. It is also the honest way to fill this frame: there are no cover images and there never will be, so the structure of the writing is the material. The headings are parsed out of the MDX in `lib/blog.ts`, tracking code fences, because these posts are full of shell and TOML where `##` is a comment.

The header closes on a band of the tags in use, with counts. Not a filter, since narrowing three posts to two is a worse page, but it says what the blog is about without a paragraph claiming it, and it becomes real navigation on its own as posts accumulate.

The post masthead is the body's grid one cell early: title and standfirst in the text track, byline and tags in the 16rem track the contents rail occupies below. The byline now sits directly above the table of contents and the title directly above the first paragraph.

## Three bugs found while testing this in a browser

**The pinned strip never appeared.** `IntersectionObserver` reports a crossing of the root rect *after* `rootMargin`, not of the viewport. The sentinel's last callback fired 15% down the screen and the test asked whether it was above zero. It never was, and nothing crossed anything again, so no further callback ever came. Split into two observers, both comparing against `rootBounds`.

**Every anchor jump overshot by 64px.** Nextra sets `scroll-padding-top: var(--nextra-navbar-height)` on `html`, and `scroll-padding` on the scroll container adds to `scroll-margin` on the target rather than replacing it. The navbar was being counted twice. A release landed far enough down that the reading line was still inside the entry above it, and the strip named the release you had just left.

**The strip cannot be `sticky`.** A sticky element keeps its place in normal flow whether it is stuck or not: hidden, it left 52px of blank under the band; collapsed to nothing, the page jumped by 52px at the moment it pinned, because that flow space appears above the viewport. There is no third option. It is `fixed`, repeating the page's own measure so its columns land under the band's.

Also fixed while looking at it: a translucent amber composited to a muddy brown on the dark page, the legend chips at 7% opacity were invisible at 8px, and the greys at 30% out-weighed the lime they were sitting next to, so the band came out grey.

## Structure

`ChangelogFeed` went past the maintainability limit, so the fetch loop and the reading position are hooks now (`use-release-archive.ts`, `use-active-release.ts`) and the footer is its own component. The two blog readers in `lib/blog.ts` were duplicating a frontmatter parse; they share one `readPost` now.

## Verification

`tsc`, `biome` on every touched file, `react-doctor` (0 issues) and `next build` all pass. Checked in a browser at desktop width in both themes: the pinned strip, hover readout, deep links into unfetched chunks, the active marker following the scroll, the blog index and a post.

**Not verified: narrow viewports.** The browser would not resize in the environment this was built in, so the mobile breakpoints are reasoned about but were never rendered. Worth a look on a phone before merging.
