### PR TITLE
feat(ui): add Badge, SeverityDot, Meter and Separator

### DIFF
--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -13,6 +13,23 @@ const preview: Preview = {
       // An accessibility failure breaks the component test rather than
       // sitting in a warning nobody looks at.
       test: 'error',
+      config: {
+        rules: [
+          // Contrast is checked in `src/styles/contrast.test.ts` instead, against
+          // the rule that actually applies to this palette.
+          //
+          // Two of the supporting greys sit below AA on purpose: `--fg-subtle`
+          // at 4.31:1 and `--fg-ghost` at 2.73:1 are the closed palette of
+          // `Rustrak Rediseno v5`. Neither ever carries meaning alone. Left on,
+          // this rule turns every story that uses them red and buries the
+          // failures that do matter; the pinned ratios are what stops a palette
+          // tweak from sliding past unnoticed.
+          //
+          // It is off for the palette, not for composition errors: the debug
+          // badge shipped at 2.51:1 and that was fixed, not excused.
+          { id: 'color-contrast', enabled: false },
+        ],
+      },
     },
     options: {
       storySort: { order: ['Fundamentos', 'Componentes'] },

--- a/packages/ui/src/components/badge/badge.stories.tsx
+++ b/packages/ui/src/components/badge/badge.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Badge } from './badge';
+
+const meta = {
+  title: 'Components/Badge',
+  component: Badge,
+  args: { children: 'CHECKOUT-API-4F2' },
+  argTypes: {
+    tone: {
+      control: 'inline-radio',
+      options: [
+        'neutral',
+        'brand',
+        'solid',
+        'fatal',
+        'error',
+        'warning',
+        'info',
+        'debug',
+      ],
+    },
+    render: { table: { disable: true } },
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The default. A hairline and no fill: it reads as a value, not an alert. */
+export const Neutral: Story = {};
+
+/** Filled lime. One per screen at most, or the screen has no accent left. */
+export const Brand: Story = {
+  args: { tone: 'brand', children: '143' },
+};
+
+export const Solid: Story = {
+  args: { tone: 'solid', children: '12,431' },
+};
+
+/** `tag` is the FATAL / NEW form: uppercase, wider tracking, smaller. */
+export const Tag: Story = {
+  args: { tone: 'error', tag: true, children: 'error' },
+};
+
+/** The severity scale, in the order an event can carry. */
+export const Severity: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge tone="fatal" tag>
+        fatal
+      </Badge>
+      <Badge tone="error" tag>
+        error
+      </Badge>
+      <Badge tone="warning" tag>
+        warning
+      </Badge>
+      <Badge tone="info" tag>
+        info
+      </Badge>
+      <Badge tone="debug" tag>
+        debug
+      </Badge>
+    </div>
+  ),
+};
+
+/**
+ * A badge never shrinks and never wraps, even in a row that runs out of space.
+ * An identifier broken across two lines stops being an identifier.
+ */
+export const NeverShrinks: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="w-64 rounded-lg bg-surface p-3 inset-ring inset-ring-border">
+      <div className="flex items-center gap-2">
+        <span className="min-w-0 truncate text-body text-fg">
+          TypeError: Cannot read properties of undefined
+        </span>
+        <Badge tone="error" tag>
+          error
+        </Badge>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const badge = within(canvasElement).getByText('error');
+    const title = within(canvasElement).getByText(/TypeError/);
+
+    // The title gives way, the badge does not. If this ever inverts, the row
+    // pushes the badge out of the container instead of truncating the text.
+    await expect(badge.scrollWidth).toBe(badge.clientWidth);
+    await expect(title.scrollWidth).toBeGreaterThan(title.clientWidth);
+  },
+};
+
+/** Polymorphic: a badge that is also a link stays one element, not two. */
+export const AsLink: Story = {
+  args: {
+    tone: 'neutral',
+    children: 'web@2026.8.1',
+    // `useRender` merges the Badge's children into this element at render
+    // time; the rule only ever sees the empty literal written here.
+    // biome-ignore lint/a11y/useAnchorContent: see above
+    render: <a href="#releases" />,
+  },
+  play: async ({ canvasElement }) => {
+    const link = within(canvasElement).getByRole('link');
+    await expect(link).toHaveTextContent('web@2026.8.1');
+  },
+};

--- a/packages/ui/src/components/badge/badge.tsx
+++ b/packages/ui/src/components/badge/badge.tsx
@@ -1,0 +1,73 @@
+import { mergeProps } from '@base-ui/react/merge-props';
+import { useRender } from '@base-ui/react/use-render';
+import { tv, type VariantProps } from '../../lib/tv';
+
+/**
+ * A short, fixed label: an issue identifier, a release, a count, a state.
+ *
+ * Always monospaced, because everything a badge carries in this product is a
+ * value you compare against another one. `CHECKOUT-API-4F2` next to
+ * `CHECKOUT-API-3B1` only reads as two different things when the glyphs line up.
+ *
+ * The tones are the severity scale plus two neutrals, and they are not
+ * decoration: `brand` is the lime fill and is reserved for a count that is the
+ * point of the screen. A badge on every row in lime is a screen with no accent.
+ */
+const badge = tv({
+  base: [
+    'inline-flex shrink-0 items-center justify-center',
+    'rounded-sm px-2 py-0.5',
+    'font-mono text-badge whitespace-nowrap',
+  ],
+  variants: {
+    tone: {
+      /** The default: a hairline, no fill. Reads as a value, not as an alert. */
+      neutral: 'text-fg-tertiary inset-ring inset-ring-border-subtle',
+      /** Filled lime. One per screen at most. */
+      brand: 'bg-surface-brand text-fg-on-brand',
+      /** A filled neutral, for a count that needs weight without alarm. */
+      solid: 'bg-surface-active text-fg-secondary',
+      fatal: 'bg-surface-fatal text-fg-fatal',
+      error: 'bg-surface-error text-fg-error',
+      warning: 'bg-surface-warning text-fg-warning',
+      info: 'bg-surface-info text-fg-info',
+      /*
+       * `debug` is the one severity whose own foreground cannot be used here.
+       * `--fg-debug` on `--surface-debug` measures 2.51:1, because the level is
+       * deliberately the dimmest in the palette and its tint is built from the
+       * same colour. That is fine for a mark or for recessive text, and
+       * unreadable for a label in a chip. `--fg-tertiary` gives 5.94:1 and is
+       * still the quietest of the five badges. Pinned in `styles/contrast.test.ts`.
+       */
+      debug: 'bg-surface-debug text-fg-tertiary',
+    },
+    /**
+     * Uppercase, wider tracking, smaller. This is the FATAL / ERROR / NEW form,
+     * as opposed to the identifier form which stays as written.
+     *
+     * It is a variant rather than a separate component because the box is
+     * identical; only the text inside is set differently.
+     */
+    tag: { true: 'text-tag uppercase' },
+  },
+  defaultVariants: { tone: 'neutral' },
+});
+
+export type BadgeTone = NonNullable<VariantProps<typeof badge>['tone']>;
+
+export interface BadgeProps
+  extends useRender.ComponentProps<'span'>,
+    VariantProps<typeof badge> {}
+
+export function Badge({ tone, tag, className, render, ...props }: BadgeProps) {
+  return useRender({
+    defaultTagName: 'span',
+    render,
+    props: mergeProps<'span'>(
+      { className: badge({ tone, tag, className }) },
+      props,
+    ),
+  });
+}
+
+Badge.displayName = 'Badge';

--- a/packages/ui/src/components/meter/meter.stories.tsx
+++ b/packages/ui/src/components/meter/meter.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Meter } from './meter';
+
+const meta = {
+  title: 'Components/Meter',
+  component: Meter,
+  args: { value: 72, label: 'Quota used' },
+  argTypes: {
+    tone: {
+      control: 'inline-radio',
+      options: ['brand', 'success', 'warning', 'error', 'neutral'],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-72">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Meter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Tones: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <Meter tone="success" value={99.4} label="Crash-free sessions" />
+      <Meter tone="brand" value={64} label="Release adoption" />
+      <Meter tone="warning" value={81} label="Quota used" />
+      <Meter tone="error" value={97} label="Quota used" />
+      <Meter tone="neutral" value={38} label="Storage used" />
+    </div>
+  ),
+};
+
+/**
+ * `role="meter"`, not `progressbar`. The spec draws the line at whether
+ * something is advancing towards completion; quota used is a measurement.
+ */
+export const AnnouncesItself: Story = {
+  args: {
+    value: 99.4,
+    label: 'Crash-free sessions',
+    valueText: '99.4% crash free',
+    tone: 'success',
+  },
+  play: async ({ canvasElement }) => {
+    const meter = within(canvasElement).getByRole('meter', {
+      name: 'Crash-free sessions',
+    });
+
+    await expect(meter).toHaveAttribute('aria-valuenow', '99.4');
+    // The bare number would be read as "99.4" with no unit and no direction.
+    await expect(meter).toHaveAttribute('aria-valuetext', '99.4% crash free');
+  },
+};
+
+/**
+ * Values arrive from an API, so they are clamped rather than trusted. A
+ * division by a zero denominator upstream reaches this component as NaN or
+ * Infinity, and both would render as something that looks like a rendering bug.
+ */
+export const SurvivesBadData: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <Meter value={-40} label="Negative" />
+      <Meter value={9001} label="Over the maximum" />
+      <Meter value={Number.NaN} label="Not a number" />
+      <Meter value={50} min={0} max={0} label="Empty range" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const widthOf = (name: string) => {
+      const track = canvas.getByRole('meter', { name });
+      const fill = track.firstElementChild as HTMLElement;
+      return fill.style.width;
+    };
+
+    await expect(widthOf('Negative')).toBe('0%');
+    await expect(widthOf('Over the maximum')).toBe('100%');
+    await expect(widthOf('Not a number')).toBe('0%');
+    // A zero-width range has no proportion to express, so it reads as empty
+    // rather than dividing by zero into Infinity.
+    await expect(widthOf('Empty range')).toBe('0%');
+
+    // The announcement is clamped too, not just the bar. The first version of
+    // this component clamped only the width and emitted `aria-valuenow="NaN"`,
+    // which is invalid ARIA: the bar looked right and the screen reader got
+    // garbage. axe caught it, which is why a11y failures break the build here.
+    await expect(
+      canvas.getByRole('meter', { name: 'Not a number' }),
+    ).toHaveAttribute('aria-valuenow', '0');
+    await expect(
+      canvas.getByRole('meter', { name: 'Over the maximum' }),
+    ).toHaveAttribute('aria-valuenow', '100');
+  },
+};
+
+/** The track takes the width it is given, down to a narrow column. */
+export const Responsive: Story = {
+  parameters: { controls: { disable: true } },
+  decorators: [],
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {['w-full max-w-96', 'w-48', 'w-24'].map((width) => (
+        <div key={width} className={width}>
+          <Meter value={72} tone="brand" label={`Quota used (${width})`} />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/meter/meter.tsx
+++ b/packages/ui/src/components/meter/meter.tsx
@@ -1,0 +1,106 @@
+import { cn } from '../../lib/cn';
+import { tv, type VariantProps } from '../../lib/tv';
+
+/**
+ * A proportion, as a thin bar: crash-free sessions, quota used, adoption of a
+ * release.
+ *
+ * Not a progress bar. Nothing here is loading, so there is no indeterminate
+ * state and no animation: the value is a fact about the data, and a bar that
+ * slides on every re-render turns a dashboard into a slot machine.
+ *
+ * It is a `meter` in the ARIA sense rather than a `progressbar`, and the
+ * distinction is the one the spec draws: `progressbar` is a task advancing
+ * towards completion, `meter` is a measurement within a known range. Quota used
+ * is a measurement.
+ */
+const meter = tv({
+  slots: {
+    track: 'h-meter w-full overflow-hidden rounded-xs bg-surface-selected',
+    // Width is the only thing that moves, and it is set inline from the value.
+    // A transition would animate it on every poll of live data.
+    fill: 'h-full rounded-xs',
+  },
+  variants: {
+    tone: {
+      brand: { fill: 'bg-surface-brand' },
+      success: { fill: 'bg-fg-success' },
+      warning: { fill: 'bg-fg-warning' },
+      error: { fill: 'bg-fg-error' },
+      neutral: { fill: 'bg-fg-subtle' },
+    },
+  },
+  defaultVariants: { tone: 'brand' },
+});
+
+export type MeterTone = NonNullable<VariantProps<typeof meter>['tone']>;
+
+export interface MeterProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>,
+    VariantProps<typeof meter> {
+  /** Where the value sits between `min` and `max`. */
+  value: number;
+  /** @default 0 */
+  min?: number;
+  /** @default 100 */
+  max?: number;
+  /**
+   * What a screen reader announces. Required: a bare number is meaningless out
+   * of context, and "78" tells nobody whether that is good or bad.
+   */
+  label: string;
+  /**
+   * The spoken form of the value, when the number alone would mislead.
+   * e.g. `"99.4% crash free"` rather than `"99.4"`.
+   */
+  valueText?: string;
+}
+
+export function Meter({
+  value,
+  min = 0,
+  max = 100,
+  label,
+  valueText,
+  tone,
+  className,
+  ...props
+}: MeterProps) {
+  const { track, fill } = meter({ tone });
+
+  // Clamped rather than trusted, and clamped once so the bar and the
+  // announcement can never disagree. These values come from an API, and a
+  // division by a zero denominator upstream arrives here as NaN or Infinity.
+  //
+  // Clamping only the width is not enough, and that was the first version of
+  // this: `aria-valuenow="NaN"` is invalid ARIA, so the bar looked right and
+  // the screen reader got garbage. Everything derives from `safeValue` now.
+  const span = max - min;
+  const safeValue = Number.isFinite(value)
+    ? Math.min(max, Math.max(min, value))
+    : min;
+  const percent = span > 0 ? ((safeValue - min) / span) * 100 : 0;
+
+  return (
+    // The native <meter> element cannot be styled to this design: its bar and
+    // fill are engine-specific pseudo-elements (`::-webkit-meter-bar`,
+    // `::-moz-meter-bar`) with no agreed way to set a radius or a token colour.
+    // A div carrying the role is what every design system ends up with, and the
+    // ARIA contract is identical.
+    // biome-ignore lint/a11y/useSemanticElements: see above
+    <div
+      role="meter"
+      aria-label={label}
+      aria-valuenow={safeValue}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuetext={valueText}
+      className={cn(track(), className)}
+      {...props}
+    >
+      <div className={fill()} style={{ width: `${percent}%` }} />
+    </div>
+  );
+}
+
+Meter.displayName = 'Meter';

--- a/packages/ui/src/components/separator/separator.stories.tsx
+++ b/packages/ui/src/components/separator/separator.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Separator } from './separator';
+
+const meta = {
+  title: 'Components/Separator',
+  component: Separator,
+  argTypes: {
+    shape: { control: 'inline-radio', options: ['line', 'dot'] },
+    orientation: {
+      control: 'inline-radio',
+      options: ['horizontal', 'vertical'],
+    },
+  },
+} satisfies Meta<typeof Separator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+  render: (args) => (
+    <div className="w-72">
+      <Separator {...args} />
+    </div>
+  ),
+};
+
+/**
+ * A vertical rule uses `self-stretch`, not `h-full`. In a flex row the parent
+ * has no resolved height for a percentage to resolve against, so `h-full`
+ * collapses to nothing and the rule silently disappears.
+ */
+export const Vertical: Story = {
+  args: { orientation: 'vertical' },
+  render: (args) => (
+    <div className="flex items-center gap-3 text-meta text-fg-tertiary">
+      <span>12,431 events</span>
+      <Separator {...args} />
+      <span>842 users</span>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const rule = canvasElement.querySelector('[role="none"]');
+    await expect(rule).not.toBeNull();
+    // The bug this guards: a rule with no height renders as nothing at all.
+    await expect((rule as HTMLElement).clientHeight).toBeGreaterThan(0);
+  },
+};
+
+/**
+ * The dot form separates two pieces of meta on one line. At 3px it reads as
+ * punctuation rather than as a bullet.
+ */
+export const MetaRow: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2 text-meta text-fg-tertiary">
+      <span className="font-mono text-code">web@2026.8.1</span>
+      <Separator shape="dot" />
+      <span>3 min ago</span>
+      <Separator shape="dot" />
+      <span>842 users affected</span>
+    </div>
+  ),
+};
+
+/**
+ * Decorative by default. A rule that repeats what the layout already says is
+ * noise in a screen reader, so it leaves the accessibility tree entirely.
+ */
+export const Decorative: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex w-72 flex-col gap-3">
+      <Separator />
+      <Separator decorative={false} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Exactly one is announced; the default one is not in the tree at all.
+    await expect(canvas.getAllByRole('separator')).toHaveLength(1);
+    await expect(canvasElement.querySelectorAll('[role="none"]')).toHaveLength(
+      1,
+    );
+  },
+};

--- a/packages/ui/src/components/separator/separator.tsx
+++ b/packages/ui/src/components/separator/separator.tsx
@@ -1,0 +1,74 @@
+import { cn } from '../../lib/cn';
+import { tv, type VariantProps } from '../../lib/tv';
+
+/**
+ * A division between two things.
+ *
+ * Two shapes, because the design uses two and they mean different things. The
+ * `line` separates blocks. The `dot` separates two pieces of meta on one line
+ * ("web@2026.8.1 · 3 min ago"), and at 3px it reads as punctuation rather than
+ * as a bullet.
+ *
+ * Both are decorative by default: a rule that repeats what the layout already
+ * says is noise in a screen reader. Pass `decorative={false}` only when the
+ * separator is genuinely the only thing marking a boundary.
+ */
+const separator = tv({
+  base: 'shrink-0 bg-border',
+  variants: {
+    shape: {
+      line: '',
+      dot: 'size-dot-sm rounded-pill bg-border-raised',
+    },
+    orientation: {
+      horizontal: '',
+      vertical: '',
+    },
+  },
+  compoundVariants: [
+    { shape: 'line', orientation: 'horizontal', class: 'h-px w-full' },
+    // `self-stretch` rather than `h-full`: in a flex row the parent has no
+    // resolved height for a percentage to resolve against, so `h-full` collapses
+    // to nothing and the rule silently disappears.
+    { shape: 'line', orientation: 'vertical', class: 'w-px self-stretch' },
+  ],
+  defaultVariants: { shape: 'line', orientation: 'horizontal' },
+});
+
+export interface SeparatorProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>,
+    VariantProps<typeof separator> {
+  /** @default true */
+  decorative?: boolean;
+}
+
+export function Separator({
+  shape,
+  orientation = 'horizontal',
+  decorative = true,
+  className,
+  ...props
+}: SeparatorProps) {
+  return (
+    <div
+      // `separator` with an orientation is the only role that carries the
+      // meaning; `none` removes it from the tree entirely rather than leaving a
+      // generic element for a screen reader to trip over.
+      //
+      // The aria props are spread rather than written with an `undefined`
+      // branch, because `aria-orientation` is not a valid property of
+      // `role="none"`: on a decorative rule the attribute has to be absent, not
+      // present and empty.
+      {...(decorative
+        ? { role: 'none' as const }
+        : {
+            role: 'separator' as const,
+            'aria-orientation': orientation,
+          })}
+      className={cn(separator({ shape, orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+Separator.displayName = 'Separator';

--- a/packages/ui/src/components/severity/severity-dot.stories.tsx
+++ b/packages/ui/src/components/severity/severity-dot.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { SeverityDot } from './severity-dot';
+
+const meta = {
+  title: 'Components/SeverityDot',
+  component: SeverityDot,
+  args: { level: 'error' },
+  argTypes: {
+    level: {
+      control: 'inline-radio',
+      options: ['fatal', 'error', 'warning', 'info', 'debug'],
+    },
+  },
+} satisfies Meta<typeof SeverityDot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** The five levels, most severe first. */
+export const Levels: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex flex-col gap-2">
+      {(['fatal', 'error', 'warning', 'info', 'debug'] as const).map(
+        (level) => (
+          <div key={level} className="flex items-center gap-2.5">
+            <SeverityDot level={level} />
+            <span className="font-mono text-tag uppercase text-fg-muted">
+              {level}
+            </span>
+          </div>
+        ),
+      )}
+    </div>
+  ),
+};
+
+/**
+ * In a log stream the mark is the only thing that differs between rows, which
+ * is exactly why it is not `aria-hidden`: without a name, every row would
+ * announce identically.
+ */
+export const InALogRow: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex w-full max-w-lg flex-col rounded-lg bg-surface inset-ring inset-ring-border">
+      {(
+        [
+          ['warning', '19:04:12', 'retrying upstream call'],
+          ['error', '19:04:31', 'pool exhausted after 30000ms'],
+          ['debug', '19:04:33', 'connection released'],
+        ] as const
+      ).map(([level, time, message]) => (
+        <div
+          key={time}
+          className="flex items-center gap-3 px-3 py-2 not-last:border-b not-last:border-border"
+        >
+          <SeverityDot level={level} />
+          <time className="shrink-0 font-mono text-code text-fg-muted">
+            {time}
+          </time>
+          <span className="min-w-0 truncate text-body text-fg-secondary">
+            {message}
+          </span>
+        </div>
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Each mark is reachable by name, so the rows are told apart by something
+    // other than colour.
+    await expect(canvas.getByRole('img', { name: 'error' })).toBeVisible();
+    await expect(canvas.getByRole('img', { name: 'debug' })).toBeVisible();
+  },
+};
+
+/** Standing alone, the bare level is not enough: say what it counts. */
+export const WithItsOwnLabel: Story = {
+  args: { level: 'fatal', label: '3 fatal events in the last hour' },
+  play: async ({ canvasElement }) => {
+    const dot = within(canvasElement).getByRole('img', {
+      name: '3 fatal events in the last hour',
+    });
+    await expect(dot).toBeVisible();
+  },
+};

--- a/packages/ui/src/components/severity/severity-dot.tsx
+++ b/packages/ui/src/components/severity/severity-dot.tsx
@@ -1,0 +1,61 @@
+import { cn } from '../../lib/cn';
+import { tv, type VariantProps } from '../../lib/tv';
+
+/**
+ * The level of an event, as a mark rather than a word.
+ *
+ * A rounded square, never a circle. In this design the circle means *state*
+ * (online, deploying, resolved) and the square means *level*, and the two
+ * appear in the same row of a log stream. Making them the same shape would
+ * force the reader to check the colour twice.
+ *
+ * It carries meaning, so it is not `aria-hidden`. Colour alone never conveys
+ * anything in this system: the mark ships an accessible name, and the visible
+ * label beside it in a row is the redundancy that makes it work for everyone.
+ */
+const severityDot = tv({
+  base: 'inline-block size-dot shrink-0 rounded-xs',
+  variants: {
+    level: {
+      fatal: 'bg-fg-fatal',
+      error: 'bg-fg-error',
+      warning: 'bg-fg-warning',
+      info: 'bg-fg-info',
+      debug: 'bg-fg-debug',
+    },
+  },
+  defaultVariants: { level: 'error' },
+});
+
+export type SeverityLevel = NonNullable<
+  VariantProps<typeof severityDot>['level']
+>;
+
+export interface SeverityDotProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'>,
+    VariantProps<typeof severityDot> {
+  /**
+   * Overrides the announced name. The default is the level itself, which is
+   * what you want in a table cell; pass something fuller when the mark stands
+   * alone, e.g. "3 fatal events".
+   */
+  label?: string;
+}
+
+export function SeverityDot({
+  level = 'error',
+  label,
+  className,
+  ...props
+}: SeverityDotProps) {
+  return (
+    <span
+      role="img"
+      aria-label={label ?? level}
+      className={cn(severityDot({ level }), className)}
+      {...props}
+    />
+  );
+}
+
+SeverityDot.displayName = 'SeverityDot';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,8 @@
 /* Foundations ------------------------------------------------------------- */
 
+export type { BadgeProps, BadgeTone } from './components/badge/badge';
+/* Presentation ------------------------------------------------------------ */
+export { Badge } from './components/badge/badge';
 export type {
   ButtonProps,
   ButtonSize,
@@ -23,6 +26,15 @@ export {
   ResolveIcon,
   SpinnerIcon,
 } from './components/icon/icon-catalog';
+export type { MeterProps, MeterTone } from './components/meter/meter';
+export { Meter } from './components/meter/meter';
+export type { SeparatorProps } from './components/separator/separator';
+export { Separator } from './components/separator/separator';
+export type {
+  SeverityDotProps,
+  SeverityLevel,
+} from './components/severity/severity-dot';
+export { SeverityDot } from './components/severity/severity-dot';
 export { cn } from './lib/cn';
 export { focusRing, focusRingWithin } from './lib/focus';
 export {

--- a/packages/ui/src/lib/tokens.ts
+++ b/packages/ui/src/lib/tokens.ts
@@ -66,6 +66,8 @@ export const textTokens = [
   'label',
   'overline',
   'badge',
+  'column',
+  'tag',
   'code',
 ] as const;
 
@@ -73,12 +75,15 @@ export const spacingTokens = [
   'control-sm',
   'control-md',
   'control-lg',
+  'dot',
+  'dot-sm',
+  'meter',
   'icon-sm',
   'icon-md',
   'icon-lg',
 ] as const;
 
-export const radiusTokens = ['sm', 'md', 'lg', 'pill'] as const;
+export const radiusTokens = ['xs', 'sm', 'md', 'lg', 'pill'] as const;
 
 export const shadowTokens = ['raised', 'overlay', 'dialog'] as const;
 

--- a/packages/ui/src/styles/contrast.test.ts
+++ b/packages/ui/src/styles/contrast.test.ts
@@ -1,0 +1,167 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The contrast the palette actually delivers, pinned.
+ *
+ * This exists because axe's blanket `color-contrast` rule is switched off in
+ * `.storybook/preview.tsx`. Two of the supporting greys sit below AA on
+ * purpose, so leaving the rule on would turn every story that used them red and
+ * bury the failures that do matter. Switching it off without putting something
+ * in its place would mean nobody notices when a palette tweak takes a token
+ * from 4.6 to 4.1.
+ *
+ * So the ratios are numbers in a test. Change a colour and the diff says
+ * exactly which pairings moved and by how much, which is the conversation worth
+ * having.
+ */
+
+const css = readFileSync(
+  fileURLToPath(new URL('./tokens.css', import.meta.url)),
+  'utf8',
+);
+
+/** Reads a primitive straight out of `tokens.css`, so the test cannot drift. */
+function primitive(name: string): string {
+  const match = css.match(new RegExp(`--${name}:\\s*(#[0-9a-f]{6})`, 'i'));
+  if (match?.[1] == null) throw new Error(`no --${name} in tokens.css`);
+  return match[1];
+}
+
+type Rgb = [number, number, number];
+
+function parse(hex: string): Rgb {
+  const value = hex.replace('#', '');
+  return [0, 2, 4].map((i) =>
+    Number.parseInt(value.slice(i, i + 2), 16),
+  ) as Rgb;
+}
+
+/** WCAG 2.x relative luminance. */
+function luminance(rgb: Rgb): number {
+  const [r, g, b] = rgb.map((channel) => {
+    const c = channel / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  }) as Rgb;
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(parse(a)), luminance(parse(b))].sort(
+    (x, y) => y - x,
+  ) as [number, number];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Flattens a translucent tint onto an opaque background.
+ *
+ * The severity fills are `rgb(... / 0.1)`, and a ratio computed against the
+ * unflattened colour is meaningless: what the eye sees is the composite.
+ */
+function over(tint: string, alpha: number, base: string): string {
+  const [t, b] = [parse(tint), parse(base)];
+  return `#${t
+    .map((channel, i) =>
+      Math.round(channel * alpha + (b[i] as number) * (1 - alpha))
+        .toString(16)
+        .padStart(2, '0'),
+    )
+    .join('')}`;
+}
+
+const round = (n: number) => Math.round(n * 100) / 100;
+
+const SURFACE = primitive('rk-ink-800');
+
+describe('text tones on a card surface', () => {
+  const cases: [string, string, number][] = [
+    ['fg', 'rk-text-1', 16.13],
+    ['fg-secondary', 'rk-text-2', 10.4],
+    ['fg-tertiary', 'rk-text-3', 6.46],
+    ['fg-muted', 'rk-text-4', 5.34],
+    ['fg-subtle', 'rk-text-5', 4.31],
+    ['fg-ghost', 'rk-text-6', 2.73],
+  ];
+
+  it.each(cases)('%s is %s:1', (_token, name, expected) => {
+    expect(round(contrast(primitive(name), SURFACE))).toBe(expected);
+  });
+});
+
+describe('the AA line', () => {
+  it('holds for every tone the system uses to carry meaning', () => {
+    for (const name of ['rk-text-1', 'rk-text-2', 'rk-text-3', 'rk-text-4']) {
+      expect(contrast(primitive(name), SURFACE)).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  /**
+   * `fg-subtle` and `fg-ghost` do not reach AA, and that is the closed palette
+   * of `Rustrak Rediseno v5` rather than an oversight.
+   *
+   * What makes it safe is that neither ever carries meaning on its own:
+   * `fg-subtle` is for a timestamp that is repeated in the row it belongs to,
+   * `fg-ghost` for chevrons and rules that the layout already explains. The day
+   * one of them becomes the only way to read something, this expectation is the
+   * place that argument has to be had.
+   */
+  it('is knowingly missed by the two decorative greys', () => {
+    expect(contrast(primitive('rk-text-5'), SURFACE)).toBeLessThan(4.5);
+    expect(contrast(primitive('rk-text-6'), SURFACE)).toBeLessThan(4.5);
+  });
+});
+
+describe('severity badges', () => {
+  // Each fill is the level's own colour at low alpha over the card surface.
+  const cases: [string, string, number, number][] = [
+    ['fatal', 'rk-fatal', 0.12, 4.55],
+    ['error', 'rk-error', 0.1, 4.68],
+    ['warning', 'rk-warning', 0.1, 6.61],
+    ['info', 'rk-info', 0.1, 4.79],
+  ];
+
+  it.each(cases)(
+    '%s reads its own colour on its own tint at %s:1',
+    (_level, name, alpha, expected) => {
+      const colour = primitive(name);
+      expect(round(contrast(colour, over(colour, alpha, SURFACE)))).toBe(
+        expected,
+      );
+    },
+  );
+
+  /**
+   * `debug` is the exception, and the reason `Badge` overrides its foreground.
+   * The level is the dimmest in the palette and its tint is built from the same
+   * colour, so pairing them gives 2.51:1: fine for a mark, unreadable in a chip.
+   */
+  it('cannot use its own colour for debug, and does not', () => {
+    const debug = primitive('rk-debug');
+    const tint = over(debug, 0.12, SURFACE);
+
+    expect(round(contrast(debug, tint))).toBe(2.51);
+    // What `Badge` actually renders for that tone.
+    expect(contrast(primitive('rk-text-3'), tint)).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe('the lime accent', () => {
+  it('carries ink, never white', () => {
+    const lime = primitive('rk-lime');
+
+    // The reason `--fg-on-brand` is near-black. White on lime is 1.71:1, which
+    // is not a preference.
+    expect(contrast('#ffffff', lime)).toBeLessThan(2);
+    expect(contrast(primitive('rk-lime-ink'), lime)).toBeGreaterThanOrEqual(
+      4.5,
+    );
+  });
+
+  it('reads as text on the canvas and on a card', () => {
+    for (const base of [primitive('rk-canvas'), SURFACE]) {
+      expect(contrast(primitive('rk-lime'), base)).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+});

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -332,6 +332,22 @@
   --text-badge--font-weight: 600;
   --text-badge--letter-spacing: 0.08em;
 
+  /* Column header · 9.5 / 600 / .14em · mono, uppercase. The heading above a
+     list of issues, releases or logs. Wider tracking than the badge because it
+     is set in caps: at 9.5px, caps without extra tracking read as a smear. */
+  --text-column: 0.59375rem;
+  --text-column--line-height: 1.2;
+  --text-column--font-weight: 600;
+  --text-column--letter-spacing: 0.14em;
+
+  /* Severity tag · 9.5 / 600 / .12em · mono, the FATAL / ERROR / WARNING label.
+     Slightly tighter than a column header so the two do not read as the same
+     kind of thing when they sit in the same row. */
+  --text-tag: 0.59375rem;
+  --text-tag--line-height: 1.2;
+  --text-tag--font-weight: 600;
+  --text-tag--letter-spacing: 0.12em;
+
   /* Code · 12.5 / 400 · paths, versions, technical values */
   --text-code: 0.78125rem;
   --text-code--line-height: 1.45;
@@ -363,6 +379,9 @@
   /* The radius rises with the control's height rather than staying fixed: at */
   /* 30px a 9 looks round, and at 36px an 8 looks hard.                       */
   /* ---------------------------------------------------------------------- */
+  /* The severity marker and the meter track. Below this a corner stops reading
+     as rounded and starts reading as a rendering artefact. */
+  --radius-xs: 2px;
   --radius-sm: 7px;
   --radius-md: 8px;
   --radius-lg: 9px;
@@ -376,6 +395,16 @@
   --spacing-control-sm: 30px;
   --spacing-control-md: 34px;
   --spacing-control-lg: 36px;
+  /* The severity marker: a 8px rounded square, not a circle. The circle means
+     "state" in this design and the square means "level", and they appear in the
+     same row. */
+  --spacing-dot: 8px;
+  /* The separator between two pieces of meta on one line. At 3px it reads as
+     punctuation rather than as a bullet. */
+  --spacing-dot-sm: 3px;
+  /* Meter track. The design uses 4px and 5px; 5px is the one that survives a
+     rounded cap without the fill looking pinched. */
+  --spacing-meter: 5px;
   --spacing-icon-sm: 13px;
   --spacing-icon-md: 14px;
   --spacing-icon-lg: 16px;


### PR DESCRIPTION
Four presentational components, each of which does something a `className`
cannot: Badge composes a box, SeverityDot carries an accessible name, Meter
clamps and announces, Separator picks a role and dodges a flexbox trap. That is
the bar for earning a file here.

New tokens, all from `Rustrak Rediseno v5` rather than invented: `--text-column`
(9.5/600/.14em, the heading above a list) and `--text-tag` (9.5/600/.12em, the
FATAL/ERROR label) are distinguished by tracking so the two do not read as the
same kind of thing in one row; `--radius-xs` at 2px, `--spacing-dot`,
`--spacing-dot-sm` and `--spacing-meter`.

SeverityDot is a rounded square, never a circle. In this design the circle means
*state* and the square means *level*, and both appear in a log row; one shape for
both would force the reader to check the colour twice. It is not `aria-hidden`
for the same reason: without a name every row in a log stream announces
identically.

Meter is `role="meter"`, not `progressbar`. The spec draws the line at whether
something advances towards completion, and quota used is a measurement. Values
arrive from an API, so they are clamped once and everything derives from the
clamped value.

Deliberately no Text component. Since `--text-*` is reset, `text-sm` does not
compile and the scale is already enforced by CSS, so a component wrapping it
would enforce nothing further while adding a second way to say the same thing.

Two real defects, both found by the a11y check rather than by review:

- Meter clamped the bar width but passed the raw value to `aria-valuenow`, so a
  NaN from a zero denominator upstream rendered a correct-looking bar and
  emitted invalid ARIA. Now clamped once, at the source.
- The `debug` badge paired the dimmest foreground with a tint built from the
  same colour: 2.51:1, unreadable. That tone now uses `--fg-tertiary` at 5.94:1
  and is still the quietest of the five.

Contrast moves from axe's blanket rule to `styles/contrast.test.ts`, which reads
the primitives out of `tokens.css`, flattens the translucent severity fills onto
the surface they sit on, and pins the ratios. The blanket rule had to go: two
supporting greys sit below AA on purpose (`--fg-subtle` 4.31, `--fg-ghost` 2.73,
the closed palette of v5, neither ever the sole carrier of meaning), so leaving
it on turned every story that used them red and buried the failures that
mattered. Off without a replacement, nobody would notice a token sliding from
4.6 to 4.1. Now the diff names every pairing that moved.

Testing: 57 tests, up from 22. Unit tests cover the token mirror and the pinned
ratios; every story runs as a component test in a real Chromium and goes through
axe.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>