### PR TITLE
feat(server): symbolicate Hermes/Metro source maps

### DIFF
--- a/.changeset/hermes-sourcemap-support.md
+++ b/.changeset/hermes-sourcemap-support.md
@@ -1,0 +1,5 @@
+---
+"@rustrak/server": patch
+---
+
+Symbolicate React Native Hermes/Metro source maps (`x_facebook_sources`) instead of skipping them.

--- a/.changeset/hermes-sourcemap-support.md
+++ b/.changeset/hermes-sourcemap-support.md
@@ -1,5 +1,0 @@
----
-"@rustrak/server": patch
----
-
-Symbolicate React Native Hermes/Metro source maps (`x_facebook_sources`) instead of skipping them.

--- a/apps/server/src/services/sourcemap.rs
+++ b/apps/server/src/services/sourcemap.rs
@@ -673,13 +673,21 @@ async fn rewrite_frames_under(
                 }
             };
 
-            // 3d. Parse source map
-            let sm = match sourcemap::SourceMap::from_reader(Cursor::new(&entry.data)) {
-                Ok(sm) => sm,
+            // 3d. Parse source map — DecodedMap auto-detects Hermes (`x_facebook_sources`)
+            // vs regular maps. SourceMap::from_reader returns IncompatibleSourceMap for Hermes.
+            let decoded = match sourcemap::DecodedMap::from_reader(Cursor::new(&entry.data)) {
+                Ok(m) => m,
                 Err(e) => {
                     log::warn!("failed to parse source map for {}: {}", debug_id, e);
                     continue;
                 }
+            };
+
+            // Indexed maps need embedded sections for lookup + contents; skip them.
+            let sm: &sourcemap::SourceMap = match &decoded {
+                sourcemap::DecodedMap::Regular(sm) => sm,
+                sourcemap::DecodedMap::Hermes(smh) => smh,
+                sourcemap::DecodedMap::Index(_) => continue,
             };
 
             // 3e. Normalize position — use let-else, NOT '?' (normalize returns Option not Result)
@@ -690,7 +698,7 @@ async fn rewrite_frames_under(
             };
 
             // 3f. Lookup token
-            let Some(token) = sm.lookup_token(norm_lineno, norm_colno) else {
+            let Some(token) = decoded.lookup_token(norm_lineno, norm_colno) else {
                 continue;
             };
 
@@ -701,6 +709,9 @@ async fn rewrite_frames_under(
 
             // 3h. Original file from token
             let original_file = token.get_source().unwrap_or("").to_string();
+            let src_line = token.get_src_line();
+            let src_col = token.get_src_col();
+            let token_name = token.get_name().map(|n| n.to_string());
 
             // 3i. Find source index via linear search (NEVER assume sourcesContent[0])
             let source_idx = (0..sm.get_source_count())
@@ -713,7 +724,7 @@ async fn rewrite_frames_under(
                 .unwrap_or_default();
 
             // 3k. Compute context window bounds
-            let l = token.get_src_line() as usize;
+            let l = src_line as usize;
             let pre_start = l.saturating_sub(3);
             let post_end = lines.len().min(l + 4);
 
@@ -724,11 +735,14 @@ async fn rewrite_frames_under(
                 .unwrap_or("")
                 .to_string();
 
-            let new_lineno = token.get_src_line() + 1; // back to 1-indexed
-            let new_colno = token.get_src_col();
-            let new_function = token
-                .get_name()
+            let new_lineno = src_line + 1; // back to 1-indexed
+            let new_colno = src_col;
+            // Hermes resolves names from x_facebook_sources (line==0, col=bytecode offset).
+            // Regular maps return None without a minified SourceView; fall back to token name.
+            let new_function = decoded
+                .get_original_function_name(norm_lineno, norm_colno, Some(&existing_function), None)
                 .map(|n| n.to_string())
+                .or(token_name)
                 .unwrap_or(existing_function);
             let context_line = lines.get(l).cloned().unwrap_or_default();
             let pre_context: Vec<serde_json::Value> = lines
@@ -900,6 +914,33 @@ mod tests {
         assert_eq!(
             frame["function"], "originalFunction",
             "function name should be resolved from names table"
+        );
+    }
+
+    /// Metro/Hermes maps include `x_facebook_sources`. SourceMap::from_reader
+    /// rejects them; DecodedMap::from_reader does not.
+    const HERMES_SOURCEMAP: &str = r#"{
+        "version": 3,
+        "sources": ["src/App.tsx"],
+        "sourcesContent": ["line 1\nline 2\nline 3\nline 4\nfunction foo() {\n  throw new Error('boom');\n}"],
+        "names": [],
+        "mappings": "AAIA",
+        "x_facebook_sources": [[{"names": ["foo"], "mappings": "AAA"}]]
+    }"#;
+
+    #[test]
+    fn hermes_map_parses_as_decoded_map_not_regular() {
+        let data = HERMES_SOURCEMAP.as_bytes();
+        let regular = sourcemap::SourceMap::from_reader(Cursor::new(data));
+        assert!(
+            matches!(regular, Err(sourcemap::Error::IncompatibleSourceMap)),
+            "regular SourceMap::from_reader must reject Hermes maps; got {:?}",
+            regular.err()
+        );
+        let decoded = sourcemap::DecodedMap::from_reader(Cursor::new(data)).unwrap();
+        assert!(
+            matches!(decoded, sourcemap::DecodedMap::Hermes(_)),
+            "DecodedMap must detect Hermes from x_facebook_sources"
         );
     }
 }

--- a/apps/server/tests/unit/sourcemap_test.rs
+++ b/apps/server/tests/unit/sourcemap_test.rs
@@ -488,3 +488,70 @@ async fn test_rewrite_image_missing_code_file() {
     let frame = &event["exception"]["values"][0]["stacktrace"]["frames"][0];
     assert_eq!(frame["filename"], orig["filename"]);
 }
+
+// ---------------------------------------------------------------------------
+// Hermes / Metro maps (`x_facebook_sources`)
+// ---------------------------------------------------------------------------
+
+/// Minimal Hermes map: generated line 0 / col 0 → `src/App.tsx` line 4,
+/// function name `foo` from `x_facebook_sources`.
+///
+/// Adapted from getsentry/rust-sourcemap tests/fixtures/react-native-hermes.
+fn make_hermes_sourcemap() -> Bytes {
+    let json = r#"{
+        "version": 3,
+        "sources": ["src/App.tsx"],
+        "sourcesContent": ["line 1\nline 2\nline 3\nline 4\nfunction foo() {\n  throw new Error('boom');\n}"],
+        "names": [],
+        "mappings": "AAIA",
+        "x_facebook_sources": [[{"names": ["foo"], "mappings": "AAA"}]]
+    }"#;
+    Bytes::from(json)
+}
+
+#[tokio::test]
+async fn test_rewrite_hermes_map() {
+    let provider = FakeSourceMapProvider::with_data(make_hermes_sourcemap());
+    // Hermes frames are reported as lineno=1, colno=bytecode_offset (here 0).
+    let mut event = json!({
+        "debug_meta": {
+            "images": [{"code_file": "index.android.bundle", "debug_id": "abc123"}]
+        },
+        "exception": {
+            "values": [{
+                "stacktrace": {
+                    "frames": [{
+                        "filename": "index.android.bundle",
+                        "lineno": 1,
+                        "colno": 0,
+                        "function": "?anon_0_"
+                    }]
+                }
+            }]
+        }
+    });
+
+    rewrite_frames(&provider, 1, &mut event).await.unwrap();
+
+    let frame = &event["exception"]["values"][0]["stacktrace"]["frames"][0];
+    assert_eq!(
+        frame["filename"].as_str().unwrap(),
+        "src/App.tsx",
+        "Hermes map must rewrite filename to the original source"
+    );
+    assert_eq!(
+        frame["lineno"].as_u64().unwrap(),
+        5,
+        "Hermes map must rewrite lineno (src_line 4 + 1)"
+    );
+    assert_eq!(
+        frame["function"].as_str().unwrap(),
+        "foo",
+        "Hermes map must resolve the original function name from x_facebook_sources"
+    );
+    assert_eq!(
+        frame["context_line"].as_str().unwrap(),
+        "function foo() {",
+        "context_line must come from the original Hermes source"
+    );
+}


### PR DESCRIPTION
## Summary
- Parse uploaded source maps with `DecodedMap::from_reader` so Metro/Hermes maps that include `x_facebook_sources` are no longer rejected as `IncompatibleSourceMap`.
- Resolve original function names via `get_original_function_name` (Hermes: generated line 0, column = bytecode offset after Sentry 1→0 normalization), falling back to the token name for regular maps.
- Regular web-style maps keep the same rewrite path; indexed maps (`sections`) are still skipped.

Fixes #266

## Test plan
- [x] `cd apps/server && cargo test sourcemap`
- [x] Existing regular-map rewrite tests (hit/miss, multi-source context, empty source name, thread frames)
- [x] New Hermes fixture: parse as `DecodedMap::Hermes`, rewrite filename/lineno **and** function name (`foo` from `x_facebook_sources`)
- [x] `cargo fmt` / `cargo clippy -- -D warnings` on touched server code
- [x] Confirmed on a real Expo / React Native project (Hermes + Metro maps from sentry-cli / RN sourcemap upload)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for symbolication of Hermes and Metro React Native source maps.
  * Error stack traces now provide more accurate original filenames, line numbers, function names, and source context for Hermes bundles.

* **Bug Fixes**
  * Improved source-map parsing and function-name resolution for supported React Native mappings.
  * Indexed source maps continue to be skipped safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->