### PR TITLE
feat(ui): add Tooltip, Menu, Checkbox and the data table

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,6 +36,7 @@
     "@base-ui/react": "1.7.0",
     "@fontsource-variable/onest": "5.3.0",
     "@fontsource/ibm-plex-mono": "5.3.0",
+    "@tanstack/react-table": "9.1.2",
     "clsx": "2.1.1",
     "lucide-react": "1.31.0",
     "tailwind-merge": "3.6.0",

--- a/packages/ui/src/components/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/checkbox/checkbox.tsx
@@ -1,0 +1,61 @@
+import { Checkbox as Base } from '@base-ui/react/checkbox';
+import { cn } from '../../lib/cn';
+import { focusRing } from '../../lib/focus';
+import { interactiveTransition, pressScaleSmall } from '../../lib/motion';
+import { tv } from '../../lib/tv';
+import { PartialIcon, ResolveIcon } from '../icon/icon-catalog';
+
+/**
+ * A box that is on, off, or partly on.
+ *
+ * The third state is the one worth getting right. A header checkbox over
+ * twelve rows with one ticked is not checked and not unchecked, and drawing a
+ * full tick there is a lie about what pressing it will do. Base UI reports it
+ * as `aria-checked="mixed"` and hands out `data-indeterminate`; the box fills
+ * the same way a checked one does and swaps the tick for a dash, so the two
+ * states are told apart by the mark rather than by the fill.
+ *
+ * State is read from the DOM throughout. There is no `isChecked` prop being
+ * threaded into class names, so the visual and the announced state cannot
+ * disagree.
+ */
+const checkbox = tv({
+  base: [
+    'inline-flex size-choice shrink-0 items-center justify-center',
+    'rounded-xs bg-surface-sunken inset-ring inset-ring-border-control',
+    'text-fg-on-brand',
+    interactiveTransition,
+    pressScaleSmall,
+    'hover:inset-ring-border-raised',
+    'data-checked:bg-surface-brand data-checked:inset-ring-surface-brand',
+    'data-indeterminate:bg-surface-brand',
+    'data-indeterminate:inset-ring-surface-brand',
+    'data-disabled:bg-surface-disabled data-disabled:text-fg-disabled',
+    'data-disabled:inset-ring-border data-disabled:pointer-events-none',
+    focusRing,
+  ],
+});
+
+export interface CheckboxProps extends React.ComponentProps<typeof Base.Root> {}
+
+export function Checkbox({ className, ...props }: CheckboxProps) {
+  return (
+    <Base.Root className={cn(checkbox(), className)} {...props}>
+      <Base.Indicator
+        // `keepMounted` is off: the indicator only exists while the box is on
+        // or mixed, so there is no hidden icon to fight over.
+        render={(indicatorProps, state) => (
+          <span {...indicatorProps}>
+            {state.indeterminate ? (
+              <PartialIcon size="sm" />
+            ) : (
+              <ResolveIcon size="sm" />
+            )}
+          </span>
+        )}
+      />
+    </Base.Root>
+  );
+}
+
+Checkbox.displayName = 'Checkbox';

--- a/packages/ui/src/components/icon/icon-catalog.ts
+++ b/packages/ui/src/components/icon/icon-catalog.ts
@@ -1,11 +1,19 @@
 import {
+  BellOff,
   Check,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
   CircleAlert,
+  Ellipsis,
   LoaderCircle,
+  Minus,
   Plus,
   RotateCcw,
   Trash2,
+  UserPlus,
 } from 'lucide-react';
 import { fromLucide } from './adapters/lucide';
 
@@ -30,7 +38,23 @@ export const ResolveIcon = fromLucide(Check);
 export const IssueIcon = fromLucide(CircleAlert);
 /** Create something that did not exist. */
 export const CreateIcon = fromLucide(Plus);
+/** Silence an issue without saying it is fixed. */
+export const IgnoreIcon = fromLucide(BellOff);
+/** Put a person's name on it. */
+export const AssignIcon = fromLucide(UserPlus);
 /** Reopen what had been resolved. */
 export const ReopenIcon = fromLucide(RotateCcw);
 /** Destroy, with no way back. */
 export const DeleteIcon = fromLucide(Trash2);
+/** The actions that did not fit, behind one control. */
+export const OverflowIcon = fromLucide(Ellipsis);
+/** A row that can open to show more about itself. */
+export const DiscloseIcon = fromLucide(ChevronRight);
+/** Some of a set is selected, not all of it. */
+export const PartialIcon = fromLucide(Minus);
+
+/* Paging through a result set. */
+export const PageFirstIcon = fromLucide(ChevronsLeft);
+export const PagePreviousIcon = fromLucide(ChevronLeft);
+export const PageNextIcon = fromLucide(ChevronRight);
+export const PageLastIcon = fromLucide(ChevronsRight);

--- a/packages/ui/src/components/menu/menu.stories.tsx
+++ b/packages/ui/src/components/menu/menu.stories.tsx
@@ -1,0 +1,249 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { Button } from '../button/button';
+import {
+  AssignIcon,
+  DeleteIcon,
+  IgnoreIcon,
+  OverflowIcon,
+  ResolveIcon,
+} from '../icon/icon-catalog';
+import {
+  MenuContent,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuLinkItem,
+  MenuRoot,
+  MenuSeparator,
+  MenuTrigger,
+} from './menu';
+
+const meta = {
+  title: 'Components/Menu',
+  component: MenuRoot,
+  parameters: { controls: { disable: true } },
+} satisfies Meta<typeof MenuRoot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The trigger is left unstyled by the menu, so a `Button` passed through
+ * `render` keeps every one of its own variants.
+ */
+export const Default: Story = {
+  render: () => (
+    <MenuRoot>
+      <MenuTrigger
+        render={
+          <Button variant="ghost" menu>
+            More actions
+          </Button>
+        }
+      />
+      <MenuContent>
+        <MenuItem icon={AssignIcon}>Assign to me</MenuItem>
+        <MenuItem icon={ResolveIcon}>Mark as reviewed</MenuItem>
+        <MenuSeparator />
+        <MenuItem tone="danger" icon={DeleteIcon}>
+          Delete issue
+        </MenuItem>
+      </MenuContent>
+    </MenuRoot>
+  ),
+};
+
+/** Opens, runs the action, and closes itself afterwards. */
+export const RunsAnAction: Story = {
+  render: function Render() {
+    const onSelect = fn();
+    return (
+      <MenuRoot>
+        <MenuTrigger
+          render={
+            <Button variant="ghost" menu>
+              More actions
+            </Button>
+          }
+        />
+        <MenuContent>
+          <MenuItem onClick={onSelect}>Assign to me</MenuItem>
+        </MenuContent>
+      </MenuRoot>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const trigger = within(canvasElement).getByRole('button');
+
+    await userEvent.click(trigger);
+    const item = await waitFor(() =>
+      within(document.body).getByRole('menuitem', { name: 'Assign to me' }),
+    );
+
+    await userEvent.click(item);
+    // Closing on select is Base UI's behaviour and this pins it: a menu that
+    // stays open after an action reads as though nothing happened.
+    await waitFor(() =>
+      expect(
+        within(document.body).queryByRole('menuitem', { name: 'Assign to me' }),
+      ).toBeNull(),
+    );
+  },
+};
+
+/** Keyboard: arrows move, Enter selects, Escape closes and focus comes back. */
+export const Keyboard: Story = {
+  render: () => (
+    <MenuRoot>
+      <MenuTrigger
+        render={
+          <Button variant="ghost" menu>
+            More actions
+          </Button>
+        }
+      />
+      <MenuContent>
+        <MenuItem>Assign to me</MenuItem>
+        <MenuItem>Mark as reviewed</MenuItem>
+      </MenuContent>
+    </MenuRoot>
+  ),
+  play: async ({ canvasElement }) => {
+    const trigger = within(canvasElement).getByRole('button');
+
+    trigger.focus();
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() =>
+      expect(within(document.body).getByRole('menu')).toBeVisible(),
+    );
+
+    const body = within(document.body);
+
+    // Opening with the keyboard lands on the first item already: a menu that
+    // opened with nothing highlighted would need a second keypress before the
+    // arrows did anything, and there would be no visible starting point.
+    await expect(
+      body.getByRole('menuitem', { name: 'Assign to me' }),
+    ).toHaveAttribute('data-highlighted');
+
+    await userEvent.keyboard('{ArrowDown}');
+    await expect(
+      body.getByRole('menuitem', { name: 'Mark as reviewed' }),
+    ).toHaveAttribute('data-highlighted');
+    await expect(
+      body.getByRole('menuitem', { name: 'Assign to me' }),
+    ).not.toHaveAttribute('data-highlighted');
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(within(document.body).queryByRole('menu')).toBeNull(),
+    );
+    // Focus returning to the trigger is what stops the keyboard user being
+    // dropped at the top of the document.
+    await expect(trigger).toHaveFocus();
+  },
+};
+
+/** Items that navigate are real anchors, so middle-click and copy-link work. */
+export const WithLinks: Story = {
+  render: () => (
+    <MenuRoot>
+      <MenuTrigger
+        render={
+          <Button variant="ghost" menu>
+            web@2026.8.1
+          </Button>
+        }
+      />
+      <MenuContent>
+        <MenuGroup>
+          <MenuGroupLabel>Recent releases</MenuGroupLabel>
+          <MenuLinkItem href="#r1">web@2026.8.1</MenuLinkItem>
+          <MenuLinkItem href="#r2">web@2026.8.0</MenuLinkItem>
+        </MenuGroup>
+      </MenuContent>
+    </MenuRoot>
+  ),
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button'));
+
+    const link = await waitFor(() =>
+      within(document.body).getByRole('menuitem', { name: 'web@2026.8.1' }),
+    );
+    // An item with an onClick that calls the router would take these away.
+    await expect(link).toHaveAttribute('href', '#r1');
+  },
+};
+
+/**
+ * The pointer is not decoration: in a flat dark interface it is the signal
+ * separating "this does something" from "this is a label".
+ *
+ * `styles/base.css` grants it to every `[role="menuitem"]` at zero specificity,
+ * which means any `cursor-*` utility on the item silently wins. This shipped
+ * once with `cursor-default` on the recipe and looked completely fine.
+ */
+export const Cursor: Story = {
+  render: () => (
+    <MenuRoot>
+      <MenuTrigger
+        render={
+          <Button variant="ghost" menu>
+            More actions
+          </Button>
+        }
+      />
+      <MenuContent>
+        <MenuItem icon={ResolveIcon}>Resolve</MenuItem>
+        <MenuItem disabled>Already resolved</MenuItem>
+      </MenuContent>
+    </MenuRoot>
+  ),
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button'));
+    const body = within(document.body);
+
+    const item = await waitFor(() =>
+      body.getByRole('menuitem', { name: 'Resolve' }),
+    );
+    await expect(getComputedStyle(item).cursor).toBe('pointer');
+
+    // The two cursor lists in base.css have to stay in step: menuitem was in
+    // the pointer one and missing from the disabled one, so a greyed-out entry
+    // looked inert and felt like plain text.
+    const disabled = body.getByRole('menuitem', { name: 'Already resolved' });
+    await expect(getComputedStyle(disabled).cursor).toBe('not-allowed');
+  },
+};
+
+/** The row overflow, which is where most of these live. */
+export const RowActions: Story = {
+  render: () => (
+    <div className="flex w-full max-w-md items-center gap-3 rounded-lg bg-surface p-3 inset-ring inset-ring-border">
+      <span className="min-w-0 truncate text-body text-fg">
+        TypeError: Cannot read properties of undefined
+      </span>
+      <MenuRoot>
+        <MenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={OverflowIcon}
+              aria-label="Issue actions"
+            />
+          }
+        />
+        <MenuContent align="end">
+          <MenuItem icon={ResolveIcon}>Resolve</MenuItem>
+          <MenuItem icon={IgnoreIcon}>Ignore</MenuItem>
+          <MenuSeparator />
+          <MenuItem tone="danger" icon={DeleteIcon}>
+            Delete
+          </MenuItem>
+        </MenuContent>
+      </MenuRoot>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/menu/menu.tsx
+++ b/packages/ui/src/components/menu/menu.tsx
@@ -1,0 +1,184 @@
+import { Menu as Base } from '@base-ui/react/menu';
+import { cn } from '../../lib/cn';
+import { popTransition } from '../../lib/motion';
+import { tv, type VariantProps } from '../../lib/tv';
+import type { IconComponent } from '../icon/icon';
+
+/**
+ * A list of actions behind a trigger: the row overflow, the project switcher,
+ * the bulk actions on a selection.
+ *
+ * Re-exported as parts rather than wrapped in a single `items={[...]}` prop.
+ * An array API looks tidy until the first separator, the first submenu and the
+ * first item that needs a badge, at which point it grows a `type` discriminator
+ * and becomes a worse version of JSX. Base UI already composes; this only
+ * supplies the styling and keeps the trigger unstyled so any `Button` can be it.
+ *
+ * Keyboard behaviour, focus return, typeahead and the escape/outside-click
+ * contract all come from Base UI and are not re-implemented here.
+ */
+
+const menu = tv({
+  slots: {
+    popup: [
+      'min-w-40 origin-(--transform-origin) rounded-lg p-1',
+      'bg-surface-floating shadow-overlay inset-ring inset-ring-border-subtle',
+      'outline-none',
+    ],
+    item: [
+      // No `cursor-*` here. `styles/base.css` gives every `[role="menuitem"]`
+      // a pointer at zero specificity, and a utility on the element would beat
+      // it. Writing `cursor-default` here was doing exactly that.
+      'flex items-center gap-2 rounded-md px-2 py-1.5',
+      'text-control text-fg-secondary select-none',
+      'transition-[color,background-color] duration-instant ease-standard',
+      // State comes from the DOM, not from props threaded down: Base UI marks
+      // the item the keyboard is on with `data-highlighted`, and hover and
+      // keyboard therefore look identical without any state to keep in sync.
+      'data-highlighted:bg-surface-hover data-highlighted:text-fg',
+      'data-disabled:text-fg-disabled data-disabled:pointer-events-none',
+      'outline-none',
+    ],
+    separator: 'my-1 h-px bg-border',
+    groupLabel: 'px-2 py-1 font-mono text-column uppercase text-fg-muted',
+  },
+  variants: {
+    tone: {
+      default: {},
+      /** Destructive. Reads as danger before it is read as a word. */
+      danger: {
+        item: [
+          'text-fg-error',
+          'data-highlighted:bg-surface-error data-highlighted:text-fg-fatal',
+        ],
+      },
+    },
+  },
+  defaultVariants: { tone: 'default' },
+});
+
+const { popup, item, separator, groupLabel } = menu();
+
+/** Groups the parts. Renders no element of its own. */
+export const MenuRoot = Base.Root;
+
+/**
+ * The control that opens it. Left unstyled on purpose so a `Button` can be
+ * passed through `render` and keep every one of its own variants.
+ */
+export const MenuTrigger = Base.Trigger;
+
+export type MenuItemTone = NonNullable<VariantProps<typeof menu>['tone']>;
+
+export interface MenuContentProps
+  extends React.ComponentProps<typeof Base.Popup> {
+  /** @default 'bottom' */
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  /** @default 'start' */
+  align?: 'start' | 'center' | 'end';
+  sideOffset?: number;
+}
+
+/**
+ * The panel. Bundles Portal, Positioner and Popup because those three are
+ * always used together and getting the order wrong is a silent positioning bug
+ * rather than an error.
+ */
+export function MenuContent({
+  side = 'bottom',
+  align = 'start',
+  sideOffset = 6,
+  className,
+  children,
+  ...props
+}: MenuContentProps) {
+  return (
+    <Base.Portal>
+      <Base.Positioner side={side} align={align} sideOffset={sideOffset}>
+        <Base.Popup
+          className={cn(popup(), popTransition, className)}
+          {...props}
+        >
+          {children}
+        </Base.Popup>
+      </Base.Positioner>
+    </Base.Portal>
+  );
+}
+
+MenuContent.displayName = 'MenuContent';
+
+export interface MenuItemProps extends React.ComponentProps<typeof Base.Item> {
+  tone?: MenuItemTone;
+  /**
+   * Drawn before the label.
+   *
+   * It inherits the item's colour rather than taking one of its own, so a
+   * danger item's icon turns with its text and the highlighted state does not
+   * leave a grey glyph next to red words.
+   */
+  icon?: IconComponent;
+}
+
+export function MenuItem({
+  tone,
+  icon: Icon,
+  className,
+  children,
+  ...props
+}: MenuItemProps) {
+  return (
+    <Base.Item className={cn(menu({ tone }).item(), className)} {...props}>
+      {Icon ? <Icon size="md" /> : null}
+      {children}
+    </Base.Item>
+  );
+}
+
+MenuItem.displayName = 'MenuItem';
+
+/**
+ * An item that navigates. A real anchor, so middle-click, copy-link and
+ * open-in-new-tab all work; an item with an `onClick` that calls the router
+ * takes those away for no gain.
+ */
+export interface MenuLinkItemProps
+  extends React.ComponentProps<typeof Base.LinkItem> {
+  icon?: IconComponent;
+}
+
+export function MenuLinkItem({
+  icon: Icon,
+  className,
+  children,
+  ...props
+}: MenuLinkItemProps) {
+  return (
+    <Base.LinkItem className={cn(item(), className)} {...props}>
+      {Icon ? <Icon size="md" /> : null}
+      {children}
+    </Base.LinkItem>
+  );
+}
+
+MenuLinkItem.displayName = 'MenuLinkItem';
+
+export function MenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Base.Separator>) {
+  return <Base.Separator className={cn(separator(), className)} {...props} />;
+}
+
+MenuSeparator.displayName = 'MenuSeparator';
+
+export const MenuGroup = Base.Group;
+
+export function MenuGroupLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Base.GroupLabel>) {
+  return <Base.GroupLabel className={cn(groupLabel(), className)} {...props} />;
+}
+
+MenuGroupLabel.displayName = 'MenuGroupLabel';

--- a/packages/ui/src/components/table/columns.tsx
+++ b/packages/ui/src/components/table/columns.tsx
@@ -1,0 +1,139 @@
+import type { Row, RowData } from '@tanstack/react-table';
+import type { ReactNode } from 'react';
+import { cn } from '../../lib/cn';
+import { Button } from '../button/button';
+import { Checkbox } from '../checkbox/checkbox';
+import { DiscloseIcon } from '../icon/icon-catalog';
+import type { DataTableFeatures } from './features';
+import { StopPropagation } from './stop-propagation';
+import { createAppColumnHelper } from './use-app-table';
+
+/**
+ * The tick column, for tables with batch actions.
+ *
+ * Fixed, unresizable and unhideable, because none of those are meaningful for
+ * a 44px control, and provided here rather than written per table so that the
+ * select-all semantics stay one decision. "All" means the rows on this page:
+ * the table only ever holds one page, and a select-all reaching rows that were
+ * never fetched is a claim it cannot honour.
+ */
+export function selectionColumn<TData extends RowData>() {
+  const helper = createAppColumnHelper<TData>();
+  return helper.display({
+    id: 'select',
+    size: 44,
+    minSize: 44,
+    maxSize: 44,
+    header: ({ table }) => (
+      <StopPropagation>
+        <Checkbox
+          aria-label="Select all rows on this page"
+          checked={table.getIsAllPageRowsSelected()}
+          indeterminate={
+            table.getIsSomePageRowsSelected() &&
+            !table.getIsAllPageRowsSelected()
+          }
+          onCheckedChange={(checked) =>
+            table.toggleAllPageRowsSelected(checked === true)
+          }
+        />
+      </StopPropagation>
+    ),
+    cell: ({ row }) => (
+      // Without this, ticking a row in a table whose rows expand or navigate
+      // would do both.
+      <StopPropagation>
+        <Checkbox
+          aria-label="Select row"
+          checked={row.getIsSelected()}
+          disabled={!row.getCanSelect()}
+          onCheckedChange={(checked) => row.toggleSelected(checked === true)}
+        />
+      </StopPropagation>
+    ),
+  });
+}
+
+/**
+ * The disclosure control, for tables whose rows open a detail panel.
+ *
+ * A real button, and it has to be. The first version of this made the whole row
+ * the control and put `aria-expanded` on the `<tr>`, which reads well and is
+ * invalid: that attribute is only defined for rows inside a `treegrid`, and
+ * claiming `treegrid` would promise a cell-by-cell arrow-key model this table
+ * does not implement. axe rejects it, correctly.
+ *
+ * So the button carries the disclosure and is the row's tab stop. Clicking
+ * anywhere in the row still toggles it for pointer users, through the shell's
+ * `onRowClick`; that path just no longer pretends to be an ARIA widget.
+ */
+export function expandColumn<TData extends RowData>() {
+  const helper = createAppColumnHelper<TData>();
+  return helper.display({
+    id: 'expand',
+    size: 36,
+    minSize: 36,
+    maxSize: 36,
+    header: () => <span className="sr-only">Expand</span>,
+    cell: ({ row }) => (
+      // Stops the row's own click handler from firing as well, which would
+      // toggle twice and land back where it started.
+      <StopPropagation>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label={row.getIsExpanded() ? 'Hide details' : 'Show details'}
+          aria-expanded={row.getIsExpanded()}
+          onClick={() => row.toggleExpanded()}
+          icon={({ className, ...props }) => (
+            <DiscloseIcon
+              {...props}
+              className={cn(
+                'transition-transform duration-fast ease-standard',
+                row.getIsExpanded() && 'rotate-90',
+                className,
+              )}
+            />
+          )}
+        />
+      </StopPropagation>
+    ),
+  });
+}
+
+/**
+ * The trailing actions column: one control per row, opening a menu.
+ *
+ * Provided rather than written per table for the same reason as the other two:
+ * the shape is identical every time and only the contents differ, so leaving it
+ * to each table means five tables with four different widths.
+ *
+ * What it fixes in place:
+ *
+ * - a width that does not grow and does not hide, because the actions are the
+ *   one thing that must stay reachable when a row is squeezed;
+ * - a header that exists for a screen reader and is invisible otherwise: a
+ *   visible title over a column of identical buttons says nothing;
+ * - `StopPropagation`, so opening the menu inside a clickable row does not also
+ *   activate the row.
+ *
+ * The menu itself is portalled by Base UI, so it escapes the table's own scroll
+ * container instead of being clipped by it.
+ */
+export function actionsColumn<TData extends RowData>(
+  render: (row: Row<DataTableFeatures, TData>) => ReactNode,
+) {
+  const helper = createAppColumnHelper<TData>();
+  return helper.display({
+    id: 'actions',
+    size: 52,
+    minSize: 52,
+    maxSize: 52,
+    header: () => <span className="sr-only">Actions</span>,
+    cell: ({ row }) => (
+      <StopPropagation>
+        <div className="flex justify-end">{render(row)}</div>
+      </StopPropagation>
+    ),
+  });
+}

--- a/packages/ui/src/components/table/data-table.stories.tsx
+++ b/packages/ui/src/components/table/data-table.stories.tsx
@@ -1,0 +1,447 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { Badge } from '../badge/badge';
+import { Button } from '../button/button';
+import {
+  AssignIcon,
+  DeleteIcon,
+  IgnoreIcon,
+  OverflowIcon,
+  ResolveIcon,
+} from '../icon/icon-catalog';
+import {
+  MenuContent,
+  MenuItem,
+  MenuRoot,
+  MenuSeparator,
+  MenuTrigger,
+} from '../menu/menu';
+import { SeverityDot } from '../severity/severity-dot';
+import { actionsColumn, expandColumn, selectionColumn } from './columns';
+import { DataTable } from './data-table';
+import { DataTablePagination } from './pagination';
+import { createAppColumnHelper, useAppTable } from './use-app-table';
+
+interface Issue {
+  id: string;
+  title: string;
+  culprit: string;
+  level: 'fatal' | 'error' | 'warning' | 'info' | 'debug';
+  events: number;
+  release: string;
+}
+
+const ISSUES: Issue[] = [
+  {
+    id: 'CHECKOUT-API-4F2',
+    title: "TypeError: Cannot read properties of undefined (reading 'total')",
+    culprit: 'src/checkout/summary.tsx · renderTotals',
+    level: 'error',
+    events: 12431,
+    release: 'web@2026.8.1',
+  },
+  {
+    id: 'CHECKOUT-API-3B1',
+    title: 'ConnectionTimeout: pool exhausted after 30000ms',
+    culprit: 'db/pool.rs · acquire',
+    level: 'fatal',
+    events: 3902,
+    release: 'api@2026.8.0',
+  },
+  {
+    id: 'CHECKOUT-API-2C8',
+    title: 'ValidationError: coupon code not applicable',
+    culprit: 'src/promo/apply.ts · applyCoupon',
+    level: 'warning',
+    events: 1204,
+    release: 'web@2026.8.1',
+  },
+];
+
+const helper = createAppColumnHelper<Issue>();
+
+// `helper.columns()` rather than a bare array: mixing a display column (typed
+// `unknown`) with accessor columns (typed by their field) in one literal makes
+// TypeScript infer an element type neither of them satisfies. This is the
+// wrapper v9 provides for exactly that.
+const columns = helper.columns([
+  helper.accessor('level', {
+    id: 'level',
+    header: 'Lvl',
+    size: 56,
+    cell: ({ getValue }) => <SeverityDot level={getValue()} />,
+  }),
+  helper.accessor('title', {
+    id: 'issue',
+    header: 'Issue',
+    // Exactly one growing column per table: it absorbs whatever the fixed
+    // columns leave over, and its `minSize` is what decides when the container
+    // starts scrolling instead.
+    meta: { grow: true },
+    minSize: 220,
+    cell: ({ row }) => (
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="truncate text-body text-fg">{row.original.title}</span>
+        <span className="truncate font-mono text-code text-fg-muted">
+          {row.original.culprit}
+        </span>
+      </div>
+    ),
+  }),
+  helper.accessor('release', {
+    id: 'release',
+    header: 'Release',
+    size: 150,
+    // Dropped on a narrow viewport. In CSS, so it resolves before the first
+    // paint; `useVisibleTiers` reads the same breakpoint for the arithmetic.
+    meta: { hideBelow: 'lg' },
+    cell: ({ getValue }) => <Badge>{getValue()}</Badge>,
+  }),
+  helper.accessor('events', {
+    id: 'events',
+    header: 'Events',
+    size: 100,
+    meta: { align: 'end', hideBelow: 'sm' },
+    cell: ({ getValue }) => (
+      <span
+        className="tabular-nums text-meta text-fg-secondary"
+        data-numeric=""
+      >
+        {getValue().toLocaleString('en-GB')}
+      </span>
+    ),
+  }),
+]);
+
+function IssuesTable({
+  withSelection = false,
+  withDetail = false,
+  withBulk = false,
+  withActions = false,
+}: {
+  /**
+   * The tick column. Off by default, because most tables are lists you read
+   * rather than sets you act on, and a column of checkboxes on one of those is
+   * 44px of nothing plus a select-all that means nothing.
+   */
+  withSelection?: boolean;
+  withDetail?: boolean;
+  withBulk?: boolean;
+  /** The trailing overflow menu, which is how most rows end. */
+  withActions?: boolean;
+}) {
+  const [rowSelection, setRowSelection] = useState({});
+  const [expanded, setExpanded] = useState({});
+
+  const table = useAppTable({
+    data: ISSUES,
+    columns: helper.columns([
+      ...(withDetail ? [expandColumn<Issue>()] : []),
+      ...(withSelection ? [selectionColumn<Issue>()] : []),
+      ...columns,
+      ...(withActions
+        ? [actionsColumn<Issue>((row) => <RowActions issue={row.original} />)]
+        : []),
+    ]),
+    state: { rowSelection, expanded },
+    onRowSelectionChange: setRowSelection,
+    onExpandedChange: setExpanded,
+    rowCount: ISSUES.length,
+  });
+
+  return (
+    <DataTable
+      table={table}
+      stickyHeader
+      bulkActions={
+        withBulk ? (
+          <>
+            <Button variant="ghost" size="sm" icon={ResolveIcon}>
+              Resolve
+            </Button>
+            <Button variant="ghost" size="sm" icon={DeleteIcon}>
+              Delete
+            </Button>
+          </>
+        ) : undefined
+      }
+      renderDetail={
+        withDetail
+          ? (row) => (
+              <div className="px-4 py-3 text-meta text-fg-secondary">
+                Last seen 3 minutes ago in {row.original.release}.
+              </div>
+            )
+          : undefined
+      }
+      onRowClick={withDetail ? (row) => row.toggleExpanded() : undefined}
+    />
+  );
+}
+
+/**
+ * The meta points at the harness rather than at `DataTable` itself: the shell
+ * takes a built table instance as a required prop, so typing stories against it
+ * would force every one of them to construct a table in `args` as well as in
+ * `render`. Every prop here is optional, so the stories stay declarative.
+ */
+/**
+ * The overflow that ends most rows. Base UI portals the popup, so it is not
+ * clipped by the table's own scroll container.
+ */
+function RowActions({ issue }: { issue: Issue }) {
+  return (
+    <MenuRoot>
+      <MenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={OverflowIcon}
+            aria-label={`Actions for ${issue.id}`}
+          />
+        }
+      />
+      <MenuContent align="end">
+        <MenuItem icon={ResolveIcon}>Resolve</MenuItem>
+        <MenuItem icon={IgnoreIcon}>Ignore</MenuItem>
+        <MenuItem icon={AssignIcon}>Assign to me</MenuItem>
+        <MenuSeparator />
+        <MenuItem tone="danger" icon={DeleteIcon}>
+          Delete issue
+        </MenuItem>
+      </MenuContent>
+    </MenuRoot>
+  );
+}
+
+const meta = {
+  title: 'Components/DataTable',
+  component: IssuesTable,
+  parameters: { layout: 'padded', controls: { disable: true } },
+} satisfies Meta<typeof IssuesTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <IssuesTable withActions />,
+};
+
+/**
+ * The trailing overflow, which is how most rows end.
+ *
+ * The column is `actionsColumn`, so its width, its screen-reader-only header
+ * and its `StopPropagation` are one decision rather than five tables' worth of
+ * slightly different ones. Opening the menu inside a clickable row must not
+ * also activate the row, and the popup must not be clipped by the table's
+ * scroll box; both are pinned below.
+ */
+export const RowActionsMenu: Story = {
+  render: () => <IssuesTable withActions withDetail />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+
+    const trigger = canvas.getByRole('button', {
+      name: 'Actions for CHECKOUT-API-4F2',
+    });
+
+    await userEvent.click(trigger);
+    // Portalled, so it lands outside the canvas and one frame later.
+    await waitFor(() =>
+      expect(
+        body.getByRole('menuitem', { name: 'Delete issue' }),
+      ).toBeVisible(),
+    );
+
+    // The row also expands on click. If the trigger's event reached the row,
+    // opening the menu would have opened the detail panel too.
+    await expect(canvas.queryByText(/Last seen 3 minutes ago/)).toBeNull();
+
+    // Portalled out of the table, so the scroll container cannot clip it.
+    const menu = body.getByRole('menu');
+    await expect(canvas.queryByRole('menu')).toBeNull();
+    await expect(menu).toBeVisible();
+  },
+};
+
+/**
+ * One growing column takes the leftover width; the rest keep their pixel size.
+ * The widths are computed in `sizing.ts` rather than left to the browser, which
+ * under `table-fixed` would redistribute surplus across every column at once.
+ */
+export const Widths: Story = {
+  render: () => <IssuesTable />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const table = canvas.getByRole('table');
+
+    // Every column ends up with an explicit number, so the browser has no
+    // distribution left to do.
+    const style = table.getAttribute('style') ?? '';
+    await expect(style).toContain('--col-issue-size');
+    await expect(style).toContain('--col-events-size');
+  },
+};
+
+/**
+ * Most tables are lists you read, not sets you act on. Selection is opt-in, so
+ * a table that has nothing to do in bulk does not carry a column of checkboxes
+ * and a select-all that means nothing.
+ */
+export const WithoutSelection: Story = {
+  render: () => <IssuesTable withActions />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.queryByRole('checkbox')).toBeNull();
+    // The actions are still there: the two are unrelated decisions.
+    await expect(
+      canvas.getByRole('button', { name: 'Actions for CHECKOUT-API-4F2' }),
+    ).toBeVisible();
+  },
+};
+
+/**
+ * Selecting rows swaps the column titles for the bulk actions in place, rather
+ * than opening a bar above the table that would push everything down.
+ */
+export const BulkActions: Story = {
+  render: () => <IssuesTable withSelection withBulk />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const [firstRowBox] = canvas.getAllByRole('checkbox', {
+      name: 'Select row',
+    });
+    await userEvent.click(firstRowBox as HTMLElement);
+
+    // The select-all box survives the swap: the action bar starts to its right
+    // precisely so that ticking more rows stays possible.
+    await expect(
+      canvas.getByRole('checkbox', { name: 'Select all rows on this page' }),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole('button', { name: 'Resolve' }),
+    ).toBeInTheDocument();
+  },
+};
+
+/**
+ * The header box goes to `mixed` when only part of the page is selected. A
+ * full tick there would be a claim about what pressing it does.
+ */
+export const PartialSelection: Story = {
+  render: () => <IssuesTable withSelection withBulk />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const [firstRowBox] = canvas.getAllByRole('checkbox', {
+      name: 'Select row',
+    });
+
+    await userEvent.click(firstRowBox as HTMLElement);
+    await expect(
+      canvas.getByRole('checkbox', { name: 'Select all rows on this page' }),
+    ).toHaveAttribute('aria-checked', 'mixed');
+  },
+};
+
+/**
+ * The disclosure lives on a real button, not on the `<tr>`.
+ *
+ * `aria-expanded` on a row is only defined inside a `treegrid`, and claiming
+ * that role would promise a cell-by-cell arrow-key model this table does not
+ * implement. The button is the row's one tab stop; clicking the row still
+ * toggles it for pointer users.
+ */
+export const ExpandableRows: Story = {
+  render: () => <IssuesTable withDetail />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const toggle = canvas.getAllByRole('button', {
+      name: 'Show details',
+    })[0] as HTMLElement;
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    toggle.focus();
+    await userEvent.keyboard('{Enter}');
+
+    await expect(
+      canvas.getAllByRole('button', { name: 'Hide details' })[0],
+    ).toHaveAttribute('aria-expanded', 'true');
+    await expect(canvas.getByText(/Last seen 3 minutes ago/)).toBeVisible();
+  },
+};
+
+/** The header stays put and the table keeps its shape while a page loads. */
+export const Pending: Story = {
+  render: function Render() {
+    const table = useAppTable({
+      data: ISSUES,
+      columns,
+      rowCount: ISSUES.length,
+    });
+    return <DataTable table={table} isPending />;
+  },
+};
+
+/**
+ * The table stays when there is nothing in it. Its header is what says what was
+ * being looked for and what a filter is hiding, which is when that is most
+ * useful.
+ */
+export const Empty: Story = {
+  render: function Render() {
+    const table = useAppTable({ data: [], columns, rowCount: 0 });
+    return (
+      <DataTable
+        table={table}
+        empty={
+          <p className="p-8 text-center text-body text-fg-muted">
+            No unresolved issues.
+          </p>
+        }
+      />
+    );
+  },
+};
+
+/** Paging renders nothing at all when there is only one page. */
+export const WithPagination: Story = {
+  render: function Render() {
+    const [pagination, setPagination] = useState({
+      pageIndex: 0,
+      pageSize: 3,
+    });
+    const table = useAppTable({
+      data: ISSUES,
+      columns,
+      state: { pagination },
+      onPaginationChange: setPagination,
+      rowCount: 42,
+    });
+
+    return (
+      <div className="flex flex-col">
+        <DataTable table={table} />
+        <DataTablePagination table={table} />
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText(/of 42/)).toBeVisible();
+    await expect(
+      canvas.getByRole('button', { name: 'First page' }),
+    ).toBeDisabled();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Next page' }));
+    await expect(
+      canvas.getByRole('button', { name: 'Previous page' }),
+    ).toBeEnabled();
+  },
+};

--- a/packages/ui/src/components/table/data-table.tsx
+++ b/packages/ui/src/components/table/data-table.tsx
@@ -1,0 +1,356 @@
+import type { Row, RowData } from '@tanstack/react-table';
+import { Fragment, type ReactNode, useRef } from 'react';
+import { cn } from '../../lib/cn';
+import type { DataTableFeatures } from './features';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './primitives';
+import { HIDE_BELOW_CLASS, useColumnLayout, useVisibleTiers } from './sizing';
+import type { DataTableInstance } from './use-app-table';
+
+/**
+ * Column ids reach CSS as custom property names, and a custom property name
+ * cannot hold whatever a column id happens to hold.
+ */
+const cssSafe = (id: string) => id.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+/** Where a column reads its width. See `useColumnLayout` for what sets it. */
+const widthOf = (columnId: string) => `var(--col-${cssSafe(columnId)}-size)`;
+
+/** One duration for both halves of the header swap, so they read as one move. */
+const SWAP = 'transition-[transform,opacity] duration-slow ease-standard';
+
+const DENSITY = {
+  compact: { head: 'h-8', cell: 'py-1.5' },
+  normal: { head: 'h-10', cell: 'py-2.5' },
+} as const;
+
+export interface DataTableProps<TData extends RowData> {
+  table: DataTableInstance<TData>;
+  /** Row height. `compact` is for high-volume lists: logs, spans, events. */
+  density?: keyof typeof DENSITY;
+  /**
+   * Pins the header while the body scrolls. Requires the table to be inside a
+   * height-bounded container, which is the shell's own scroll box.
+   */
+  stickyHeader?: boolean;
+  /**
+   * A navigation or mutation is in flight. Dims the body and blocks pointer
+   * input without unmounting it, so the page does not collapse to a spinner
+   * and back on every page change.
+   */
+  isPending?: boolean;
+  /**
+   * Shown under the header when there are no rows.
+   *
+   * The table stays: its header is what tells a reader what they were looking
+   * for and what a filter is currently hiding, and swapping the whole thing
+   * for a message takes that away at the moment it is most useful.
+   */
+  empty?: ReactNode;
+  /**
+   * What to offer once rows are ticked.
+   *
+   * Rendered **inside the header row**, not above the table: the column titles
+   * slide down out of the way and these drop in from above to take their
+   * place. A bar that appeared above the table instead would push everything
+   * below it down by its own height the moment a checkbox was clicked.
+   */
+  bulkActions?: ReactNode;
+  /**
+   * An extra row rendered under an expanded row, spanning the full width.
+   *
+   * This is markup, not data: the table has no sub-rows, so expanding is a
+   * disclosure of detail about the row the user already has.
+   */
+  renderDetail?: (row: Row<DataTableFeatures, TData>) => ReactNode;
+  /** Makes the whole row activate. Leave unset when only part of it should. */
+  onRowClick?: (row: Row<DataTableFeatures, TData>) => void;
+  /**
+   * A class for one row, from what the row is.
+   *
+   * For state the columns cannot express on their own: a disabled rule that
+   * should read as dimmed, a row mid-deletion. Not a styling hook for things a
+   * cell could say itself.
+   */
+  getRowClassName?: (row: Row<DataTableFeatures, TData>) => string | undefined;
+  className?: string;
+}
+
+/**
+ * The table shell every Rustrak list renders through.
+ *
+ * ## How width works
+ *
+ * One model, no modes. A column either has a fixed `size` in pixels or is
+ * marked `meta.grow` and takes what is left over. Every resulting width is a
+ * number computed in `useColumnLayout` and handed to the browser, which is
+ * left with no distribution of its own to do -- see that file for why letting
+ * it try does not survive a resize.
+ *
+ * The table is exactly as wide as its columns add up to. When that exceeds the
+ * container the container scrolls horizontally, which is what `minSize` on the
+ * growing column ultimately decides. Same contract as AG Grid's and MUI
+ * DataGrid's `flex` plus `minWidth`.
+ */
+export function DataTable<TData extends RowData>({
+  table,
+  density = 'normal',
+  stickyHeader = false,
+  isPending = false,
+  empty,
+  bulkActions,
+  renderDetail,
+  onRowClick,
+  getRowClassName,
+  className,
+}: DataTableProps<TData>) {
+  const container = useRef<HTMLDivElement>(null);
+  const visibleTiers = useVisibleTiers();
+  const { widths, totalWidth, fillerWidth } = useColumnLayout(
+    table,
+    container,
+    visibleTiers,
+  );
+  const rows = table.getRowModel().rows;
+  const spacing = DENSITY[density];
+  const showBulk =
+    Boolean(bulkActions) && table.getSelectedRowModel().rows.length > 0;
+
+  /**
+   * Widths reach the cells as custom properties on the `<table>` rather than
+   * as an inline width on every cell, so a resize drag rewrites one attribute
+   * instead of one per cell and the cells' own style strings never change.
+   */
+  const widthVars: Record<string, string> = {};
+  for (const [columnId, width] of widths) {
+    widthVars[`--col-${cssSafe(columnId)}-size`] = `${width}px`;
+  }
+
+  return (
+    <div
+      ref={container}
+      className={cn(
+        // This element is the scroll box, and it has to be: a sticky header is
+        // sticky inside whatever scrolls, so a second wrapper anywhere in
+        // between would silently detach the two. `primitives.tsx` deliberately
+        // brings no wrapper of its own.
+        'relative min-h-0 overflow-auto rounded-lg',
+        'bg-surface inset-ring inset-ring-border',
+        isPending && 'pointer-events-none',
+        className,
+      )}
+    >
+      <Table
+        style={{
+          ...widthVars,
+          width: totalWidth ? totalWidth + fillerWidth : undefined,
+        }}
+        className={cn(
+          'table-fixed',
+          isPending && 'opacity-60 transition-opacity',
+        )}
+      >
+        <TableHeader
+          className={cn(
+            stickyHeader && 'sticky top-0 z-10',
+            // Opaque, or the rows scroll through it.
+            'bg-surface',
+          )}
+        >
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow
+              key={headerGroup.id}
+              className="bg-surface-subtle hover:bg-surface-subtle"
+            >
+              {headerGroup.headers.map((header, index) => {
+                const meta = header.column.columnDef.meta;
+                // The tick column keeps its head while the rest slide away:
+                // the bar starts to its right precisely so select-all survives
+                // the swap, and a checkbox that left with the titles would
+                // undo that.
+                const keepsTitle = Boolean(bulkActions) && index === 0;
+                return (
+                  <TableHead
+                    key={header.id}
+                    style={{ width: widthOf(header.column.id) }}
+                    className={cn(
+                      'relative select-none',
+                      spacing.head,
+                      meta?.hideBelow && HIDE_BELOW_CLASS[meta.hideBelow],
+                      meta?.className,
+                      meta?.headerClassName,
+                    )}
+                  >
+                    {/* The clip lives on a wrapper rather than on the cell so
+                        the title can slide out of sight while the resize
+                        handle, which straddles the cell's edge, does not get
+                        cut in half by the same rule. */}
+                    {header.isPlaceholder ? null : (
+                      <div className="overflow-hidden">
+                        <span
+                          className={cn(
+                            'block truncate',
+                            SWAP,
+                            meta?.align === 'end' && 'text-right',
+                            showBulk &&
+                              !keepsTitle &&
+                              'translate-y-full opacity-0',
+                          )}
+                        >
+                          <table.FlexRender header={header} />
+                        </span>
+                      </div>
+                    )}
+
+                    {/* Anchored to the first cell and widened across the rest
+                        of the table, so it covers the header row without
+                        needing a row of its own -- a second row would be what
+                        decides the column widths under `table-fixed`.
+                        Sliding it up hides it: the scroll container's own edge
+                        clips it.
+
+                        It starts *after* the first column, which is the tick
+                        column on every table that has batch actions. Covering
+                        that too would take away select-all at exactly the
+                        moment someone is selecting. */}
+                    {index === 0 && bulkActions && (
+                      <div
+                        aria-hidden={!showBulk}
+                        // `pointer-events-none` would stop the pointer and
+                        // leave the buttons in the tab order, which is a
+                        // focusable control inside an `aria-hidden` subtree.
+                        // `inert` takes both away at once.
+                        inert={!showBulk}
+                        style={{
+                          left: widths.get(header.column.id) ?? 0,
+                          width:
+                            totalWidth +
+                            fillerWidth -
+                            (widths.get(header.column.id) ?? 0),
+                        }}
+                        className={cn(
+                          // Above the column dividers, which are `z-20`: while
+                          // the header is an action bar it is not a set of
+                          // columns, and boundaries showing through it read as
+                          // stray marks.
+                          'absolute inset-y-0 z-30',
+                          // The header row is `bg-surface-subtle` over the
+                          // header's own `bg-surface`. Repeating both, in that
+                          // order, is what keeps the swap from also being a
+                          // change of colour: only the contents move.
+                          'bg-surface',
+                          SWAP,
+                          showBulk
+                            ? 'translate-y-0 opacity-100'
+                            : '-translate-y-full opacity-0',
+                        )}
+                      >
+                        <div className="flex h-full items-center gap-2 bg-surface-subtle pr-3 text-fg">
+                          {bulkActions}
+                        </div>
+                      </div>
+                    )}
+                  </TableHead>
+                );
+              })}
+              {/* A `td`, not a `th`: this cell exists only so the rows reach
+                  the container's border, and it heads no column. Left without
+                  a role, because marking a cell presentational is what both
+                  linters here flag, and an empty trailing cell reads as what
+                  it is. */}
+              {fillerWidth > 0 && <td style={{ width: fillerWidth }} />}
+            </TableRow>
+          ))}
+        </TableHeader>
+
+        <TableBody>
+          {rows.map((row) => {
+            const isExpanded = row.getIsExpanded();
+            const detail = isExpanded ? renderDetail?.(row) : null;
+
+            return (
+              <Fragment key={row.id}>
+                <TableRow
+                  data-state={row.getIsSelected() ? 'selected' : undefined}
+                  onClick={onRowClick ? () => onRowClick(row) : undefined}
+                  // A tab stop only when the row is the sole way in. A table
+                  // with `renderDetail` puts a real button in `expandColumn`
+                  // that already carries the disclosure and its own tab stop;
+                  // a second one here would be two stops per row doing the same
+                  // thing. The row click stays either way, for the pointer.
+                  tabIndex={onRowClick && !renderDetail ? 0 : undefined}
+                  onKeyDown={
+                    onRowClick && !renderDetail
+                      ? (event) => {
+                          if (event.key !== 'Enter' && event.key !== ' ')
+                            return;
+                          // A key pressed inside a cell's own control -- a
+                          // checkbox, a link -- belongs to that control.
+                          if (event.target !== event.currentTarget) return;
+                          // Or Space scrolls the page out from under the row it
+                          // just expanded.
+                          event.preventDefault();
+                          onRowClick(row);
+                        }
+                      : undefined
+                  }
+                  className={cn(
+                    onRowClick &&
+                      'cursor-pointer outline-none focus-visible:inset-ring-2 focus-visible:inset-ring-ring',
+                    isExpanded && 'bg-surface-subtle hover:bg-surface-subtle',
+                    getRowClassName?.(row),
+                  )}
+                >
+                  {row.getAllCells().map((cell) => {
+                    const meta = cell.column.columnDef.meta;
+                    return (
+                      <TableCell
+                        key={cell.id}
+                        style={{ width: widthOf(cell.column.id) }}
+                        className={cn(
+                          // `max-w-0` is what lets `truncate` inside a cell
+                          // measure against the column instead of the content,
+                          // which is the difference between a growing column
+                          // that ellipsises and one that forces a scrollbar.
+                          'max-w-0',
+                          spacing.cell,
+                          meta?.align === 'end' && 'text-right',
+                          meta?.hideBelow && HIDE_BELOW_CLASS[meta.hideBelow],
+                          meta?.className,
+                        )}
+                      >
+                        <table.FlexRender cell={cell} />
+                      </TableCell>
+                    );
+                  })}
+                  {fillerWidth > 0 && <td />}
+                </TableRow>
+
+                {detail && (
+                  <TableRow className="hover:bg-transparent">
+                    <TableCell
+                      colSpan={
+                        row.getAllCells().length + (fillerWidth > 0 ? 1 : 0)
+                      }
+                      className="bg-surface-sunken p-0"
+                    >
+                      {detail}
+                    </TableCell>
+                  </TableRow>
+                )}
+              </Fragment>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      {rows.length === 0 && empty}
+    </div>
+  );
+}

--- a/packages/ui/src/components/table/features.ts
+++ b/packages/ui/src/components/table/features.ts
@@ -1,0 +1,77 @@
+import {
+  columnSizingFeature,
+  rowExpandingFeature,
+  rowPaginationFeature,
+  rowSelectionFeature,
+  tableFeatures,
+} from '@tanstack/react-table';
+
+/**
+ * What a column tells the shell beyond its width.
+ *
+ * Registered on the feature set rather than by declaration-merging the global
+ * `ColumnMeta` interface: v9 resolves `columnMeta` from the features object
+ * first, which keeps the type scoped to tables built with `useAppTable`
+ * instead of every TanStack table anyone ever adds to the app.
+ */
+export interface DataTableColumnMeta {
+  /**
+   * Absorbs the width left over once the fixed columns have taken theirs.
+   *
+   * At most one column per table should set it.
+   *
+   * (Once `columnResizingFeature` is registered, dragging this column's handle
+   * will stop the flag applying: an explicit entry in `columnSizing` wins over
+   * `columnDef.size` inside `column.getSize()`, and the shell reads the same
+   * state. That is the behaviour AG Grid and MUI DataGrid both settled on.
+   * There is no handle to drag today.)
+   */
+  grow?: boolean;
+  /** Aligns header and cells together, so the two cannot disagree. */
+  align?: 'start' | 'end';
+  /**
+   * Drops the column below this breakpoint.
+   *
+   * Done in CSS rather than through `columnVisibility`. The original reason was
+   * that measuring the viewport renders one set of columns on the server and
+   * another after hydration; this app has no server render, so that particular
+   * hazard is gone. The conclusion survives it: CSS resolves before the first
+   * paint, so a narrow viewport never shows the wide layout for a frame, and
+   * nothing has to re-render on a resize.
+   *
+   * The shell feeds the same breakpoint into its width arithmetic, so the two
+   * cannot disagree.
+   */
+  hideBelow?: 'sm' | 'md' | 'lg' | 'xl';
+  /** Applied to both `<th>` and `<td>`, for anything the shell does not cover. */
+  className?: string;
+  /** Applied to the `<th>` only, for the rare header-specific override. */
+  headerClassName?: string;
+}
+
+/**
+ * The features every Rustrak table gets, and no others.
+ *
+ * v9 made features opt-in and tree-shakable, so this list is a bundle
+ * decision, not just a config one. Nothing is registered speculatively:
+ * sorting, filtering, resizing, pinning and grouping are all absent because
+ * no table asks for them, and adding one later is a one-line change.
+ *
+ * `columnSizingFeature` stays without `columnResizingFeature`: it is what
+ * gives a column `size`, `minSize` and `getSize()`, which the layout needs to
+ * decide widths. Only the drag is gone.
+ *
+ * No row models are registered. Every table here renders exactly the page the
+ * server returned; the client never derives rows. `rowExpandingFeature` is
+ * included for its state and toggles only, since the shell's detail panel is
+ * an extra row of markup rather than a sub-row of data.
+ */
+export const dataTableFeatures = tableFeatures({
+  rowPaginationFeature,
+  rowSelectionFeature,
+  rowExpandingFeature,
+  columnSizingFeature,
+  columnMeta: {} as DataTableColumnMeta,
+});
+
+export type DataTableFeatures = typeof dataTableFeatures;

--- a/packages/ui/src/components/table/pagination.tsx
+++ b/packages/ui/src/components/table/pagination.tsx
@@ -1,0 +1,96 @@
+import type { RowData } from '@tanstack/react-table';
+import { Button } from '../button/button';
+import {
+  PageFirstIcon,
+  PageLastIcon,
+  PageNextIcon,
+  PagePreviousIcon,
+} from '../icon/icon-catalog';
+import type { DataTableInstance } from './use-app-table';
+
+/**
+ * The footer of a paginated table: what is on screen, and the way to the rest.
+ *
+ * Reads the table rather than taking counts, so the range and the controls
+ * cannot disagree with the rows above them. Every table here is
+ * `manualPagination`, so `getPageCount()` is derived from the `rowCount` the
+ * server reported.
+ *
+ * Renders nothing when there is nothing to page through. A single page of
+ * results does not need "Page 1 of 1" and two dead arrows under it.
+ */
+export function DataTablePagination<TData extends RowData>({
+  table,
+  disabled = false,
+}: {
+  table: DataTableInstance<TData>;
+  disabled?: boolean;
+}) {
+  const { pageIndex, pageSize } = table.state.pagination;
+  const pageCount = table.getPageCount();
+  const rowCount = table.getRowCount();
+
+  if (pageCount <= 1) return null;
+
+  const first = pageIndex * pageSize + 1;
+  const last = Math.min((pageIndex + 1) * pageSize, rowCount);
+
+  return (
+    <div className="flex shrink-0 flex-col items-center justify-between gap-2 pt-3 sm:flex-row">
+      {/* No empty case to handle: `pageCount <= 1` returned above, and under
+          `manualPagination` no rows means no pages. An empty list says so
+          through the shell's `empty` slot, where the message can be about what
+          was being looked for. */}
+      <p className="text-meta text-fg-tertiary tabular-nums" data-numeric="">
+        <span className="text-fg">
+          {first.toLocaleString()}-{last.toLocaleString()}
+        </span>{' '}
+        of {rowCount.toLocaleString()}
+      </p>
+
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={PageFirstIcon}
+          aria-label="First page"
+          onClick={() => table.setPageIndex(0)}
+          disabled={disabled || !table.getCanPreviousPage()}
+        />
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={PagePreviousIcon}
+          aria-label="Previous page"
+          onClick={() => table.previousPage()}
+          disabled={disabled || !table.getCanPreviousPage()}
+        />
+
+        <span
+          className="px-2 text-meta text-fg-tertiary tabular-nums"
+          data-numeric=""
+        >
+          Page <span className="text-fg">{pageIndex + 1}</span> of{' '}
+          {pageCount.toLocaleString()}
+        </span>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={PageNextIcon}
+          aria-label="Next page"
+          onClick={() => table.nextPage()}
+          disabled={disabled || !table.getCanNextPage()}
+        />
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={PageLastIcon}
+          aria-label="Last page"
+          onClick={() => table.setPageIndex(pageCount - 1)}
+          disabled={disabled || !table.getCanNextPage()}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/table/primitives.tsx
+++ b/packages/ui/src/components/table/primitives.tsx
@@ -1,0 +1,74 @@
+import { cn } from '../../lib/cn';
+
+/**
+ * The bare table elements, styled from the token scale.
+ *
+ * These replace what a component kit would hand you. They are deliberately
+ * thin: every decision about width, density and layout is made in
+ * `data-table.tsx` and `sizing.ts`, and a primitive that also had opinions
+ * about those would be a second place to look when a column comes out wrong.
+ *
+ * No scroll wrapper. `DataTable` owns the scroll box, because that is the
+ * element a sticky header has to be sticky inside; a wrapper here would nest a
+ * second one and quietly detach the two.
+ */
+
+export function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <table
+      className={cn('w-full border-collapse text-body', className)}
+      {...props}
+    />
+  );
+}
+
+export function TableHeader({
+  className,
+  ...props
+}: React.ComponentProps<'thead'>) {
+  return <thead className={cn('[&_tr]:border-b', className)} {...props} />;
+}
+
+export function TableBody({
+  className,
+  ...props
+}: React.ComponentProps<'tbody'>) {
+  return (
+    <tbody className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+  );
+}
+
+export function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      className={cn(
+        'border-b border-border',
+        'transition-colors duration-instant ease-standard',
+        'hover:bg-surface-hover',
+        // Selection is read from the attribute the shell sets, not from a prop
+        // threaded down, so the row cannot look selected while the table thinks
+        // otherwise.
+        'data-[state=selected]:bg-surface-selected',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      className={cn(
+        'px-3 text-left align-middle',
+        'font-mono text-column uppercase text-fg-muted',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return <td className={cn('px-3 align-middle', className)} {...props} />;
+}

--- a/packages/ui/src/components/table/sizing.ts
+++ b/packages/ui/src/components/table/sizing.ts
@@ -1,0 +1,218 @@
+import type { RowData } from '@tanstack/react-table';
+import { type RefObject, useLayoutEffect, useState } from 'react';
+import type { DataTableInstance } from './use-app-table';
+
+/**
+ * The breakpoint below which a column is not rendered.
+ *
+ * Hiding is done in CSS, not through `columnVisibility`, so it resolves before
+ * the first paint instead of after a measurement. The cost is that JavaScript
+ * cannot see which columns are on screen, and the width arithmetic below needs
+ * to. That is what `useVisibleTiers` is for: the class list and the arithmetic
+ * read the same breakpoint, so they cannot drift.
+ */
+export type HideBelow = 'sm' | 'md' | 'lg' | 'xl';
+
+/**
+ * Static class strings, because Tailwind cannot see a class it has to compute.
+ * `table-cell` rather than `block` so the cell keeps participating in the
+ * table's column layout when it comes back.
+ */
+export const HIDE_BELOW_CLASS: Record<HideBelow, string> = {
+  sm: 'hidden sm:table-cell',
+  md: 'hidden md:table-cell',
+  lg: 'hidden lg:table-cell',
+  xl: 'hidden xl:table-cell',
+};
+
+/** Tailwind's own values. Keep in step with the class map above. */
+const MIN_WIDTH_PX: Record<HideBelow, number> = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+};
+
+const TIERS: readonly HideBelow[] = ['sm', 'md', 'lg', 'xl'];
+
+/** Reads the breakpoints straight from the browser. */
+function measureTiers(): ReadonlySet<HideBelow> {
+  const visible = new Set<HideBelow>();
+  for (const tier of TIERS) {
+    if (window.matchMedia(`(min-width: ${MIN_WIDTH_PX[tier]}px)`).matches) {
+      visible.add(tier);
+    }
+  }
+  return visible;
+}
+
+/**
+ * Which `hideBelow` tiers are currently on screen.
+ *
+ * Measured in the initialiser rather than defaulted to "all of them" and
+ * corrected on mount. That correction existed because this table used to render
+ * on a server, where there is no viewport to ask; here there always is one, so
+ * the very first render is already right and a narrow viewport never lays out
+ * as though it were wide.
+ */
+export function useVisibleTiers(): ReadonlySet<HideBelow> {
+  const [visible, setVisible] = useState<ReadonlySet<HideBelow>>(measureTiers);
+
+  useLayoutEffect(() => {
+    const queries = TIERS.map(
+      (tier) =>
+        [
+          tier,
+          window.matchMedia(`(min-width: ${MIN_WIDTH_PX[tier]}px)`),
+        ] as const,
+    );
+
+    const sync = () => {
+      setVisible((previous) => {
+        const next = new Set<HideBelow>();
+        for (const [tier, query] of queries) {
+          if (query.matches) next.add(tier);
+        }
+        // Same membership means the same layout; returning `previous` keeps
+        // the table from re-rendering on unrelated viewport changes.
+        if (
+          next.size === previous.size &&
+          [...next].every((tier) => previous.has(tier))
+        ) {
+          return previous;
+        }
+        return next;
+      });
+    };
+
+    // No initial `sync()`: the initialiser already measured, and calling it
+    // here would be a second render on every mount for no change.
+    // One controller owns every listener, so the cleanup cannot fall out of
+    // step with the loop that registered them.
+    const controller = new AbortController();
+    for (const [, query] of queries) {
+      query.addEventListener('change', sync, { signal: controller.signal });
+    }
+    return () => controller.abort();
+  }, []);
+
+  return visible;
+}
+
+/** The width of the box the table has to lay itself out in. */
+function useAvailableWidth(container: RefObject<HTMLElement | null>): number {
+  const [width, setWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const element = container.current;
+    if (!element) return;
+
+    // Measured before paint, so the first frame is already correct rather than
+    // showing default widths and snapping.
+    setWidth(element.clientWidth);
+
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) setWidth(Math.round(entry.contentRect.width));
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [container]);
+
+  return width;
+}
+
+export interface ColumnLayout {
+  /** Every visible leaf column's width in pixels, keyed by column id. */
+  widths: ReadonlyMap<string, number>;
+  /** What the columns add up to. Wider than the container means scrolling. */
+  totalWidth: number;
+  /**
+   * Width of the inert trailing column, when the real ones do not reach the
+   * end of the container.
+   *
+   * This is a table with no growing column: without it the rows would stop
+   * short of the container's own border and the table would look truncated.
+   */
+  fillerWidth: number;
+}
+
+/**
+ * Every column's width, in pixels, decided here rather than by the browser.
+ *
+ * ## Why this is not CSS
+ *
+ * The obvious version of this is `table-layout: fixed`, pixel widths on the
+ * fixed columns, `width: auto` on the growing one, and a `min-width` on the
+ * table. It very nearly works, and then does not: under fixed layout, when the
+ * declared widths add up to less than the table's own width, the browser
+ * distributes the surplus **across every column**. So the moment a growing
+ * column is pinned by a resize, nothing is left to absorb the slack and every
+ * other column silently inflates. Widths stop meaning anything.
+ *
+ * So the distribution is done here: fixed columns take their `size`, growing
+ * columns split whatever is left down to their `minSize`, and every column
+ * ends up with an explicit number. The browser is left with no distribution to
+ * do, which is the only way to be sure it does none.
+ *
+ * A table whose columns are all fixed renders at their total and does not
+ * stretch. Filling the container is what `meta.grow` is for, and guessing at
+ * it -- stretching the last column, say -- would make a right-aligned final
+ * column behave differently from every other table.
+ */
+export function useColumnLayout<TData extends RowData>(
+  table: DataTableInstance<TData>,
+  container: RefObject<HTMLElement | null>,
+  visibleTiers: ReadonlySet<HideBelow>,
+): ColumnLayout {
+  const available = useAvailableWidth(container);
+
+  const widths = new Map<string, number>();
+  const growing: { id: string; floor: number }[] = [];
+  let fixedTotal = 0;
+
+  for (const column of table.getAllLeafColumns()) {
+    const meta = column.columnDef.meta;
+
+    // Hidden at this breakpoint: still given a width, because CSS is what
+    // hides it and the two could be a frame apart, but it claims no space.
+    // Every column is a leaf here; nothing in this app hides one by state.
+    if (meta?.hideBelow && !visibleTiers.has(meta.hideBelow)) {
+      widths.set(column.id, column.getSize());
+      continue;
+    }
+
+    if (meta?.grow) {
+      growing.push({ id: column.id, floor: column.columnDef.minSize ?? 0 });
+    } else {
+      const size = column.getSize();
+      widths.set(column.id, size);
+      fixedTotal += size;
+    }
+  }
+
+  if (growing.length > 0) {
+    const leftover = Math.max(0, available - fixedTotal);
+    const share = Math.floor(leftover / growing.length);
+    growing.forEach((column, index) => {
+      // The last one takes the rounding remainder, so the columns add up to
+      // the container exactly and no hairline gap opens on the right.
+      const isLast = index === growing.length - 1;
+      const width = isLast ? leftover - share * (growing.length - 1) : share;
+      widths.set(column.id, Math.max(column.floor, width));
+    });
+  }
+
+  let totalWidth = 0;
+  for (const column of table.getAllLeafColumns()) {
+    const meta = column.columnDef.meta;
+    if (meta?.hideBelow && !visibleTiers.has(meta.hideBelow)) continue;
+    totalWidth += widths.get(column.id) ?? 0;
+  }
+
+  return {
+    widths,
+    totalWidth,
+    // Zero before the first measurement, so nothing is drawn on a guess.
+    fillerWidth: available > 0 ? Math.max(0, available - totalWidth) : 0,
+  };
+}

--- a/packages/ui/src/components/table/stop-propagation.tsx
+++ b/packages/ui/src/components/table/stop-propagation.tsx
@@ -1,0 +1,18 @@
+/**
+ * Keeps a control inside a clickable row to itself.
+ *
+ * The shell gives a row with `onRowClick` its own click handler and its own
+ * Enter/Space handler. Without this, ticking a checkbox in such a row would
+ * also activate the row: one gesture, two things happening, and only one of
+ * them asked for.
+ */
+export function StopPropagation({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      onClick={(event) => event.stopPropagation()}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/components/table/use-app-table.ts
+++ b/packages/ui/src/components/table/use-app-table.ts
@@ -1,0 +1,70 @@
+import {
+  createTableHook,
+  type ReactTable,
+  type RowData,
+} from '@tanstack/react-table';
+import { dataTableFeatures } from './features';
+
+/**
+ * The one place a Rustrak table is configured.
+ *
+ * `createTableHook` is the v9 API for exactly this: features, defaults and
+ * option choices are declared once, and a table then only has to name its
+ * columns and its data. Everything below is a decision no individual table
+ * should be re-making.
+ *
+ * Components are deliberately **not** registered here. `createTableHook` can
+ * pre-bind cell/header/table components onto the instance, but that makes the
+ * hook module import the components and the components import the hook, and
+ * this codebase reads better with every import naming the file it wants.
+ * `ColumnHeader` and the rest take the header or table as a prop instead.
+ */
+export const { useAppTable, createAppColumnHelper } = createTableHook({
+  features: dataTableFeatures,
+
+  /**
+   * `size` is the fixed width in pixels and `minSize` the floor a growing
+   * column will not go below. 150 is TanStack's own default, kept so an
+   * unconfigured column is visibly unconfigured rather than subtly wrong.
+   */
+  defaultColumn: { size: 150, minSize: 60, maxSize: 800 },
+
+  /**
+   * The server does the work. Without this the table would quietly re-paginate
+   * the single page it was handed, which looks like it works until the result
+   * set is larger than `per_page`.
+   *
+   * There is no `manualSorting` or `manualFiltering` because neither feature
+   * is registered: ordering and filtering are query parameters the server
+   * reads, and the table never sees them.
+   */
+  manualPagination: true,
+  manualExpanding: true,
+
+  /**
+   * Every row can open its detail panel.
+   *
+   * TanStack's default asks whether a row has sub-rows, which is the right
+   * question for a tree and the wrong one here: the shell's detail panel is a
+   * disclosure about the row itself, and no table in this app has sub-rows.
+   * Left at the default, `toggleExpanded` returns without doing anything and
+   * the row simply never opens.
+   *
+   * Whether a table expands at all is decided by whether it passes
+   * `renderDetail` to the shell, not by the shape of its data.
+   */
+  getRowCanExpand: () => true,
+});
+
+/**
+ * A table instance as the shell and its parts accept it.
+ *
+ * Left on the default `TSelected`, which is the full table state, because the
+ * shell reads `table.state.columnSizing` to lay itself out. Tables that pass a
+ * narrowing selector to `useAppTable` would not be assignable here, and none
+ * do: the selector is for subscribing a leaf of the tree, not the shell.
+ */
+export type DataTableInstance<TData extends RowData> = ReactTable<
+  typeof dataTableFeatures,
+  TData
+>;

--- a/packages/ui/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/ui/src/components/tooltip/tooltip.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { Button } from '../button/button';
+import { DeleteIcon, ReopenIcon, ResolveIcon } from '../icon/icon-catalog';
+import { Tooltip, TooltipProvider } from './tooltip';
+
+const meta = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  args: {
+    content: 'Reopen issue',
+    side: 'top',
+    // `children` is required, so it belongs in the meta: without it every
+    // story has to repeat the trigger in `args` as well as in `render`.
+    children: (
+      <Button variant="ghost" icon={ReopenIcon} aria-label="Reopen issue" />
+    ),
+  },
+  argTypes: {
+    side: {
+      control: 'inline-radio',
+      options: ['top', 'right', 'bottom', 'left'],
+    },
+  },
+  // One provider for the whole canvas, the way the application mounts one at
+  // its root. A second one anywhere down the tree silently splits the shared
+  // open-delay timer.
+  decorators: [
+    (Story) => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Tooltip {...args}>
+      <Button variant="ghost" icon={ReopenIcon} aria-label="Reopen issue" />
+    </Tooltip>
+  ),
+};
+
+/**
+ * The tooltip makes the name visible; it does not supply it. The button
+ * already carries `aria-label`, and the type enforces that, so a person using
+ * a screen reader never depends on hovering.
+ */
+export const DoesNotCarryTheName: Story = {
+  render: (args) => (
+    <Tooltip {...args}>
+      <Button variant="ghost" icon={ReopenIcon} aria-label="Reopen issue" />
+    </Tooltip>
+  ),
+  play: async ({ canvasElement }) => {
+    const button = within(canvasElement).getByRole('button', {
+      name: 'Reopen issue',
+    });
+
+    // Named before anything is hovered.
+    await expect(button).toBeVisible();
+  },
+};
+
+/** Opens on hover, and the panel is found through the portal, not the canvas. */
+export const OpensOnHover: Story = {
+  args: { delay: 0 },
+  render: (args) => (
+    <Tooltip {...args}>
+      <Button variant="ghost" icon={ResolveIcon} aria-label="Resolve" />
+    </Tooltip>
+  ),
+  play: async ({ canvasElement }) => {
+    const button = within(canvasElement).getByRole('button');
+
+    await userEvent.hover(button);
+    // The popup is portalled to the body, so the query is document-wide.
+    await waitFor(() =>
+      expect(within(document.body).getByText('Reopen issue')).toBeVisible(),
+    );
+
+    await userEvent.unhover(button);
+    await waitFor(() =>
+      expect(within(document.body).queryByText('Reopen issue')).toBeNull(),
+    );
+  },
+};
+
+/** `disabled` suppresses the panel without unmounting the control. */
+export const Disabled: Story = {
+  args: { disabled: true, delay: 0 },
+  render: (args) => (
+    <Tooltip {...args}>
+      <Button variant="ghost" icon={DeleteIcon} aria-label="Delete" />
+    </Tooltip>
+  ),
+  play: async ({ canvasElement }) => {
+    const button = within(canvasElement).getByRole('button');
+
+    await userEvent.hover(button);
+    await expect(within(document.body).queryByText('Reopen issue')).toBeNull();
+    // The control itself is untouched.
+    await expect(button).toBeEnabled();
+  },
+};
+
+/** A toolbar of icon-only actions, which is what this exists for. */
+export const InAToolbar: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex items-center gap-1 rounded-lg bg-surface p-1.5 inset-ring inset-ring-border">
+      {(
+        [
+          [ResolveIcon, 'Resolve'],
+          [ReopenIcon, 'Reopen'],
+          [DeleteIcon, 'Delete'],
+        ] as const
+      ).map(([icon, label]) => (
+        <Tooltip key={label} content={label}>
+          <Button variant="ghost" size="sm" icon={icon} aria-label={label} />
+        </Tooltip>
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/tooltip/tooltip.tsx
+++ b/packages/ui/src/components/tooltip/tooltip.tsx
@@ -1,0 +1,81 @@
+import { Tooltip as Base } from '@base-ui/react/tooltip';
+import type { ReactNode } from 'react';
+import { cn } from '../../lib/cn';
+import { popTransition } from '../../lib/motion';
+
+/**
+ * The name of a control that has no visible label.
+ *
+ * Not a general annotation layer. An icon-only button in this system is
+ * *required* to carry an `aria-label`, so a tooltip is what makes that name
+ * visible to people who are not using a screen reader; it is not what supplies
+ * it. Hover is not an interaction everyone has, so a tooltip must never be the
+ * only place something is said.
+ *
+ * `Tooltip.Provider` is deliberately not exported. Base UI uses it to share the
+ * "one has opened recently, so open the next one instantly" timer, and the
+ * application mounts exactly one at its root. Exposing it here would invite a
+ * second provider somewhere down the tree, which silently splits that timer and
+ * makes a toolbar feel inconsistent as the pointer crosses it.
+ */
+export interface TooltipProps {
+  /** The control being named. Must be a single focusable element. */
+  children: ReactNode;
+  /** What the control does. Short: this is a name, not documentation. */
+  content: ReactNode;
+  /** @default 'top' */
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  /**
+   * How long the pointer must rest before it opens.
+   *
+   * 600ms is Base UI's default and it is kept: shorter turns a toolbar into a
+   * flicker as the pointer crosses it on the way somewhere else.
+   */
+  delay?: number;
+  /** Suppresses the tooltip without unmounting the trigger. */
+  disabled?: boolean;
+}
+
+export function Tooltip({
+  children,
+  content,
+  side = 'top',
+  delay,
+  disabled,
+}: TooltipProps) {
+  return (
+    <Base.Root disabled={disabled}>
+      <Base.Trigger delay={delay} render={children as React.ReactElement} />
+      <Base.Portal>
+        <Base.Positioner side={side} sideOffset={6}>
+          <Base.Popup
+            className={cn(
+              'rounded-md bg-surface-floating px-2 py-1',
+              'text-control-sm text-fg-secondary',
+              'shadow-overlay inset-ring inset-ring-border-subtle',
+              // Grows from the trigger rather than from its own centre, which
+              // is what ties the panel to the thing that opened it.
+              popTransition,
+            )}
+          >
+            {content}
+          </Base.Popup>
+        </Base.Positioner>
+      </Base.Portal>
+    </Base.Root>
+  );
+}
+
+Tooltip.displayName = 'Tooltip';
+
+/**
+ * Mount once, at the application root.
+ *
+ * Exported separately from `Tooltip` so that the one-per-app rule is visible in
+ * the import rather than implied.
+ */
+export function TooltipProvider({ children }: { children: ReactNode }) {
+  return <Base.Provider>{children}</Base.Provider>;
+}
+
+TooltipProvider.displayName = 'TooltipProvider';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,6 +10,9 @@ export type {
 } from './components/button/button';
 /* Actions ----------------------------------------------------------------- */
 export { Button } from './components/button/button';
+export type { CheckboxProps } from './components/checkbox/checkbox';
+/* Forms ------------------------------------------------------------------- */
+export { Checkbox } from './components/checkbox/checkbox';
 /* Icons ------------------------------------------------------------------- */
 export { fromLucide } from './components/icon/adapters/lucide';
 export type {
@@ -26,6 +29,22 @@ export {
   ResolveIcon,
   SpinnerIcon,
 } from './components/icon/icon-catalog';
+export type {
+  MenuContentProps,
+  MenuItemProps,
+  MenuItemTone,
+} from './components/menu/menu';
+/* Overlays ---------------------------------------------------------------- */
+export {
+  MenuContent,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuLinkItem,
+  MenuRoot,
+  MenuSeparator,
+  MenuTrigger,
+} from './components/menu/menu';
 export type { MeterProps, MeterTone } from './components/meter/meter';
 export { Meter } from './components/meter/meter';
 export type { SeparatorProps } from './components/separator/separator';
@@ -35,6 +54,36 @@ export type {
   SeverityLevel,
 } from './components/severity/severity-dot';
 export { SeverityDot } from './components/severity/severity-dot';
+/* Table -------------------------------------------------------------------- */
+export {
+  actionsColumn,
+  expandColumn,
+  selectionColumn,
+} from './components/table/columns';
+export type { DataTableProps } from './components/table/data-table';
+export { DataTable } from './components/table/data-table';
+export type {
+  DataTableColumnMeta,
+  DataTableFeatures,
+} from './components/table/features';
+export { dataTableFeatures } from './components/table/features';
+export { DataTablePagination } from './components/table/pagination';
+export {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './components/table/primitives';
+export type { HideBelow } from './components/table/sizing';
+export type { DataTableInstance } from './components/table/use-app-table';
+export {
+  createAppColumnHelper,
+  useAppTable,
+} from './components/table/use-app-table';
+export type { TooltipProps } from './components/tooltip/tooltip';
+export { Tooltip, TooltipProvider } from './components/tooltip/tooltip';
 export { cn } from './lib/cn';
 export { focusRing, focusRingWithin } from './lib/focus';
 export {

--- a/packages/ui/src/lib/tokens.ts
+++ b/packages/ui/src/lib/tokens.ts
@@ -78,6 +78,7 @@ export const spacingTokens = [
   'dot',
   'dot-sm',
   'meter',
+  'choice',
   'icon-sm',
   'icon-md',
   'icon-lg',

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -53,14 +53,23 @@
     -webkit-tap-highlight-color: transparent;
   }
 
-  /* Disabled is not "nothing happens": it is "not here, and for a reason". */
+  /* Disabled is not "nothing happens": it is "not here, and for a reason".
+   *
+   * This list has to stay in step with the pointer one above, and it did not:
+   * `menuitem`, `option` and `tab` were granted a pointer and then left at
+   * `auto` when disabled, so a greyed-out menu entry looked inert and felt like
+   * plain text. Anything that can be pressed can also be unavailable. */
   :where([data-theme])
   :is(
     button,
+    summary,
     [role="button"],
     [role="checkbox"],
     [role="radio"],
     [role="switch"],
+    [role="tab"],
+    [role="option"],
+    [role="menuitem"],
     [role="combobox"],
     input,
     textarea,

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -405,6 +405,9 @@
   /* Meter track. The design uses 4px and 5px; 5px is the one that survives a
      rounded cap without the fill looking pinched. */
   --spacing-meter: 5px;
+  /* Checkbox and radio. Big enough to hit, small enough not to dominate a
+     44px selection column. */
+  --spacing-choice: 16px;
   --spacing-icon-sm: 13px;
   --spacing-icon-md: 14px;
   --spacing-icon-lg: 16px;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,9 @@ importers:
       '@fontsource/ibm-plex-mono':
         specifier: 5.3.0
         version: 5.3.0
+      '@tanstack/react-table':
+        specifier: 9.1.2
+        version: 9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -3723,6 +3726,12 @@ packages:
     peerDependencies:
       react: '>=18'
 
+  '@tanstack/react-table@9.1.2':
+    resolution: {integrity: sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: '>=18'
+
   '@tanstack/react-virtual@3.13.18':
     resolution: {integrity: sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==}
     peerDependencies:
@@ -3785,6 +3794,10 @@ packages:
 
   '@tanstack/table-core@9.0.0':
     resolution: {integrity: sha512-IyKCc4D7d/+I9euQntlVDQ7lnilmFRKpIROBeI5/866adFy+65xWvCFPz76NZ5j2lXe/RFDvFVV7bfETmwHEMA==}
+    engines: {node: '>=20'}
+
+  '@tanstack/table-core@9.1.2':
+    resolution: {integrity: sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g==}
     engines: {node: '>=20'}
 
   '@tanstack/virtual-core@3.13.18':
@@ -12150,6 +12163,14 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
+  '@tanstack/react-table@9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/react-store': 0.11.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/table-core': 9.1.2
+      react: 19.2.8
+    transitivePeerDependencies:
+      - react-dom
+
   '@tanstack/react-virtual@3.13.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/virtual-core': 3.13.18
@@ -12234,6 +12255,10 @@ snapshots:
   '@tanstack/store@0.9.3': {}
 
   '@tanstack/table-core@9.0.0':
+    dependencies:
+      '@tanstack/store': 0.11.0
+
+  '@tanstack/table-core@9.1.2':
     dependencies:
       '@tanstack/store': 0.11.0
 
@@ -12692,9 +12717,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))(vitest@4.1.10)
 
   '@vitest/expect@3.2.4':
     dependencies:


### PR DESCRIPTION
Four overlays and controls plus the table, which is the piece the issue list
cannot be built without.

## The table is a port, not a rewrite

`apps/webview-ui/src/shared/ui/components/data-table/` already held a
thoroughly worked TanStack Table v9 implementation, reviewed in #249. Rewriting
it would have thrown away that review. The logic is carried over intact:
`tableFeatures` with only the features any table actually asks for (in v9 that
is a bundle decision, not just config), `createTableHook` so features and
defaults are declared once, the width arithmetic in `sizing.ts`, and column
hiding done in CSS.

What changed in the move:

- shadcn's table primitives are replaced by token-styled ones in
  `primitives.tsx`, which deliberately bring no scroll wrapper: `DataTable`
  owns the scroll box, and a sticky header is sticky inside whatever scrolls,
  so a second wrapper would silently detach the two.
- The `MIXED` block, twelve lines of overrides repairing a kit checkbox that
  drew a full tick for a partial selection, is gone. `Checkbox` here reads
  `data-indeterminate` and draws a dash.
- `useVisibleTiers` measures in its initialiser instead of defaulting to "all
  tiers visible" and correcting on mount. That correction existed because the
  table used to render on a server with no viewport to ask; here there always
  is one, so the first render is already right and a narrow viewport never lays
  out as though it were wide.
- `actionsColumn` is new: the trailing overflow is how most rows end, and its
  width, screen-reader-only header and `StopPropagation` are one decision
  rather than five tables' worth of slightly different ones.

## A real defect the a11y check found in the ported code

The original put `aria-expanded` on the `<tr>`. That attribute is only defined
for rows inside a `treegrid`, and claiming `treegrid` would promise a
cell-by-cell arrow-key model this table does not implement; axe rejects it.

The original comment argued the chevron should not be a button because it would
be a second tab stop per row, but that was decided without knowing the attribute
was invalid. The disclosure now lives on a real button in `expandColumn`, which
is the row's one tab stop; clicking the row still toggles it for pointer users,
that path just no longer pretends to be an ARIA widget. **The same bug is still
live in `apps/webview-ui`.**

## Cursor, and a gap it exposed

`Menu`'s item recipe shipped with `cursor-default`, which beat the pointer
`styles/base.css` grants every `[role="menuitem"]` at zero specificity. Removing
it exposed the real problem: base.css's two cursor lists had drifted apart.
`menuitem`, `option` and `tab` could be pressed but were left at `auto` when
disabled, so a greyed-out entry looked inert and read as plain text. Both lists
now match.

## Smaller decisions worth stating

`Menu` is exported as parts rather than an `items={[...]}` prop: an array API is
tidy until the first separator, submenu and badge, at which point it grows a
`type` discriminator and becomes a worse JSX. Items take an `icon` that inherits
the item's colour, so a destructive action's glyph turns red with its words.

`TooltipProvider` is exported separately so the one-per-app rule is visible in
the import. A second provider down the tree silently splits Base UI's shared
open-delay timer.

Selection is opt-in and the stories show it that way. Most tables are lists you
read rather than sets you act on, and on those a column of checkboxes is 44px of
nothing plus a select-all that means nothing.

New tokens, all from the design: `--text-column`, `--text-tag`, `--radius-xs`,
`--spacing-choice`.

Testing: 78 tests, up from 57.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>