### PR TITLE
feat(server): serve the dashboard from the binary behind a cargo feature

### DIFF
--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -2510,6 +2510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3504,6 +3514,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.119",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,11 +3684,13 @@ dependencies = [
  "hmac 0.13.0",
  "lettre",
  "log",
+ "mime_guess",
  "pretty_assertions",
  "proptest",
  "rand 0.10.2",
  "reqwest",
  "rstest",
+ "rust-embed",
  "rustrak",
  "sentry",
  "serde",
@@ -4858,6 +4905,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -61,6 +61,10 @@ rand = "0.10.2"
 # Hex encoding
 hex = "0.4.3"
 
+# Embedded dashboard assets (optional, behind the `dashboard` feature)
+rust-embed = { version = "8.12.0", optional = true }
+mime_guess = { version = "2.0.5", optional = true }
+
 # Compression (for decompressing gzip/deflate/brotli payloads)
 flate2 = "1.1.9"
 brotli = "8.0.4"
@@ -161,10 +165,19 @@ opt-level = 0
 debug = true
 
 [features]
+# `dashboard` is deliberately NOT here. It embeds `apps/dashboard/dist`, which
+# is a build artifact and is gitignored, so a default that included it would
+# make `cargo build` fail on a fresh clone until someone ran the JS build. A
+# Rust contributor should be able to clone and build. The Dockerfile and the
+# release turn it on explicitly.
 default = ["sqlite"]
 postgres = ["sqlx/postgres"]
 sqlite = ["sqlx/sqlite"]
 openapi = ["dep:utoipa", "dep:utoipa-scalar"]
+# Embeds the built dashboard (`apps/dashboard/dist`) into the binary and serves
+# it from `/`. Turned off, the crate compiles without `dist/` existing at all,
+# which is what keeps `cargo build` usable on its own.
+dashboard = ["dep:rust-embed", "dep:mime_guess"]
 # Compiles the `ProjectService` test seams (`create_with_stale_slug` and the two
 # race helpers). Never enabled for the shipped binary: the self dev-dependency
 # below turns it on for test targets only, so `cargo test --release` builds

--- a/apps/server/src/dashboard.rs
+++ b/apps/server/src/dashboard.rs
@@ -1,0 +1,116 @@
+//! Serving the built dashboard from inside the binary.
+//!
+//! The whole point: `rustrak` becomes one artifact. No Node process, no second
+//! container, no `RUSTRAK_API_URL` to configure. The browser talks to the same
+//! origin that served it, so the session cookie works with no CORS involved.
+//!
+//! The assets are **embedded**, not read from disk. Serving them from a
+//! directory is the other common answer (Qdrant does it) and it creates a whole
+//! class of deployment bug: the binary starts fine and every page is a 404
+//! because the folder was not copied. Embedding makes that unrepresentable.
+//!
+//! Compiled only with the `dashboard` feature. Without it this module does not
+//! exist, `rust-embed` is not a dependency, and `apps/dashboard/dist` does not
+//! need to exist to build the server.
+
+use actix_web::body::BoxBody;
+use actix_web::http::header::{HeaderValue, CACHE_CONTROL, CONTENT_TYPE, ETAG, IF_NONE_MATCH};
+use actix_web::{HttpRequest, HttpResponse};
+use rust_embed::RustEmbed;
+
+/// The output of `pnpm --filter=dashboard build`.
+///
+/// The path is resolved at compile time relative to this crate's manifest. The
+/// build order is guaranteed by turbo, not by cargo: `@rustrak/server` depends
+/// on `dashboard`, so `dist/` exists before `cargo build` runs. If it does not,
+/// compilation fails here and says so, which is the right failure.
+#[derive(RustEmbed)]
+#[folder = "../dashboard/dist"]
+struct Assets;
+
+/// The SPA shell. Every route the client owns is served from this one file.
+const SHELL: &str = "index.html";
+
+/// Whether the dashboard should be served at all.
+///
+/// Compiled in and still switchable at run time, because those are different
+/// questions: a distribution decides what to ship, an operator decides what to
+/// expose. Someone fronting Rustrak with their own UI wants the API alone
+/// without rebuilding from source.
+pub fn is_enabled() -> bool {
+    !matches!(
+        std::env::var("RUSTRAK_DASHBOARD").as_deref(),
+        Ok("off" | "false" | "0")
+    )
+}
+
+/// Serve an embedded asset, falling back to the SPA shell.
+///
+/// Registered as the app's `default_service`, so it only ever sees requests no
+/// API route matched. That is what makes mounting at `/` safe: `/api/*`,
+/// `/auth/*` and `/health*` are claimed before this runs.
+pub async fn serve(req: HttpRequest) -> HttpResponse {
+    let path = req.path().trim_start_matches('/');
+    let path = if path.is_empty() { SHELL } else { path };
+
+    match Assets::get(path) {
+        Some(asset) => respond(&req, path, asset),
+        // Deep links are the reason this fallback exists: a reload on
+        // `/issues` has to return the shell so the router can take over.
+        //
+        // But only for paths that do not look like a file. A missing
+        // `/assets/index-abc123.js` must stay a 404: answering it with HTML
+        // gets swallowed by the browser as a MIME type error, which is a
+        // genuinely awful thing to debug. A 404 says what actually happened.
+        None if !looks_like_a_file(path) => match Assets::get(SHELL) {
+            Some(shell) => respond(&req, SHELL, shell),
+            None => HttpResponse::NotFound().finish(),
+        },
+        None => HttpResponse::NotFound().finish(),
+    }
+}
+
+/// A path segment with an extension is asking for a file, not for a route.
+fn looks_like_a_file(path: &str) -> bool {
+    path.rsplit('/')
+        .next()
+        .is_some_and(|last| last.contains('.'))
+}
+
+fn respond(req: &HttpRequest, path: &str, asset: rust_embed::EmbeddedFile) -> HttpResponse {
+    let etag = format!("\"{}\"", hex::encode(asset.metadata.sha256_hash()));
+
+    // The hash is the content, so a match means the client already has this
+    // exact byte sequence. Cheap, and it makes a reload free.
+    if req
+        .headers()
+        .get(IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == etag)
+    {
+        return HttpResponse::NotModified().finish();
+    }
+
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+
+    // Vite fingerprints everything under `assets/`, so those URLs can never
+    // mean anything else and are safe to keep forever. The shell must never be
+    // cached: it is the file that names the current fingerprints, and a stale
+    // one points the browser at assets that no longer exist.
+    let cache = if path.starts_with("assets/") {
+        "public, max-age=31536000, immutable"
+    } else {
+        "no-cache"
+    };
+
+    let mut response = HttpResponse::Ok();
+    response
+        .insert_header((CONTENT_TYPE, mime.as_ref()))
+        .insert_header((CACHE_CONTROL, HeaderValue::from_static(cache)));
+
+    if let Ok(value) = HeaderValue::from_str(&etag) {
+        response.insert_header((ETAG, value));
+    }
+
+    response.body(BoxBody::new(asset.data.into_owned()))
+}

--- a/apps/server/src/lib.rs
+++ b/apps/server/src/lib.rs
@@ -5,6 +5,8 @@
 pub mod auth;
 pub mod bootstrap;
 pub mod config;
+#[cfg(feature = "dashboard")]
+pub mod dashboard;
 pub mod db;
 pub mod digest;
 pub mod error;

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -139,6 +139,22 @@ async fn main() -> std::io::Result<()> {
     #[cfg(feature = "openapi")]
     let openapi_scalar_doc = openapi::ApiDoc::openapi();
 
+    // Read once, outside the factory: `HttpServer::new` runs its closure per
+    // worker thread, and an env lookup per worker is noise in the logs.
+    #[cfg(feature = "dashboard")]
+    let serve_dashboard = rustrak::dashboard::is_enabled();
+    // Not compiled in at all, so there is nothing to serve and nothing to
+    // exempt. Declared rather than `#[cfg]`-ed at every use site so the wiring
+    // below reads the same in both builds.
+    #[cfg(not(feature = "dashboard"))]
+    let serve_dashboard = false;
+
+    if serve_dashboard {
+        log::info!("Serving the dashboard at /");
+    } else {
+        log::info!("Dashboard not served; API only");
+    }
+
     let session_aggregator_data = web::Data::new(session_aggregator.clone());
 
     // Processor registry — single dispatch surface for the ingest pipeline.
@@ -202,8 +218,11 @@ async fn main() -> std::io::Result<()> {
                     .cookie_same_site(actix_web::cookie::SameSite::Lax)
                     .build(),
             )
-            // Authentication middleware (must be after SessionMiddleware)
-            .wrap(RequireAuth)
+            // Authentication middleware (must be after SessionMiddleware).
+            // It has to know whether a public SPA is being served: when it is,
+            // the shell and its assets are fetched with no session and must not
+            // 401. When it is not, this stays strict.
+            .wrap(RequireAuth::new(serve_dashboard))
             // Health check routes (no auth required)
             .service(
                 web::scope("/health")
@@ -251,6 +270,16 @@ async fn main() -> std::io::Result<()> {
             .configure(routes::storage::configure)
             // Ingest routes (Sentry SDK auth)
             .configure(routes::ingest::configure);
+
+        // The dashboard is registered last, as the fallback: it only ever sees
+        // requests that no API route claimed. That is what makes mounting the
+        // SPA at `/` safe alongside `/api/*`, `/auth/*` and `/health*`.
+        #[cfg(feature = "dashboard")]
+        let app = if serve_dashboard {
+            app.default_service(web::to(rustrak::dashboard::serve))
+        } else {
+            app
+        };
 
         #[cfg(feature = "openapi")]
         let app = {

--- a/apps/server/src/middleware/auth.rs
+++ b/apps/server/src/middleware/auth.rs
@@ -11,7 +11,28 @@ use std::rc::Rc;
 use crate::auth;
 
 /// Middleware to require authentication for routes
-pub struct RequireAuth;
+#[derive(Clone, Copy, Default)]
+pub struct RequireAuth {
+    /// Whether a public single-page app is being served from `/`.
+    ///
+    /// Defaults to `false`, which is the strict behaviour: everything outside
+    /// the exempt list demands a session. The permissive branch has to be asked
+    /// for, so nothing widens by accident.
+    public_spa: bool,
+}
+
+impl RequireAuth {
+    /// Build the middleware, saying whether a public SPA is being served.
+    ///
+    /// This is a runtime flag rather than a `#[cfg]` because serving the
+    /// dashboard is itself a runtime decision (`RUSTRAK_DASHBOARD`). Gating the
+    /// exemption at compile time instead meant that turning the dashboard off
+    /// left the exemption on, and an unknown `GET` answered 404 where it used
+    /// to answer 401.
+    pub fn new(public_spa: bool) -> Self {
+        Self { public_spa }
+    }
+}
 
 impl<S, B> Transform<S, ServiceRequest> for RequireAuth
 where
@@ -28,12 +49,14 @@ where
     fn new_transform(&self, service: S) -> Self::Future {
         ready(Ok(RequireAuthMiddleware {
             service: Rc::new(service),
+            public_spa: self.public_spa,
         }))
     }
 }
 
 pub struct RequireAuthMiddleware<S> {
     service: Rc<S>,
+    public_spa: bool,
 }
 
 impl<S, B> Service<ServiceRequest> for RequireAuthMiddleware<S>
@@ -69,6 +92,23 @@ where
                     false
                 }
             };
+
+        // When a public SPA is being served, it owns every path the API does
+        // not, and its shell and assets are public by design: the login screen
+        // lives inside the bundle, so demanding a session to fetch it would be
+        // a loop. Authorisation is enforced where the data is, by the 401s the
+        // API returns, and the client redirects on those. This is what Grafana
+        // and Sentry do.
+        //
+        // Restricted to safe methods on purpose. Every mutating route is under
+        // `/api/` and already exempt here (its extractor does the checking), so
+        // this widens nothing that writes.
+        let is_exempt = is_exempt
+            || (self.public_spa
+                && matches!(
+                    *req.method(),
+                    actix_web::http::Method::GET | actix_web::http::Method::HEAD
+                ));
 
         if is_exempt {
             let service = Rc::clone(&self.service);

--- a/apps/server/tests/integration/auth_test.rs
+++ b/apps/server/tests/integration/auth_test.rs
@@ -614,7 +614,7 @@ async fn test_middleware_blocks_unauthenticated_access() {
                     .cookie_secure(false)
                     .build(),
             )
-            .wrap(RequireAuth)
+            .wrap(RequireAuth::default())
             .configure(routes::auth::configure)
             .configure(routes::projects::configure),
     )
@@ -646,7 +646,7 @@ async fn test_middleware_allows_authenticated_access() {
                     .cookie_secure(false)
                     .build(),
             )
-            .wrap(RequireAuth)
+            .wrap(RequireAuth::default())
             .configure(routes::auth::configure)
             .configure(routes::projects::configure),
     )
@@ -691,7 +691,7 @@ async fn test_middleware_exempts_auth_routes() {
                     .cookie_secure(false)
                     .build(),
             )
-            .wrap(RequireAuth)
+            .wrap(RequireAuth::default())
             .configure(routes::auth::configure),
     )
     .await;
@@ -727,7 +727,7 @@ async fn test_middleware_exempts_health_routes() {
                     .cookie_secure(false)
                     .build(),
             )
-            .wrap(RequireAuth)
+            .wrap(RequireAuth::default())
             .service(
                 web::scope("/health")
                     .route("", web::get().to(routes::health::liveness))
@@ -981,4 +981,94 @@ async fn test_logout_invalidates_session() {
         .to_request();
     let me_resp2 = test::call_service(&app, me_req2).await;
     assert_eq!(me_resp2.status(), 401);
+}
+
+// ---------------------------------------------------------------------------
+// RequireAuth and the public SPA
+//
+// These pin the boundary between "the dashboard is served, so its shell and
+// assets must be fetchable without a session" and "it is not, so nothing is".
+//
+// They exist because that boundary already drifted once: the exemption was
+// gated at compile time while the serving was gated at run time, so turning the
+// dashboard off left the exemption on and an unknown GET answered 404 where it
+// used to answer 401. Nothing caught it. Now something does.
+//
+// No database: the middleware never touches one, and a test that needs a
+// container to assert a status code is a test nobody runs.
+// ---------------------------------------------------------------------------
+
+/// An app wrapped in `RequireAuth` with no routes at all, so every request
+/// falls through to the middleware's own decision and nothing else.
+macro_rules! require_auth_app {
+    ($middleware:expr) => {
+        test::init_service(
+            App::new()
+                .wrap($middleware)
+                .wrap(
+                    SessionMiddleware::builder(
+                        CookieSessionStore::default(),
+                        Key::from(&[0u8; 64]),
+                    )
+                    .cookie_secure(false)
+                    .build(),
+                )
+                .default_service(web::to(actix_web::HttpResponse::Ok)),
+        )
+        .await
+    };
+}
+
+#[actix_web::test]
+async fn strict_require_auth_rejects_an_unauthenticated_get() {
+    let app = require_auth_app!(RequireAuth::default());
+
+    let resp = test::call_service(&app, test::TestRequest::get().uri("/issues").to_request()).await;
+
+    // The default is strict on purpose: the permissive branch has to be asked
+    // for, so nothing widens by accident.
+    assert_eq!(resp.status(), 401);
+}
+
+#[actix_web::test]
+async fn public_spa_lets_an_unauthenticated_get_through() {
+    let app = require_auth_app!(RequireAuth::new(true));
+
+    let resp = test::call_service(&app, test::TestRequest::get().uri("/issues").to_request()).await;
+
+    // Reloading on a client-side route has to reach the SPA shell. Demanding a
+    // session first would be a loop: the login screen is inside that bundle.
+    assert_eq!(resp.status(), 200);
+}
+
+#[actix_web::test]
+async fn public_spa_still_rejects_an_unauthenticated_write() {
+    let app = require_auth_app!(RequireAuth::new(true));
+
+    for request in [
+        test::TestRequest::post().uri("/whatever").to_request(),
+        test::TestRequest::delete().uri("/whatever").to_request(),
+    ] {
+        let resp = test::call_service(&app, request).await;
+
+        // The exemption is safe-methods only. Serving a UI must never widen
+        // anything that writes.
+        assert_eq!(resp.status(), 401);
+    }
+}
+
+#[actix_web::test]
+async fn public_spa_does_not_change_the_api_surface() {
+    let app = require_auth_app!(RequireAuth::new(true));
+
+    // `/api/*` is exempt from this middleware either way, because each route
+    // authenticates through its own extractor. Serving the dashboard must not
+    // move that line.
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/api/projects").to_request(),
+    )
+    .await;
+
+    assert_eq!(resp.status(), 200);
 }


### PR DESCRIPTION
Rustrak becomes one artifact. No Node process, no second container, no
`RUSTRAK_API_URL` to configure, and self-hosters stop needing Node at all. The
browser talks to the same origin that served it, so the session cookie works
with no CORS involved.

The assets are embedded, not read from disk. Serving them from a directory is
the other common answer (Qdrant does it) and it creates a whole class of
deployment bug: the binary starts fine and every page is a 404 because the
folder was not copied. Embedding makes that unrepresentable. Measured cost on a
release build: 15.83 MiB to 16.63 MiB, +823 KiB, +5.1%. `dist/` is 792 KiB, so
the binary grows by the assets plus about 30 KiB of rust-embed and mime_guess.
There is no hidden multiplier.

`dashboard` is deliberately not a default feature. It embeds
`apps/dashboard/dist`, a gitignored build artifact, so a default that included
it would make `cargo build` fail on a fresh clone until someone ran the JS
build. A Rust contributor should be able to clone and build. Verified: with
`dist/` deleted, `cargo build --no-default-features --features sqlite` compiles.

Compiled in and still switchable at run time, because those are different
questions: a distribution decides what to ship, an operator decides what to
expose. `RUSTRAK_DASHBOARD=off` leaves the API alone.

The fallback is registered as `default_service`, so it only sees requests no API
route matched; `/api/*`, `/auth/*` and `/health*` are claimed first, which is
what makes mounting at `/` safe. A reload on `/issues` returns the shell so the
router can take over, but only for paths that do not look like a file: a missing
`/assets/index-abc123.js` stays a 404, because answering it with HTML is
swallowed by the browser as a MIME type error and is genuinely awful to debug.

`RequireAuth` now takes the flag rather than a `#[cfg]`. Serving the dashboard
is a run-time decision, and gating the exemption at compile time meant that
turning the dashboard off left the exemption on, so an unknown GET answered 404
where it used to answer 401. `Default` is strict, so the permissive branch has
to be asked for and nothing widens by accident.

When a public SPA is served, its shell and assets are public by design: the
login screen lives inside the bundle, so demanding a session to fetch it would
be a loop. Authorisation is enforced where the data is, by the API's 401s, and
the client redirects on those. This is what Grafana and Sentry do. The exemption
is restricted to safe methods; every mutating route is under `/api/` and already
authenticates through its own extractor, so nothing that writes is widened.

Caching: `assets/` is fingerprinted by Vite and gets `immutable`; the shell gets
`no-cache`, because it is the file that names the current fingerprints and a
stale one points the browser at assets that no longer exist. ETags come from the
content hash, so a reload is a 304 with no body.

Testing: four regression tests pin the auth boundary, and each was watched
failing before being kept. Reverting the flag to an unconditional exemption
turns `strict_require_auth_rejects_an_unauthenticated_get` red. 366 integration
tests pass.

Still to do, and deliberately not here: the server Dockerfile needs a Node stage
to build `dist/` before the cargo stage, and `FEATURES` needs `dashboard` added,
or the published image ships without a UI.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>