### PR TITLE
fix(mcp): derive the advertised version from package.json

### DIFF
--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -105,7 +105,7 @@ packages/mcp/
 ```typescript
 // src/server.ts
 export function createServer(client: RustrakClient): McpServer {
-  const server = new McpServer({ name: 'rustrak-mcp-server', version: '0.1.0' });
+  const server = new McpServer({ name: 'rustrak-mcp', version: VERSION });
   registerProjectTools(server, client);
   registerIssueTools(server, client);
   registerEventTools(server, client);
@@ -114,6 +114,13 @@ export function createServer(client: RustrakClient): McpServer {
   return server;
 }
 ```
+
+`VERSION` is read from `package.json` at module load, never written down in
+source. `packages/mcp` is in the `fixed` group in `.changeset/config.json`, so
+every release bumps package.json; a hardcoded copy would go stale between
+releases without anything failing. `../package.json` resolves to the package
+root from both `src/` and the bundled `dist/`, and npm always ships
+package.json regardless of the `files` list.
 
 **Why factory pattern?**
 - Decouples env config from server construction

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RustrakClient } from '@rustrak/client';
 import { registerAgentTools } from './tools/agents.js';
@@ -15,10 +16,27 @@ import { registerTeamTools } from './tools/team.js';
 import { registerTokenTools } from './tools/tokens.js';
 import { registerTransactionTools } from './tools/transactions.js';
 
+/**
+ * The version advertised in the MCP handshake, read from package.json.
+ *
+ * It is derived rather than written down because `packages/mcp` is in the
+ * `fixed` group in `.changeset/config.json`: every release bumps package.json,
+ * and a second copy of the number would silently go stale between releases.
+ *
+ * `../package.json` resolves to the package root from both `src/server.ts` and
+ * the bundled `dist/index.js`, since both sit one level down. npm always ships
+ * package.json regardless of the `files` list, so it is there at runtime.
+ */
+const VERSION = (
+  JSON.parse(
+    readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+  ) as { version: string }
+).version;
+
 export function createServer(client: RustrakClient): McpServer {
   const server = new McpServer({
     name: 'rustrak-mcp',
-    version: '0.1.0',
+    version: VERSION,
   });
 
   registerProjectTools(server, client);

--- a/packages/mcp/tests/integration/server.test.ts
+++ b/packages/mcp/tests/integration/server.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createTestEnv } from '../setup.js';
 
@@ -136,6 +137,21 @@ describe('MCP server integration', () => {
 
   afterEach(async () => {
     await testEnv.mcpClient.close();
+  });
+
+  // The version an MCP client sees comes from the handshake, so this is the
+  // only place the advertised number is observable. Read package.json here
+  // rather than importing the server's own constant: comparing the constant to
+  // itself would pass no matter how stale it got.
+  it('advertises the published package version', () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+    ) as { version: string };
+
+    const info = testEnv.mcpClient.getServerVersion();
+
+    expect(info?.name).toBe('rustrak-mcp');
+    expect(info?.version).toBe(pkg.version);
   });
 
   it(`registers all ${EXPECTED_TOOLS.length} tools`, async () => {


### PR DESCRIPTION
Closes #149.

## Problem

`createServer` hardcoded `version: '0.1.0'` in the `McpServer` metadata while `packages/mcp/package.json` was at `0.14.1`. That number is what every MCP client reads from the handshake, so Claude Desktop, Cursor and Claude Code all saw a version thirteen minors stale. Nothing failed when it drifted, which is why it drifted.

`get_server_version` did not cover this: that tool returns the *Rustrak server* version over HTTP, not the version of the MCP process itself.

## Fix

Read the version from `package.json` at module load rather than writing it down in source.

`packages/mcp` is in the `fixed` group in `.changeset/config.json`, so `changeset version` already bumps that file on every release, and `release.yml` already asserts it matches the release being cut. Deriving from it hooks the advertised version onto machinery that already exists — no sync script, no build step, and no change to `release.yml`.

`../package.json` resolves to the package root from both `src/server.ts` and the bundled `dist/index.js`, since both sit one level down. npm always includes `package.json` in the tarball regardless of the `files` list, so it is present at runtime.

## Tests

TDD, one cycle:

- RED: the new test failed with `expected '0.1.0' to be '0.14.1'` — the bug as reported.
- GREEN: 125/125 pass, `tsc --noEmit` clean, biome clean.

The test reads `package.json` itself and compares it against what the server advertises over the MCP handshake, rather than importing the server's own constant — comparing that constant to itself would pass no matter how stale it got.

## Verified against the bundle

The test suite runs on the source, so it would not catch esbuild rewriting the URL resolution. Checked the published shape separately: `pnpm build`, then an `initialize` over stdio against `dist/index.js` from an unrelated cwd answers

```
{ name: 'rustrak-mcp', version: '0.14.1' }
```

and the bundle keeps the call intact at `dist/index.js:1233`. Resolution is by module location, not cwd.

## Also

`packages/mcp/CLAUDE.md` documented the factory with `name: 'rustrak-mcp-server', version: '0.1.0'` — both already wrong before this change. Corrected, with a note on why the version is derived.
