### PR TITLE
fix(server): return HTTP 200 when assemble reports missing chunks

### DIFF
--- a/.changeset/assemble-always-200.md
+++ b/.changeset/assemble-always-200.md
@@ -1,5 +1,0 @@
----
-"@rustrak/server": patch
----
-
-Return HTTP 200 with `state: "not_found"` and `missingChunks` from artifact-bundle assemble, matching what sentry-cli `--wait` polls. Missing chunks previously used HTTP 202, which made `--wait` fail or hang.

--- a/.changeset/assemble-always-200.md
+++ b/.changeset/assemble-always-200.md
@@ -1,0 +1,5 @@
+---
+"@rustrak/server": patch
+---
+
+Return HTTP 200 with `state: "not_found"` and `missingChunks` from artifact-bundle assemble, matching what sentry-cli `--wait` polls. Missing chunks previously used HTTP 202, which made `--wait` fail or hang.

--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -68,17 +68,7 @@
         },
         "responses": {
           "200": {
-            "description": "Assembly job state (ok / created / processing)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AssembleResponse"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "Missing chunks — upload required",
+            "description": "Assembly job state (not_found / created / assembling / ok / error). Missing chunks are listed in missingChunks.",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/server/src/routes/sourcemaps.rs
+++ b/apps/server/src/routes/sourcemaps.rs
@@ -265,6 +265,24 @@ pub async fn artifact_bundle_assemble(
     )
     .await?;
 
+    // A finished (or in-flight) job answers the poll before the chunk check:
+    // the assembly worker deletes the consumed chunk rows on success, so a
+    // sentry-cli `--wait` poll after completion would otherwise see its own
+    // chunks as missing forever. Error jobs fall through so a re-submit with
+    // corrected chunks can re-queue via the ON CONFLICT below.
+    let existing_job: Option<crate::models::source_file::AssemblyJob> = sqlx::query_as(
+        "SELECT * FROM assembly_jobs WHERE bundle_checksum = $1 AND project_id = $2",
+    )
+    .bind(&body.checksum)
+    .bind(project_id)
+    .fetch_optional(pool.get_ref())
+    .await?;
+    if let Some(job) = existing_job {
+        if job.state != "error" {
+            return Ok(assembly_state_response(job.state.as_str(), job.detail));
+        }
+    }
+
     // Check for missing chunks
     let missing = get_missing_chunks(pool.get_ref(), &body.chunks).await?;
     if !missing.is_empty() {

--- a/apps/server/src/routes/sourcemaps.rs
+++ b/apps/server/src/routes/sourcemaps.rs
@@ -203,8 +203,7 @@ pub async fn chunk_upload(
     params(("org_slug" = String, Path, description = "Organization slug")),
     request_body = AssembleBody,
     responses(
-        (status = 200, description = "Assembly job state (ok / created / processing)", body = AssembleResponse),
-        (status = 202, description = "Missing chunks — upload required", body = AssembleResponse),
+        (status = 200, description = "Assembly job state (not_found / created / assembling / ok / error). Missing chunks are listed in missingChunks.", body = AssembleResponse),
         (status = 400, description = "Bad request or checksum mismatch", body = crate::error::ErrorResponse),
         (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
         (status = 404, description = "Project not found", body = crate::error::ErrorResponse),
@@ -269,7 +268,7 @@ pub async fn artifact_bundle_assemble(
     // Check for missing chunks
     let missing = get_missing_chunks(pool.get_ref(), &body.chunks).await?;
     if !missing.is_empty() {
-        return Ok(HttpResponse::Accepted().json(AssembleResponse {
+        return Ok(HttpResponse::Ok().json(AssembleResponse {
             state: "not_found".to_string(),
             missing_chunks: missing,
             detail: None,

--- a/apps/server/tests/integration/sourcemaps_api_test.rs
+++ b/apps/server/tests/integration/sourcemaps_api_test.rs
@@ -179,6 +179,33 @@ async fn insert_assembly_job_with_state(
     .expect("insert assembly_jobs must succeed");
 }
 
+async fn set_assembly_job_state(
+    pool: &rustrak::db::DbPool,
+    checksum: &str,
+    project_id: i32,
+    state: &str,
+) {
+    #[cfg(feature = "postgres")]
+    sqlx::query(
+        "UPDATE assembly_jobs SET state = $1 WHERE bundle_checksum = $2 AND project_id = $3",
+    )
+    .bind(state)
+    .bind(checksum)
+    .bind(project_id)
+    .execute(pool)
+    .await
+    .expect("update assembly_jobs state must succeed");
+
+    #[cfg(not(feature = "postgres"))]
+    sqlx::query("UPDATE assembly_jobs SET state = ? WHERE bundle_checksum = ? AND project_id = ?")
+        .bind(state)
+        .bind(checksum)
+        .bind(project_id)
+        .execute(pool)
+        .await
+        .expect("update assembly_jobs state must succeed");
+}
+
 /// Binds a UUID-typed column: Postgres requires a native `Uuid` value (a bare
 /// `&str` is sent as `text`, which Postgres refuses to assign into a `uuid`
 /// column — code 42804), while SQLite's `uuid` columns are untyped `TEXT` and
@@ -649,7 +676,7 @@ async fn test_assemble_before_upload_returns_not_found_with_missing_chunks() {
         .to_request();
 
     let resp = test::call_service(&app, req).await;
-    assert_eq!(resp.status(), 202, "missing chunks must return 202");
+    assert_eq!(resp.status(), 200, "missing chunks must return 200");
 
     let body: Value = test::read_body_json(resp).await;
     assert_eq!(body["state"], "not_found");
@@ -732,6 +759,120 @@ async fn test_assemble_after_upload_enqueues_job_returns_created() {
     assert!(
         missing.is_empty(),
         "no chunks should be missing after upload"
+    );
+}
+
+/// sentry-cli `--wait` polls assemble until `state` is terminal. Every poll
+/// must be HTTP 200; missing chunks are `state: "not_found"`, not 202.
+#[actix_web::test]
+async fn test_assemble_wait_poll_returns_ok_after_chunks_uploaded() {
+    let db = TestDb::new().await;
+    let token = create_test_token(&db.pool).await;
+
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "assemble-wait-poll".to_string(),
+            slug: Some("assemble-wait-poll".to_string()),
+            platform: None,
+        },
+    )
+    .await
+    .expect("project creation must succeed");
+
+    let config = create_test_config();
+    let (provider, config_data) = sourcemap_app_data(&db.pool, &config);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(config_data)
+            .app_data(web::Data::new(Arc::clone(&provider)))
+            .configure(routes::sourcemaps::configure),
+    )
+    .await;
+
+    let bundle = build_test_artifact_bundle();
+    let chunk_sha1 = sha1_hex(&bundle);
+    let bundle_checksum = sha1_hex(&bundle);
+    let auth = format!("Bearer {}", token);
+
+    let assemble_body = serde_json::json!({
+        "checksum": bundle_checksum,
+        "chunks": [chunk_sha1],
+        "projects": [project.slug]
+    });
+
+    let missing_req = test::TestRequest::post()
+        .uri("/api/0/organizations/my-org/artifactbundle/assemble/")
+        .insert_header(("Authorization", auth.clone()))
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(&assemble_body)
+        .to_request();
+    let missing_resp = test::call_service(&app, missing_req).await;
+    assert_eq!(
+        missing_resp.status(),
+        200,
+        "assemble with missing chunks must return 200, not 202"
+    );
+    let missing_body: Value = test::read_body_json(missing_resp).await;
+    assert_eq!(missing_body["state"], "not_found");
+    let missing = missing_body["missingChunks"]
+        .as_array()
+        .expect("missingChunks must be an array");
+    assert!(
+        missing.iter().any(|c| c == &chunk_sha1),
+        "missingChunks must include the uploaded checksum; got: {:?}",
+        missing
+    );
+
+    let boundary = "waitpollboundary";
+    let upload_body = build_multipart(boundary, &[(chunk_sha1.as_str(), bundle.as_slice())]);
+    let upload_req = test::TestRequest::post()
+        .uri("/api/0/organizations/my-org/chunk-upload/")
+        .insert_header(("Authorization", auth.clone()))
+        .insert_header((
+            "Content-Type",
+            format!("multipart/form-data; boundary={}", boundary),
+        ))
+        .set_payload(upload_body)
+        .to_request();
+    let upload_resp = test::call_service(&app, upload_req).await;
+    assert_eq!(upload_resp.status(), 200, "chunk-upload must succeed");
+
+    let created_req = test::TestRequest::post()
+        .uri("/api/0/organizations/my-org/artifactbundle/assemble/")
+        .insert_header(("Authorization", auth.clone()))
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(&assemble_body)
+        .to_request();
+    let created_resp = test::call_service(&app, created_req).await;
+    assert_eq!(created_resp.status(), 200);
+    let created_body: Value = test::read_body_json(created_resp).await;
+    let created_state = created_body["state"].as_str().unwrap_or("");
+    assert!(
+        created_state == "created" || created_state == "assembling",
+        "after chunks exist, assemble must enqueue the job; got state={}",
+        created_state
+    );
+
+    // The integration suite does not run AssemblyWorker; mark the job complete
+    // the same way the worker would, then poll assemble again (sentry-cli --wait).
+    set_assembly_job_state(&db.pool, &bundle_checksum, project.id, "ok").await;
+
+    let ok_req = test::TestRequest::post()
+        .uri("/api/0/organizations/my-org/artifactbundle/assemble/")
+        .insert_header(("Authorization", auth))
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(&assemble_body)
+        .to_request();
+    let ok_resp = test::call_service(&app, ok_req).await;
+    assert_eq!(ok_resp.status(), 200);
+    let ok_body: Value = test::read_body_json(ok_resp).await;
+    assert_eq!(
+        ok_body["state"], "ok",
+        "polling assemble after the job completes must return state=ok; got: {}",
+        ok_body["state"]
     );
 }
 
@@ -2088,7 +2229,7 @@ async fn test_assemble_with_numeric_project_id_returns_not_found_or_created() {
     // GIVEN: a project exists with a known numeric ID
     // WHEN:  assemble is called with projects: ["<numeric_id>"] instead of the slug
     // THEN:  it does NOT return 404 (project found by ID fallback)
-    //        returns 202 not_found (chunks missing) rather than 404 project not found
+    //        returns 200 not_found (chunks missing) rather than 404 project not found
     let db = TestDb::new().await;
     let token = create_test_token(&db.pool).await;
 
@@ -2129,7 +2270,7 @@ async fn test_assemble_with_numeric_project_id_returns_not_found_or_created() {
 
     let resp = test::call_service(&app, req).await;
     // Must NOT be 404 — project was found by numeric ID fallback
-    // Should be 202 (missing chunks) since no chunks uploaded
+    // Should be 200 (missing chunks) since no chunks uploaded
     assert_ne!(
         resp.status(),
         404,
@@ -2137,9 +2278,11 @@ async fn test_assemble_with_numeric_project_id_returns_not_found_or_created() {
     );
     assert_eq!(
         resp.status(),
-        202,
-        "assemble with numeric project ID and missing chunks must return 202"
+        200,
+        "assemble with numeric project ID and missing chunks must return 200"
     );
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["state"], "not_found");
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/integration/sourcemaps_api_test.rs
+++ b/apps/server/tests/integration/sourcemaps_api_test.rs
@@ -876,6 +876,94 @@ async fn test_assemble_wait_poll_returns_ok_after_chunks_uploaded() {
     );
 }
 
+/// After a successful assembly the worker deletes the chunk rows. A later
+/// assemble poll (sentry-cli `--wait`) must still return the job's state —
+/// reporting the consumed chunks as missing sends the client into an
+/// infinite poll loop.
+#[actix_web::test]
+async fn test_assemble_poll_returns_ok_after_worker_deleted_chunks() {
+    let db = TestDb::new().await;
+    let token = create_test_token(&db.pool).await;
+
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "assemble-poll-chunks-gone".to_string(),
+            slug: Some("assemble-poll-chunks-gone".to_string()),
+            platform: None,
+        },
+    )
+    .await
+    .expect("project creation must succeed");
+
+    let config = create_test_config();
+    let (provider, config_data) = sourcemap_app_data(&db.pool, &config);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(config_data)
+            .app_data(web::Data::new(Arc::clone(&provider)))
+            .configure(routes::sourcemaps::configure),
+    )
+    .await;
+
+    let bundle = build_test_artifact_bundle();
+    let chunk_sha1 = sha1_hex(&bundle);
+    let bundle_checksum = sha1_hex(&bundle);
+    let auth = format!("Bearer {}", token);
+
+    rustrak::services::sourcemap::store_chunks(
+        &db.pool,
+        vec![(chunk_sha1.clone(), bundle.clone())],
+        config.max_chunk_size_bytes,
+    )
+    .await
+    .expect("store_chunks must succeed");
+
+    let assemble_body = serde_json::json!({
+        "checksum": bundle_checksum,
+        "chunks": [chunk_sha1],
+        "projects": [project.slug]
+    });
+
+    let created_req = test::TestRequest::post()
+        .uri("/api/0/organizations/my-org/artifactbundle/assemble/")
+        .insert_header(("Authorization", auth.clone()))
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(&assemble_body)
+        .to_request();
+    let created_resp = test::call_service(&app, created_req).await;
+    assert_eq!(created_resp.status(), 200);
+    let created_body: Value = test::read_body_json(created_resp).await;
+    assert_eq!(created_body["state"], "created");
+
+    // Simulate the assembly worker completing: job goes ok AND the consumed
+    // chunk rows are deleted (assemble_bundle step 8).
+    set_assembly_job_state(&db.pool, &bundle_checksum, project.id, "ok").await;
+    sqlx::query("DELETE FROM chunk WHERE checksum = $1")
+        .bind(&chunk_sha1)
+        .execute(&db.pool)
+        .await
+        .expect("chunk delete must succeed");
+
+    let poll_req = test::TestRequest::post()
+        .uri("/api/0/organizations/my-org/artifactbundle/assemble/")
+        .insert_header(("Authorization", auth))
+        .insert_header(("Content-Type", "application/json"))
+        .set_json(&assemble_body)
+        .to_request();
+    let poll_resp = test::call_service(&app, poll_req).await;
+    assert_eq!(poll_resp.status(), 200);
+    let poll_body: Value = test::read_body_json(poll_resp).await;
+    assert_eq!(
+        poll_body["state"], "ok",
+        "poll after worker completion must return the job state, not re-request \
+         the deleted chunks; got: {}",
+        poll_body
+    );
+}
+
 #[actix_web::test]
 async fn test_assemble_idempotent_same_bundle_twice() {
     let db = TestDb::new().await;


### PR DESCRIPTION
Closes #268.

`sentry-cli sourcemaps upload --wait` never finishes against Rustrak. Missing chunks came back as **HTTP 202** + `state: "not_found"`. sentry-cli then errors with `Failed to process uploaded files: unknown error` and can poll 202 forever, even after the worker has set `assembly_jobs.state = 'ok'`.

## Why 202 existed

It was not Sentry’s assemble contract. `HttpResponse::Accepted()` was added in 365c287 (PR #95) as a REST-ish “upload required / not done yet” mapping. The JSON already had the real protocol (`state`, `missingChunks`).

f8e4391 later switched the `error` state from 400 → 200 because ky throws on 4xx, and left 202 alone because it is still 2xx. sentry-cli `--wait` only treats **200** as a successful poll.

Sentry’s assemble endpoint always returns HTTP 200. The outcome lives in `state`: `not_found | created | assembling | ok | error`. Missing hashes belong in `missingChunks`, not the status code.

## The fix

`artifact_bundle_assemble`: missing chunks now return **200** with the same `AssembleResponse` (`state: "not_found"`, `missingChunks`). OpenAPI no longer documents 202 on that handler.

Enqueue / `ON CONFLICT` / the assembly worker are unchanged. After chunks exist, the same checksum still goes `created` → worker → `ok`. A later assemble POST still returns 200 + `state: "ok"` via `assembly_state_response`.

Sourcemap rewrite, Hermes parse (#266 / PR #267), releases stubs (#91), and dSYMs are out of scope.

## Test plan

- [x] `cd apps/server && cargo test --test integration_tests -- assemble` — 14 passed, 2 ignored (need `AssemblyWorker`)
- [x] Missing chunks → **200** + `state: "not_found"` + hashes in `missingChunks` (including numeric project id)
- [x] Chunks still in DB → assemble returns 200 `created`; a later POST with the job row set to `ok` returns 200 `ok`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Artifact-bundle assembly responses now consistently use HTTP 200, including when chunks are missing.
  * Missing chunks are reported through `missingChunks`, alongside the current assembly state.
  * Assembly responses now clearly support `not_found`, `created`, `assembling`, `ok`, and `error` states.
  * Waiting for assembly completion now provides a complete polling flow from missing chunks through upload and successful completion.
  * Numeric project identifiers are supported in assembly requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->