### PR TITLE
fix(server): redact 5xx response bodies and log the detail under an incident id

### DIFF
--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -7817,6 +7817,10 @@
             },
             "description": "Machine-readable annotations naming the inputs that were rejected.\n\nOmitted from the JSON entirely when empty, so every consumer written\nbefore this existed keeps seeing exactly the body it saw before."
           },
+          "incident_id": {
+            "type": "string",
+            "description": "Correlates this response with the `log::error!` line that carries the\ndetail [`INTERNAL_ERROR_MESSAGE`] replaced.\n\nPresent on every 5xx and on nothing else: a 4xx says what went wrong in\n`message`, logs nothing, and so has no line for an id to point at.\n\n`nullable = false`: `skip_serializing_if` means the key is *absent* on\na 4xx, never `null`."
+          },
           "message": {
             "type": "string"
           },

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -1,6 +1,30 @@
 use actix_web::{http::StatusCode, HttpResponse, ResponseError};
 use serde::Serialize;
 
+/// The `message` every 5xx body carries, in place of the error's `Display`.
+///
+/// Fixed on purpose. `AppError::Database` renders `sqlx::Error`, whose
+/// Postgres arm names the constraint, table and column of the failed query,
+/// and `AppError::Internal` interpolates whatever string its call site had to
+/// hand. Neither is safe on a wire that a caller holding nothing but a public
+/// DSN can read.
+pub const INTERNAL_ERROR_MESSAGE: &str = "Internal server error";
+
+/// Response header echoing [`ErrorDetail::incident_id`].
+///
+/// Duplicates the body on purpose. `middleware::Logger` is the only place that
+/// knows the method and path of the request that failed, and a response header
+/// is the only part of the response it can read, so this is what lets one
+/// `grep <id>` return both the access-log line naming the route and the
+/// `log::error!` line carrying the detail.
+pub const INCIDENT_ID_HEADER: &str = "X-Rustrak-Incident";
+
+/// The `log::error!` line that carries what [`INTERNAL_ERROR_MESSAGE`] took
+/// out of the response body.
+fn incident_log_line(incident_id: &str, error: &AppError) -> String {
+    format!("incident {incident_id}: {error}")
+}
+
 /// JSON error response structure
 #[derive(Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -20,6 +44,17 @@ pub struct ErrorDetail {
     /// before this existed keeps seeing exactly the body it saw before.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub fields: Vec<FieldError>,
+    /// Correlates this response with the `log::error!` line that carries the
+    /// detail [`INTERNAL_ERROR_MESSAGE`] replaced.
+    ///
+    /// Present on every 5xx and on nothing else: a 4xx says what went wrong in
+    /// `message`, logs nothing, and so has no line for an id to point at.
+    ///
+    /// `nullable = false`: `skip_serializing_if` means the key is *absent* on
+    /// a 4xx, never `null`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(nullable = false))]
+    pub incident_id: Option<String>,
 }
 
 /// One rejected input, named as data rather than buried in the prose of
@@ -280,15 +315,32 @@ impl ResponseError for AppError {
     }
 
     fn error_response(&self) -> HttpResponse {
-        let response = ErrorResponse {
-            error: ErrorDetail {
-                error_type: self.error_type().to_string(),
-                message: self.to_string(),
-                fields: self.field_errors().to_vec(),
-            },
+        let status = self.status_code();
+        let incident_id = status
+            .is_server_error()
+            .then(|| uuid::Uuid::new_v4().to_string());
+
+        let message = match &incident_id {
+            Some(id) => {
+                log::error!("{}", incident_log_line(id, self));
+                INTERNAL_ERROR_MESSAGE.to_string()
+            }
+            None => self.to_string(),
         };
 
-        HttpResponse::build(self.status_code()).json(response)
+        let mut builder = HttpResponse::build(status);
+        if let Some(id) = &incident_id {
+            builder.insert_header((INCIDENT_ID_HEADER, id.as_str()));
+        }
+
+        builder.json(ErrorResponse {
+            error: ErrorDetail {
+                error_type: self.error_type().to_string(),
+                message,
+                fields: self.field_errors().to_vec(),
+                incident_id,
+            },
+        })
     }
 }
 
@@ -298,6 +350,151 @@ pub type AppResult<T> = Result<T, AppError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Reads the JSON body an `AppError` actually puts on the wire.
+    async fn body_of(error: &AppError) -> serde_json::Value {
+        let response = error.error_response();
+        let bytes = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("the error body must be readable");
+        serde_json::from_slice(&bytes).expect("the error body must be JSON")
+    }
+
+    /// A 500 must never put `Display` on the wire. `sqlx::Error` renders the
+    /// constraint, table and column names of whatever query failed, and
+    /// `Internal` interpolates arbitrary internal text, so the message a
+    /// caller receives has to be a fixed string chosen here.
+    #[actix_web::test]
+    async fn a_server_error_redacts_its_display_message() {
+        let error = AppError::Internal(
+            "duplicate key value violates unique constraint \"users_email_key\"".to_string(),
+        );
+
+        let body = body_of(&error).await;
+
+        assert_eq!(body["error"]["message"], INTERNAL_ERROR_MESSAGE);
+        assert_eq!(body["error"]["type"], "InternalError");
+    }
+
+    /// `ResponseError::error_response` never sees the request, so the incident
+    /// line cannot name the route. The access log can: it is the one place
+    /// that has the method and path, and headers are the only part of a
+    /// response it can read. Echoing the id there is what turns one `grep`
+    /// into both the route and the detail.
+    #[actix_web::test]
+    async fn a_server_error_echoes_its_incident_id_in_a_header() {
+        let error = AppError::Database(sqlx::Error::PoolClosed);
+        let response = error.error_response();
+
+        let header = response
+            .headers()
+            .get(INCIDENT_ID_HEADER)
+            .expect("a 5xx must echo its incident id as a header")
+            .to_str()
+            .expect("the header must be ASCII")
+            .to_string();
+
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("the error body must be readable");
+        let body: serde_json::Value =
+            serde_json::from_slice(&body).expect("the error body must be JSON");
+
+        assert_eq!(
+            body["error"]["incident_id"], header,
+            "the header and the body must name the same incident"
+        );
+    }
+
+    /// Nothing was logged for a 4xx, so there is no incident to point at and
+    /// the header would be a promise the log cannot keep.
+    #[actix_web::test]
+    async fn a_client_error_sets_no_incident_header() {
+        let response = AppError::Validation("slug is required".to_string()).error_response();
+
+        assert!(response.headers().get(INCIDENT_ID_HEADER).is_none());
+    }
+
+    /// The detail the body no longer carries has to land somewhere, keyed by
+    /// the id the caller was given. Asserted on the formatted line rather than
+    /// on a captured logger: `log` is global state, and the property that
+    /// matters is what the line says.
+    #[test]
+    fn the_log_line_pairs_the_incident_id_with_the_unredacted_detail() {
+        let error = AppError::Database(sqlx::Error::RowNotFound);
+        let incident_id = "0b3f1c1e-2a4d-4b8e-9f1a-6c7d8e9f0a1b";
+
+        let line = incident_log_line(incident_id, &error);
+
+        assert!(line.contains(incident_id), "line must quote the id: {line}");
+        assert!(
+            line.contains(&error.to_string()),
+            "line must carry the detail the body dropped: {line}"
+        );
+    }
+
+    /// Redacting without a correlation id would trade a leak for an outage
+    /// nobody can diagnose: the caller has a 500 with no handle, and the
+    /// operator has a log line with nothing to match it against. Every 5xx
+    /// carries an id, and the log line carries the same one.
+    #[actix_web::test]
+    async fn a_server_error_carries_an_incident_id() {
+        let body = body_of(&AppError::Internal("pool exhausted".to_string())).await;
+
+        let incident_id = body["error"]["incident_id"]
+            .as_str()
+            .expect("a 5xx body must carry an incident_id");
+        assert!(
+            uuid::Uuid::parse_str(incident_id).is_ok(),
+            "incident_id must be a UUID, got {incident_id:?}"
+        );
+    }
+
+    /// Two 500s are two incidents. Reusing an id, or deriving it from the
+    /// error's contents, would collapse unrelated failures into one line in
+    /// whatever the operator greps.
+    #[actix_web::test]
+    async fn each_server_error_gets_its_own_incident_id() {
+        let error = AppError::Internal("pool exhausted".to_string());
+
+        let first = body_of(&error).await;
+        let second = body_of(&error).await;
+
+        assert_ne!(
+            first["error"]["incident_id"], second["error"]["incident_id"],
+            "each response must be its own incident"
+        );
+    }
+
+    /// A 4xx is not an incident: it is the caller's input being rejected, the
+    /// message already says everything, and nothing was logged for an id to
+    /// point at. The key is absent, never null, matching how `fields` and
+    /// `FieldError::message` already behave.
+    #[actix_web::test]
+    async fn a_client_error_carries_no_incident_id() {
+        let body = body_of(&AppError::NotFound("project".to_string())).await;
+
+        assert!(
+            body["error"].get("incident_id").is_none(),
+            "a 4xx body must omit incident_id entirely, got {body}"
+        );
+    }
+
+    /// The split is on the status, not on the variant. A 4xx message describes
+    /// the caller's own input, is written by hand at the call site, and is the
+    /// only thing that makes a 409 actionable, so redacting it would be a
+    /// regression dressed as hardening.
+    #[actix_web::test]
+    async fn a_client_error_keeps_its_display_message() {
+        let error = AppError::Conflict("Project with slug 'api' already exists".to_string());
+
+        let body = body_of(&error).await;
+
+        assert_eq!(
+            body["error"]["message"],
+            "Conflict: Project with slug 'api' already exists"
+        );
+    }
 
     /// The no-nesting invariant is what makes `field_errors()` (which reads
     /// one level) agree with `kind()`/`error_type()`/`status_code()` (which

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -182,7 +182,16 @@ async fn main() -> std::io::Result<()> {
             .app_data(session_aggregator_data.clone())
             .app_data(processors_data.clone())
             // Middleware
-            .wrap(middleware::Logger::default())
+            // `Logger::default()`'s format, plus the incident id a 5xx echoes
+            // in `INCIDENT_ID_HEADER`. `error_response` never sees the request
+            // and so cannot name the route in its own log line; this is the
+            // line that has the method and path, so the id has to appear here
+            // for the two to be greppable as one incident. Reads `-` on every
+            // response that is not a 5xx.
+            .wrap(middleware::Logger::new(&format!(
+                "%a \"%r\" %s %b \"%{{Referer}}i\" \"%{{User-Agent}}i\" %T incident=%{{{}}}o",
+                rustrak::error::INCIDENT_ID_HEADER
+            )))
             .wrap(middleware::Compress::default())
             .wrap(cors) // CORS must be before SessionMiddleware
             .wrap(

--- a/packages/client/src/utils/http.ts
+++ b/packages/client/src/utils/http.ts
@@ -134,6 +134,27 @@ function warnUnknownFieldErrorCode(code: string, field: string): void {
  * consumer would render. Dropping it here makes the rule true of the value, not
  * only of its producer.
  */
+/**
+ * Read `error.incident_id` out of a 5xx `AppError` body.
+ *
+ * The one thing a 500 is willing to say about itself. `error_response` replaced
+ * its `Display` with a fixed string so a `sqlx::Error`'s constraint and column
+ * names stay off the wire (gh-233), and logged the detail under this id; a user
+ * quoting it is what lets an operator find that line.
+ *
+ * Returns `undefined`, never `null` or `''`, for the three bodies that carry no
+ * id: a proxy-generated 502/503, a server older than gh-233, and a 500 whose
+ * body is not JSON at all. The caller omits the key entirely in that case, so
+ * `'incidentId' in error` stays an honest test.
+ */
+function readIncidentId(error: HTTPError): string | undefined {
+  const body = error.data as { error?: { incident_id?: unknown } } | null;
+  const raw =
+    body && typeof body === 'object' ? body.error?.incident_id : undefined;
+
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
 function readFieldErrors(error: HTTPError): FieldError[] | undefined {
   const body = error.data as { error?: { fields?: unknown } } | null;
   const raw = body && typeof body === 'object' ? body.error?.fields : undefined;
@@ -225,13 +246,24 @@ export function transformHttpError(error: HTTPError): RustrakError {
   const { response } = error;
   const status = response.status;
 
-  // 5xx never carries a server-supplied message. `AppError::Internal` and
-  // `AppError::Database` interpolate arbitrary internal text (a pool error, an
-  // OS errno, a filesystem path), and every consumer of this client renders
-  // `error.message` somewhere. Discard it here, once, rather than trusting 128
-  // call sites to remember.
+  // 5xx never carries a server-supplied message. The server redacts its own
+  // `Display` now (gh-233), but this stays: a 502 from a reverse proxy and a
+  // server older than that fix both still send prose, and every consumer of
+  // this client renders `error.message` somewhere. Discard it here, once,
+  // rather than trusting 128 call sites to remember.
+  //
+  // `incidentId` is the exception, and the reason the redaction is no longer
+  // lossy: it names the log line carrying what the body dropped, and is
+  // omitted entirely when the body has none.
   if (status >= 500) {
-    return { kind: 'server_error', status, message: SERVER_ERROR_MESSAGE };
+    const base = {
+      kind: 'server_error',
+      status,
+      message: SERVER_ERROR_MESSAGE,
+    } as const;
+    const incidentId = readIncidentId(error);
+
+    return incidentId === undefined ? base : { ...base, incidentId };
   }
 
   const message = readErrorMessage(error, status);

--- a/packages/client/tests/integration/error-handling.test.ts
+++ b/packages/client/tests/integration/error-handling.test.ts
@@ -174,10 +174,7 @@ describe('Error Handling', () => {
     it('should map 500 to server_error', async () => {
       server.use(
         http.get('http://localhost:8080/api/projects', () =>
-          appErrorResponse(
-            'InternalError',
-            'Internal server error: Database pool not configured',
-          ),
+          appErrorResponse('InternalError'),
         ),
       );
 
@@ -185,7 +182,53 @@ describe('Error Handling', () => {
 
       expect(error.kind).toBe('server_error');
       expect(isRetryable(error)).toBe(true);
-      expect(error).toMatchObject({ status: 500 });
+      // `message` is pinned, not just `status`. `appErrorResponse` throws when
+      // a fixture hands it a 5xx message, but msw turns a resolver that throws
+      // into a 500 of its own, which is the exact status this test asserts: a
+      // fixture rejected for being the old leaky shape would otherwise sail
+      // through here green.
+      expect(error).toMatchObject({
+        status: 500,
+        message: SERVER_ERROR_MESSAGE,
+      });
+    });
+
+    it('should surface the incident id a 500 body carries', async () => {
+      server.use(
+        http.get('http://localhost:8080/api/projects', () =>
+          appErrorResponse('DatabaseError', undefined, undefined, {
+            incidentId: '0b3f1c1e-2a4d-4b8e-9f1a-6c7d8e9f0a1b',
+          }),
+        ),
+      );
+
+      const error = expectErr(await client.projects.list());
+
+      expect(error.kind).toBe('server_error');
+      // The message stays redacted. The id is the only thing the server is
+      // willing to say about a 500, and it is what a user quotes in a bug
+      // report to point the operator at the `log::error!` line.
+      expect(error).toMatchObject({
+        status: 500,
+        message: SERVER_ERROR_MESSAGE,
+        incidentId: '0b3f1c1e-2a4d-4b8e-9f1a-6c7d8e9f0a1b',
+      });
+    });
+
+    // A 5xx from a proxy has no Rustrak body, and an older server predates the
+    // field. Neither may produce `incidentId: undefined`: `structuredClone`
+    // round-trips it, but `'incidentId' in error` would start lying.
+    it('should omit incidentId entirely when the 5xx body has none', async () => {
+      server.use(
+        http.get('http://localhost:8080/api/projects', () =>
+          appErrorResponse('InternalError'),
+        ),
+      );
+
+      const error = expectErr(await client.projects.list());
+
+      expect(error.kind).toBe('server_error');
+      expect('incidentId' in error).toBe(false);
     });
 
     // 502 and 503 are the deliberate exception: `AppError::status_code` cannot
@@ -698,10 +741,7 @@ describe('Error Handling', () => {
         http.get('http://localhost:8080/api/projects', () => {
           attempts++;
           if (attempts < 2) {
-            return appErrorResponse(
-              'DatabaseError',
-              'Database error: connection closed',
-            );
+            return appErrorResponse('DatabaseError');
           }
           return HttpResponse.json({
             items: [],
@@ -771,10 +811,7 @@ describe('Error Handling', () => {
       server.use(
         http.get('http://localhost:8080/api/projects', () => {
           attempts++;
-          return appErrorResponse(
-            'DatabaseError',
-            'Database error: connection closed',
-          );
+          return appErrorResponse('DatabaseError');
         }),
       );
 
@@ -887,7 +924,7 @@ describe('Error Handling', () => {
 
       server.use(
         http.get('http://localhost:8080/api/projects', () =>
-          appErrorResponse('InternalError', 'Internal server error: boom'),
+          appErrorResponse('InternalError'),
         ),
       );
       cases.push(expectErr(await client.projects.list()));

--- a/packages/client/tests/mocks/handlers.ts
+++ b/packages/client/tests/mocks/handlers.ts
@@ -56,38 +56,78 @@ export const APP_ERROR_STATUS = {
 } as const satisfies Record<AppErrorType, number>;
 
 /**
+ * The fixed `message` every 5xx body carries, mirroring
+ * `INTERNAL_ERROR_MESSAGE` in `apps/server/src/error.rs`.
+ *
+ * `tests/unit/app-error-contract.test.ts` reads that constant out of the Rust
+ * file and asserts it still equals this one, so rewording it on either side is
+ * a failing test rather than a fixture that quietly stops matching the server.
+ */
+export const INTERNAL_ERROR_MESSAGE = 'Internal server error';
+
+/**
  * Build the nested body every `AppError` produces:
  * `{"error": {"type": ..., "message": ...}}`, with the status derived from the
  * variant.
  *
- * `message` is `AppError`'s `Display`, so it always carries the thiserror
- * prefix: a 404 reads `Resource not found: <detail>`, never a bare detail.
- * Passing a message without its prefix throws here rather than producing a body
- * the server could never send.
+ * **4xx**: `message` is `AppError`'s `Display`, so it always carries the
+ * thiserror prefix: a 404 reads `Resource not found: <detail>`, never a bare
+ * detail. Passing a message without its prefix throws here rather than
+ * producing a body the server could never send.
  *
- * `fields` is optional and mirrors the server exactly: `ErrorDetail.fields` is
+ * **5xx**: there is no caller-supplied message at all. `error_response`
+ * replaces `Display` with {@link INTERNAL_ERROR_MESSAGE} so a `sqlx::Error`'s
+ * constraint and column names never reach the wire (gh-233), which means a
+ * fixture that passed its own 500 message would be testing a body the server
+ * stopped emitting. Passing one throws. `incidentId` is what a 500 carries
+ * instead, and it is optional here because a proxy-generated 5xx and a server
+ * older than gh-233 both send a body without one.
+ *
+ * `fields` mirrors the server exactly: `ErrorDetail.fields` is
  * `#[serde(skip_serializing_if = "Vec::is_empty")]`, so an absent or empty list
  * means the key is absent from the body, never `[]` and never `null`. Fixtures
  * go through here rather than inlining a body precisely so that this stays true
- * in one place.
+ * in one place. `incident_id` is skipped the same way.
  */
 export function appErrorResponse(
   type: AppErrorType,
-  message: string,
+  message?: string,
   fields?: FieldError[],
+  options?: { incidentId?: string },
 ) {
+  const status = APP_ERROR_STATUS[type];
+  const isServerError = status >= 500;
+
+  if (isServerError && message !== undefined) {
+    throw new Error(
+      `appErrorResponse('${type}', ...) takes no message: every 5xx body is ` +
+        `${JSON.stringify(INTERNAL_ERROR_MESSAGE)}, fixed by the server.`,
+    );
+  }
+  if (!isServerError && message === undefined) {
+    throw new Error(`appErrorResponse('${type}', ...) requires a message.`);
+  }
+
   const prefix = APP_ERROR_PREFIXES[type];
-  if (!message.startsWith(prefix)) {
+  if (message !== undefined && !message.startsWith(prefix)) {
     throw new Error(
       `appErrorResponse('${type}', ...) expects the server's Display prefix: ` +
         `message must start with ${JSON.stringify(prefix)}, got ${JSON.stringify(message)}`,
     );
   }
+
   return HttpResponse.json(
-    fields === undefined || fields.length === 0
-      ? { error: { type, message } }
-      : { error: { type, message, fields } },
-    { status: APP_ERROR_STATUS[type] },
+    {
+      error: {
+        type,
+        message: isServerError ? INTERNAL_ERROR_MESSAGE : message,
+        ...(fields !== undefined && fields.length > 0 ? { fields } : {}),
+        ...(options?.incidentId !== undefined
+          ? { incident_id: options.incidentId }
+          : {}),
+      },
+    },
+    { status },
   );
 }
 
@@ -488,16 +528,10 @@ export const handlers = [
     rateLimitResponse(59),
   ),
   http.get(`${BASE_URL}/__status-transform/database-error`, () =>
-    appErrorResponse(
-      'DatabaseError',
-      'Database error: pool timed out while waiting for an open connection',
-    ),
+    appErrorResponse('DatabaseError'),
   ),
   http.get(`${BASE_URL}/__status-transform/internal-error`, () =>
-    appErrorResponse(
-      'InternalError',
-      'Internal server error: failed to store source file: No space left on device (os error 28)',
-    ),
+    appErrorResponse('InternalError'),
   ),
   // 410 and the catch-all have no `AppError` producer at all: `status_code`
   // cannot return either. They exist for a retired endpoint and for whatever a

--- a/packages/client/tests/unit/app-error-contract.test.ts
+++ b/packages/client/tests/unit/app-error-contract.test.ts
@@ -6,6 +6,7 @@ import {
   APP_ERROR_PREFIXES,
   APP_ERROR_STATUS,
   type AppErrorType,
+  INTERNAL_ERROR_MESSAGE,
 } from '../mocks/handlers.js';
 
 /**
@@ -148,6 +149,41 @@ describe.skipIf(source === null)(
           `${variant}'s #[error(...)] must end with {0}, got "${display}"`,
         ).toBe(true);
       }
+    });
+
+    // -----------------------------------------------------------------------
+    // The 5xx redaction (gh-233)
+    //
+    // A `Display` string is no longer what a 5xx puts on the wire. The tables
+    // above still describe `#[error(...)]` faithfully, and still must: that
+    // text is what `log::error!` carries, so it is what an operator greps.
+    // What changed is which bodies it reaches. These two pin the split itself,
+    // because every fixture in this suite now builds a 500 body out of a
+    // constant declared in TypeScript, and nothing else would notice the Rust
+    // side rewording or dropping it.
+    // -----------------------------------------------------------------------
+
+    it('INTERNAL_ERROR_MESSAGE matches the Rust constant', () => {
+      const match = rust.match(
+        /pub const INTERNAL_ERROR_MESSAGE: &str = "([^"]*)";/,
+      );
+
+      expect(match, 'INTERNAL_ERROR_MESSAGE must exist in error.rs').not.toBe(
+        null,
+      );
+      expect(match?.[1]).toBe(INTERNAL_ERROR_MESSAGE);
+    });
+
+    it('error_response redacts on the status, not on the variant', () => {
+      // Anchored on `is_server_error()` rather than on a variant list: the
+      // rule has to keep holding for a ninth variant nobody has written yet,
+      // and a `match` naming `Database` and `Internal` would silently exempt
+      // it. `_ = INTERNAL_ERROR_MESSAGE;` somewhere unrelated would satisfy a
+      // grep for the constant alone, so both halves are asserted together.
+      const body = rust.slice(rust.indexOf('fn error_response'));
+
+      expect(body).toContain('is_server_error()');
+      expect(body).toContain('INTERNAL_ERROR_MESSAGE');
     });
 
     it('APP_ERROR_PREFIXES matches the #[error(...)] Display prefixes', () => {


### PR DESCRIPTION
Closes #233.

## The leak

`AppError::error_response` serialised `self.to_string()` for every variant, so both 500s put their `Display` on the wire. `sqlx::Error`'s Postgres arm names the constraint, table and column of the failed query; `Internal` interpolates whatever string its call site had to hand.

Two corrections to the issue as filed, from reading the source:

- **Reachability is worse than "curl with an API token".** `SentryAuth::from_request` ends in `ProjectService::get_by_id(...).await?`, so a database error during DSN validation returned that body to a caller holding only a `sentry_key` — the key every Sentry SDK embeds in browser JS. The lowest-privilege tier of the product reached the leak.
- **Severity is narrower than "the SQL and the values".** `impl Display for PgDatabaseError` writes `message()` plus an optional line number and nothing else; Postgres puts the offending value in the `D` field, exposed as `.detail()` and never rendered. No `sqlx-core` variant interpolates the query either. So a unique violation leaked `duplicate key value violates unique constraint "users_email_key"`, not the email. It is schema-metadata disclosure. The one variant that can carry a connection string is `Error::Configuration`.

And one thing the issue did not mention: **nothing was logged**. `error.rs` had no `log::error!` and there is no error-logging middleware, so the detail went to the wire and *only* to the wire. Redacting alone would have traded a leak for undebuggable 500s.

## The fix

`error_response` splits on `status.is_server_error()`, not on the variant, so a ninth variant inherits the rule instead of having to opt into it.

- **5xx** serialises a fixed `INTERNAL_ERROR_MESSAGE` plus a fresh `incident_id`, and logs the real `Display` under that id.
- **4xx** is untouched. Its message describes the caller's own input, is hand-written at the call site, and is the only thing that makes a 409 actionable.

That split is the rule Relay states in its own comment in `endpoints/common.rs`: render the cause when the cause is about the caller. (Relay is *not* a precedent for redacting 5xx — `ApiErrorResponse::from_error` serialises the detail *and* the full source-cause chain, and returns it on two real 500s. It just has no database.) The precedent for the body shape is the Sentry monolith: `{"detail": "Internal Error", "errorId": event_id}` in `src/sentry/api/base.py`.

### Correlating the incident with a route

`ResponseError::error_response` never sees the request, so the incident line cannot name the route. The access log knows method and path but can only read *headers*, not bodies. So the id is echoed in `X-Rustrak-Incident` and added to the `Logger` format. One `grep <id>` returns both lines.

### Client

`@rustrak/client` fills the `incidentId` slot that has been declared and unused since #220. The key is omitted entirely for a proxy-generated 5xx or a server older than this, so `'incidentId' in error` stays honest. The client-side redaction of the 5xx message stays regardless — a 502 from a reverse proxy still sends prose.

## Tests

Seven RED→GREEN cycles. Two of them passed on the first run because they are guards rather than new behaviour (4xx passthrough, and the contract-test constant); both were proved by mutating the production side and watching them fail.

One trap found on the way, worth knowing about: **msw turns a throwing resolver into a 500, which is the exact status the 5xx tests assert.** The new guard in `appErrorResponse` (it throws if a fixture hands it a 5xx message) was therefore completely toothless — the old leaky fixture sailed through it green. Those tests now pin `message`, not only `status`.

`packages/client/tests/unit/app-error-contract.test.ts` learns the split: it reads `INTERNAL_ERROR_MESSAGE` out of `error.rs` and asserts the fixtures still match it, and pins that `error_response` redacts on the status rather than on a variant list.

`pnpm run ci` green, 22/22.

## Deliberately not in this PR

- **Neither the dashboard nor the MCP server shows the id to a human yet**, so the "quote it in a bug report" half of the issue is not real yet. `apps/webview-ui` runs architecture tests only and its `vitest.config.mts` scopes `include` to `src/__tests__/architecture/**` with a written note that restoring a test harness is its own decision — so a TDD'd copy change there is not a free addition. Happy to open a follow-up.
- **`fields` is still serialised on a 5xx.** `FieldError::custom` takes arbitrary prose, so it is a theoretical hole, but no production site annotates a `Database`/`Internal` error (the only hit is a unit test). Guarding it would be an invented requirement.
- **No changeset.** This is a wire change — new `incident_id` field, new header, different 5xx message — so it likely wants a `minor` on `@rustrak/server`. Say the word.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incident IDs to server error responses for easier troubleshooting.
  * Added an incident ID response header and client-side error support.
* **Bug Fixes**
  * Sensitive details are now hidden from 5xx error messages and replaced with a consistent message.
  * 4xx responses retain their existing messages and do not include incident metadata.
* **Tests**
  * Expanded coverage for error redaction, incident ID propagation, response consistency, and unchanged 4xx behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->