### PR TITLE
fix(server): Harden ingest durability and recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,27 @@ jobs:
           cargo run --manifest-path apps/server/Cargo.toml --bin gen_openapi --features openapi
           git diff --exit-code -- apps/server/openapi.json || \
             (echo "::error::openapi.json is out of date. Run: cd apps/server && cargo run --bin gen_openapi --features openapi" && exit 1)
+
+  # The default build is SQLite, which happily masks Postgres-only breakage
+  # (e.g. sqlx type_name/column-type mismatches only fail at decode time on
+  # Postgres). The e2e suite runs migrations and the full ingest pipeline
+  # against a real Postgres via testcontainers — the only suite that compiles
+  # under the postgres feature.
+  postgres-e2e:
+    if: github.head_ref != 'changeset-release/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          workspaces: apps/server -> target
+          key: postgres
+
+      - name: Run Postgres e2e tests
+        working-directory: apps/server
+        run: cargo test --no-default-features --features postgres --test e2e_tests

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          command: check
-          arguments: --features postgres,openapi
+          command: check advisories licenses
+          arguments: --all-features
           manifest-path: apps/server/Cargo.toml
 
   cargo-audit:
@@ -38,7 +38,7 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked --quiet
       - name: Run cargo audit
-        run: cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097
+        run: cargo audit
         working-directory: apps/server
 
   clippy:

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -54,7 +54,6 @@ dependencies = [
  "flate2",
  "foldhash",
  "futures-core",
- "h2 0.3.27",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -71,31 +70,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "zstd",
-]
-
-[[package]]
-name = "actix-http-test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061d27c2a6fea968fdaca0961ff429d23a4ec878c4f68f5d08626663ade69c80"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-server",
- "actix-service",
- "actix-tls",
- "actix-utils",
- "awc",
- "bytes",
- "futures-core",
- "http 0.2.12",
- "log",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "slab",
- "socket2 0.5.10",
- "tokio",
 ]
 
 [[package]]
@@ -184,7 +158,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tracing",
 ]
@@ -213,48 +187,6 @@ dependencies = [
  "rand 0.9.5",
  "serde",
  "serde_json",
- "tracing",
-]
-
-[[package]]
-name = "actix-test"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439022b5a7b5dac10798465029a9566e8e0cca7a6014541ed277b695691fac5f"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-http-test",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "actix-web",
- "awc",
- "futures-core",
- "futures-util",
- "log",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
-]
-
-[[package]]
-name = "actix-tls"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6176099de3f58fbddac916a7f8c6db297e021d706e7a6b99947785fee14abe9f"
-dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.5.0",
- "impl-more 0.1.9",
- "pin-project-lite",
- "tokio",
- "tokio-util",
  "tracing",
 ]
 
@@ -292,7 +224,7 @@ dependencies = [
  "foldhash",
  "futures-core",
  "futures-util",
- "impl-more 0.3.5",
+ "impl-more",
  "itoa",
  "language-tags",
  "log",
@@ -305,7 +237,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.5",
+ "socket2",
  "time",
  "tracing",
  "url",
@@ -549,39 +481,6 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "awc"
-version = "3.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7dc0207013c5059ddce268fe12045bd12b2e919318ee660c891bfe297a54f1f"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-rt",
- "actix-service",
- "actix-tls",
- "actix-utils",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "cookie",
- "derive_more",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "itoa",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand 0.9.5",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
-]
 
 [[package]]
 name = "aws-lc-rs"
@@ -1740,25 +1639,6 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
@@ -1951,7 +1831,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.18",
+ "h2",
  "http 1.5.0",
  "http-body",
  "httparse",
@@ -2038,7 +1918,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2198,12 +2078,6 @@ name = "if_chain"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
-
-[[package]]
-name = "impl-more"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "impl-more"
@@ -2425,7 +2299,7 @@ dependencies = [
  "percent-encoding",
  "quoted_printable",
  "rustls",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tokio-rustls",
  "url",
@@ -3195,7 +3069,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -3234,7 +3108,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3640,7 +3514,6 @@ dependencies = [
  "actix-multipart",
  "actix-rt",
  "actix-session",
- "actix-test",
  "actix-web",
  "argon2",
  "async-trait",
@@ -4157,16 +4030,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -4623,7 +4486,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4724,7 +4587,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.18",
+ "h2",
  "http 1.5.0",
  "http-body",
  "http-body-util",
@@ -4733,7 +4596,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.5",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -44,7 +44,6 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "base64 0.22.1",
  "bitflags 2.13.1",
  "brotli",
  "bytes",
@@ -59,12 +58,9 @@ dependencies = [
  "httpdate",
  "itoa",
  "language-tags",
- "local-channel",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.10.2",
- "sha1",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -2334,17 +2330,6 @@ name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
-
-[[package]]
-name = "local-channel"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
-dependencies = [
- "futures-core",
- "futures-sink",
- "local-waker",
-]
 
 [[package]]
 name = "local-waker"

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -15,8 +15,6 @@ actix-web = { version = "4.14.1", default-features = false, features = [
     "compress-zstd",
     "cookies",
     "unicode",
-    "compat",
-    "ws",
 ] }
 actix-rt = "2.11.0"
 

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -7,8 +7,17 @@ description = "Ultra-lightweight error tracking server compatible with Sentry SD
 license = "GPL-3.0-only"
 
 [dependencies]
-# Web framework
-actix-web = { version = "4.14.1", features = ["cookies"] }
+# Web framework (HTTP/2 is disabled until Actix moves to h2 0.4.)
+actix-web = { version = "4.14.1", default-features = false, features = [
+    "macros",
+    "compress-brotli",
+    "compress-gzip",
+    "compress-zstd",
+    "cookies",
+    "unicode",
+    "compat",
+    "ws",
+] }
 actix-rt = "2.11.0"
 
 # Session management
@@ -117,8 +126,6 @@ rustrak = { path = ".", default-features = false, features = ["test-seams"] }
 rstest = "0.26.1"
 serial_test = "4.0.1"
 
-# HTTP testing for actix-web
-actix-test = "0.1.5"
 # Note: reqwest available from main dependencies
 
 # Database testing with real PostgreSQL containers

--- a/apps/server/migrations/postgres/20260821000000_alert_history_payload.down.sql
+++ b/apps/server/migrations/postgres/20260821000000_alert_history_payload.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE alert_history DROP COLUMN payload;

--- a/apps/server/migrations/postgres/20260821000000_alert_history_payload.up.sql
+++ b/apps/server/migrations/postgres/20260821000000_alert_history_payload.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE alert_history ADD COLUMN payload JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Rows created before payload persistence cannot be reconstructed; make them
+-- terminal failures instead of leaving the retry worker stuck on `{}` forever.
+UPDATE alert_history
+SET status = 'failed',
+    error_message = 'legacy alert payload unavailable after migration',
+    next_retry_at = NULL
+WHERE status = 'pending';

--- a/apps/server/migrations/postgres/20260821010000_ingest_retry_identity.down.sql
+++ b/apps/server/migrations/postgres/20260821010000_ingest_retry_identity.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_logs_dedupe_key;
+ALTER TABLE logs DROP COLUMN IF EXISTS dedupe_key;
+DROP INDEX IF EXISTS idx_spans_standalone_identity;

--- a/apps/server/migrations/postgres/20260821010000_ingest_retry_identity.down.sql
+++ b/apps/server/migrations/postgres/20260821010000_ingest_retry_identity.down.sql
@@ -1,3 +1,2 @@
 DROP INDEX IF EXISTS idx_logs_dedupe_key;
 ALTER TABLE logs DROP COLUMN IF EXISTS dedupe_key;
-DROP INDEX IF EXISTS idx_spans_standalone_identity;

--- a/apps/server/migrations/postgres/20260821010000_ingest_retry_identity.up.sql
+++ b/apps/server/migrations/postgres/20260821010000_ingest_retry_identity.up.sql
@@ -3,6 +3,10 @@ DELETE FROM spans a
 USING spans b
 WHERE a.transaction_id IS NULL
   AND b.transaction_id IS NULL
+  AND a.trace_id IS NOT NULL
+  AND a.span_id IS NOT NULL
+  AND b.trace_id IS NOT NULL
+  AND b.span_id IS NOT NULL
   AND a.project_id = b.project_id
   AND a.trace_id = b.trace_id
   AND a.span_id = b.span_id
@@ -10,7 +14,9 @@ WHERE a.transaction_id IS NULL
 
 CREATE UNIQUE INDEX idx_spans_standalone_identity
     ON spans(project_id, trace_id, span_id)
-    WHERE transaction_id IS NULL;
+    WHERE transaction_id IS NULL
+      AND trace_id IS NOT NULL
+      AND span_id IS NOT NULL;
 
 ALTER TABLE logs ADD COLUMN dedupe_key TEXT;
 CREATE UNIQUE INDEX idx_logs_dedupe_key

--- a/apps/server/migrations/postgres/20260821010000_ingest_retry_identity.up.sql
+++ b/apps/server/migrations/postgres/20260821010000_ingest_retry_identity.up.sql
@@ -1,0 +1,18 @@
+-- A retried standalone span is the same logical span, not a new row.
+DELETE FROM spans a
+USING spans b
+WHERE a.transaction_id IS NULL
+  AND b.transaction_id IS NULL
+  AND a.project_id = b.project_id
+  AND a.trace_id = b.trace_id
+  AND a.span_id = b.span_id
+  AND a.id > b.id;
+
+CREATE UNIQUE INDEX idx_spans_standalone_identity
+    ON spans(project_id, trace_id, span_id)
+    WHERE transaction_id IS NULL;
+
+ALTER TABLE logs ADD COLUMN dedupe_key TEXT;
+CREATE UNIQUE INDEX idx_logs_dedupe_key
+    ON logs(project_id, dedupe_key)
+    WHERE dedupe_key IS NOT NULL;

--- a/apps/server/migrations/postgres/20260821010000_ingest_retry_identity.up.sql
+++ b/apps/server/migrations/postgres/20260821010000_ingest_retry_identity.up.sql
@@ -12,12 +12,6 @@ WHERE a.transaction_id IS NULL
   AND a.span_id = b.span_id
   AND a.id > b.id;
 
-CREATE UNIQUE INDEX idx_spans_standalone_identity
-    ON spans(project_id, trace_id, span_id)
-    WHERE transaction_id IS NULL
-      AND trace_id IS NOT NULL
-      AND span_id IS NOT NULL;
-
 ALTER TABLE logs ADD COLUMN dedupe_key TEXT;
 CREATE UNIQUE INDEX idx_logs_dedupe_key
     ON logs(project_id, dedupe_key)

--- a/apps/server/migrations/postgres/20260821020000_assembly_chunk_ownership.down.sql
+++ b/apps/server/migrations/postgres/20260821020000_assembly_chunk_ownership.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS assembly_job_chunks;

--- a/apps/server/migrations/postgres/20260821020000_assembly_chunk_ownership.up.sql
+++ b/apps/server/migrations/postgres/20260821020000_assembly_chunk_ownership.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE assembly_job_chunks (
+    job_id   BIGINT NOT NULL REFERENCES assembly_jobs(id) ON DELETE CASCADE,
+    checksum CHAR(40) NOT NULL REFERENCES chunk(checksum) ON DELETE RESTRICT,
+    PRIMARY KEY (job_id, checksum)
+);
+CREATE INDEX idx_assembly_job_chunks_checksum ON assembly_job_chunks(checksum);
+
+INSERT INTO assembly_job_chunks(job_id, checksum)
+SELECT jobs.id, chunks.checksum
+FROM assembly_jobs jobs
+CROSS JOIN LATERAL unnest(jobs.chunks) AS chunks(checksum)
+JOIN chunk ON chunk.checksum = chunks.checksum
+WHERE jobs.state <> 'ok';

--- a/apps/server/migrations/postgres/20260821030000_event_alert_type.down.sql
+++ b/apps/server/migrations/postgres/20260821030000_event_alert_type.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events DROP COLUMN IF EXISTS alert_type;

--- a/apps/server/migrations/postgres/20260821030000_event_alert_type.up.sql
+++ b/apps/server/migrations/postgres/20260821030000_event_alert_type.up.sql
@@ -1,1 +1,4 @@
-ALTER TABLE events ADD COLUMN alert_type TEXT;
+-- VARCHAR, not TEXT: `AlertType` derives sqlx::Type with type_name = "varchar"
+-- (models/alert.rs); sqlx's Postgres driver refuses to decode a TEXT column
+-- into it at runtime. SQLite is not affected (its migration stays TEXT).
+ALTER TABLE events ADD COLUMN alert_type VARCHAR;

--- a/apps/server/migrations/postgres/20260821030000_event_alert_type.up.sql
+++ b/apps/server/migrations/postgres/20260821030000_event_alert_type.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN alert_type TEXT;

--- a/apps/server/migrations/postgres/20260821035000_standalone_span_identity_dedup.down.sql
+++ b/apps/server/migrations/postgres/20260821035000_standalone_span_identity_dedup.down.sql
@@ -1,0 +1,2 @@
+-- Deduplication cannot be reversed; deleted duplicate rows are gone.
+SELECT 1;

--- a/apps/server/migrations/postgres/20260821035000_standalone_span_identity_dedup.up.sql
+++ b/apps/server/migrations/postgres/20260821035000_standalone_span_identity_dedup.up.sql
@@ -1,0 +1,14 @@
+-- Re-dedup immediately before the unique index build in 20260821040000: rows
+-- may have been written since the 20260821010000 dedup (e.g. by a replica
+-- still running old code during a rolling deploy), and CREATE UNIQUE INDEX
+-- CONCURRENTLY fails on duplicates instead of ignoring them.
+DELETE FROM spans a
+    USING spans b
+    WHERE a.id > b.id
+      AND a.project_id = b.project_id
+      AND a.trace_id = b.trace_id
+      AND a.span_id = b.span_id
+      AND a.transaction_id IS NULL
+      AND b.transaction_id IS NULL
+      AND a.trace_id IS NOT NULL
+      AND a.span_id IS NOT NULL;

--- a/apps/server/migrations/postgres/20260821036000_standalone_span_identity_predrop.down.sql
+++ b/apps/server/migrations/postgres/20260821036000_standalone_span_identity_predrop.down.sql
@@ -1,0 +1,2 @@
+-- Nothing to reverse: the pre-drop only removes a leftover invalid index.
+SELECT 1;

--- a/apps/server/migrations/postgres/20260821036000_standalone_span_identity_predrop.up.sql
+++ b/apps/server/migrations/postgres/20260821036000_standalone_span_identity_predrop.up.sql
@@ -1,0 +1,8 @@
+-- no-transaction
+-- An interrupted CONCURRENTLY build in 20260821040000 (connection drop,
+-- restart mid-migration) leaves an INVALID index that still owns the name:
+-- without this drop, every retry after clearing the dirty migration row would
+-- fail with "relation already exists" and require manual surgery. Must be its
+-- own single-statement migration: CONCURRENTLY refuses to run inside the
+-- implicit transaction that wraps multi-statement batches.
+DROP INDEX CONCURRENTLY IF EXISTS idx_spans_standalone_identity;

--- a/apps/server/migrations/postgres/20260821040000_standalone_span_identity_index.down.sql
+++ b/apps/server/migrations/postgres/20260821040000_standalone_span_identity_index.down.sql
@@ -1,0 +1,2 @@
+-- no-transaction
+DROP INDEX CONCURRENTLY IF EXISTS idx_spans_standalone_identity;

--- a/apps/server/migrations/postgres/20260821040000_standalone_span_identity_index.up.sql
+++ b/apps/server/migrations/postgres/20260821040000_standalone_span_identity_index.up.sql
@@ -1,0 +1,6 @@
+-- no-transaction
+CREATE UNIQUE INDEX CONCURRENTLY idx_spans_standalone_identity
+    ON spans(project_id, trace_id, span_id)
+    WHERE transaction_id IS NULL
+      AND trace_id IS NOT NULL
+      AND span_id IS NOT NULL;

--- a/apps/server/migrations/sqlite/20260821000000_alert_history_payload.down.sql
+++ b/apps/server/migrations/sqlite/20260821000000_alert_history_payload.down.sql
@@ -1,1 +1,38 @@
--- SQLite cannot drop a column without recreating the table.
+CREATE TABLE alert_history_old (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    alert_rule_id    INTEGER REFERENCES alert_rules(id) ON DELETE SET NULL,
+    integration_id   INTEGER REFERENCES alert_integrations(id) ON DELETE SET NULL,
+    issue_id         TEXT REFERENCES issues(id) ON DELETE SET NULL,
+    project_id       INTEGER REFERENCES projects(id) ON DELETE SET NULL,
+    alert_type       TEXT NOT NULL,
+    channel_type     TEXT NOT NULL,
+    channel_name     TEXT NOT NULL,
+    status           TEXT NOT NULL CHECK (status IN ('pending', 'sent', 'failed', 'skipped')),
+    attempt_count    INTEGER NOT NULL DEFAULT 0,
+    next_retry_at    TEXT,
+    error_message    TEXT,
+    http_status_code INTEGER,
+    idempotency_key  TEXT NOT NULL UNIQUE,
+    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    sent_at          TEXT
+);
+
+INSERT INTO alert_history_old (
+    id, alert_rule_id, integration_id, issue_id, project_id,
+    alert_type, channel_type, channel_name, status,
+    attempt_count, next_retry_at, error_message, http_status_code,
+    idempotency_key, created_at, sent_at
+)
+SELECT
+    id, alert_rule_id, integration_id, issue_id, project_id,
+    alert_type, channel_type, channel_name, status,
+    attempt_count, next_retry_at, error_message, http_status_code,
+    idempotency_key, created_at, sent_at
+FROM alert_history;
+
+DROP TABLE alert_history;
+ALTER TABLE alert_history_old RENAME TO alert_history;
+
+CREATE INDEX idx_alert_history_pending ON alert_history(next_retry_at) WHERE status = 'pending';
+CREATE INDEX idx_alert_history_issue ON alert_history(issue_id);
+CREATE INDEX idx_alert_history_project ON alert_history(project_id);

--- a/apps/server/migrations/sqlite/20260821000000_alert_history_payload.down.sql
+++ b/apps/server/migrations/sqlite/20260821000000_alert_history_payload.down.sql
@@ -1,0 +1,1 @@
+-- SQLite cannot drop a column without recreating the table.

--- a/apps/server/migrations/sqlite/20260821000000_alert_history_payload.up.sql
+++ b/apps/server/migrations/sqlite/20260821000000_alert_history_payload.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE alert_history ADD COLUMN payload TEXT NOT NULL DEFAULT '{}';
+
+-- Rows created before payload persistence cannot be reconstructed; make them
+-- terminal failures instead of leaving the retry worker stuck on `{}` forever.
+UPDATE alert_history
+SET status = 'failed',
+    error_message = 'legacy alert payload unavailable after migration',
+    next_retry_at = NULL
+WHERE status = 'pending';

--- a/apps/server/migrations/sqlite/20260821010000_ingest_retry_identity.down.sql
+++ b/apps/server/migrations/sqlite/20260821010000_ingest_retry_identity.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_logs_dedupe_key;
+ALTER TABLE logs DROP COLUMN dedupe_key;
+DROP INDEX IF EXISTS idx_spans_standalone_identity;

--- a/apps/server/migrations/sqlite/20260821010000_ingest_retry_identity.up.sql
+++ b/apps/server/migrations/sqlite/20260821010000_ingest_retry_identity.up.sql
@@ -1,15 +1,21 @@
 DELETE FROM spans
 WHERE transaction_id IS NULL
+  AND trace_id IS NOT NULL
+  AND span_id IS NOT NULL
   AND id NOT IN (
       SELECT MIN(id)
       FROM spans
       WHERE transaction_id IS NULL
+        AND trace_id IS NOT NULL
+        AND span_id IS NOT NULL
       GROUP BY project_id, trace_id, span_id
   );
 
 CREATE UNIQUE INDEX idx_spans_standalone_identity
     ON spans(project_id, trace_id, span_id)
-    WHERE transaction_id IS NULL;
+    WHERE transaction_id IS NULL
+      AND trace_id IS NOT NULL
+      AND span_id IS NOT NULL;
 
 ALTER TABLE logs ADD COLUMN dedupe_key TEXT;
 CREATE UNIQUE INDEX idx_logs_dedupe_key

--- a/apps/server/migrations/sqlite/20260821010000_ingest_retry_identity.up.sql
+++ b/apps/server/migrations/sqlite/20260821010000_ingest_retry_identity.up.sql
@@ -1,0 +1,17 @@
+DELETE FROM spans
+WHERE transaction_id IS NULL
+  AND id NOT IN (
+      SELECT MIN(id)
+      FROM spans
+      WHERE transaction_id IS NULL
+      GROUP BY project_id, trace_id, span_id
+  );
+
+CREATE UNIQUE INDEX idx_spans_standalone_identity
+    ON spans(project_id, trace_id, span_id)
+    WHERE transaction_id IS NULL;
+
+ALTER TABLE logs ADD COLUMN dedupe_key TEXT;
+CREATE UNIQUE INDEX idx_logs_dedupe_key
+    ON logs(project_id, dedupe_key)
+    WHERE dedupe_key IS NOT NULL;

--- a/apps/server/migrations/sqlite/20260821020000_assembly_chunk_ownership.down.sql
+++ b/apps/server/migrations/sqlite/20260821020000_assembly_chunk_ownership.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS assembly_job_chunks;

--- a/apps/server/migrations/sqlite/20260821020000_assembly_chunk_ownership.up.sql
+++ b/apps/server/migrations/sqlite/20260821020000_assembly_chunk_ownership.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE assembly_job_chunks (
+    job_id   INTEGER NOT NULL REFERENCES assembly_jobs(id) ON DELETE CASCADE,
+    checksum TEXT NOT NULL REFERENCES chunk(checksum) ON DELETE RESTRICT,
+    PRIMARY KEY (job_id, checksum)
+);
+CREATE INDEX idx_assembly_job_chunks_checksum ON assembly_job_chunks(checksum);
+
+INSERT INTO assembly_job_chunks(job_id, checksum)
+SELECT jobs.id, json_each.value
+FROM assembly_jobs jobs, json_each(jobs.chunks)
+JOIN chunk ON chunk.checksum = json_each.value
+WHERE jobs.state <> 'ok';

--- a/apps/server/migrations/sqlite/20260821030000_event_alert_type.down.sql
+++ b/apps/server/migrations/sqlite/20260821030000_event_alert_type.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events DROP COLUMN alert_type;

--- a/apps/server/migrations/sqlite/20260821030000_event_alert_type.up.sql
+++ b/apps/server/migrations/sqlite/20260821030000_event_alert_type.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN alert_type TEXT;

--- a/apps/server/src/db/mod.rs
+++ b/apps/server/src/db/mod.rs
@@ -161,3 +161,86 @@ pub async fn checkpoint_full(pool: &DbPool) -> Result<bool, sqlx::Error> {
         .await?;
     Ok(busy == 0)
 }
+
+/// Decides whether a caller still needs its own WAL checkpoint.
+///
+/// A commit is durably in the main database file once any `FULL` checkpoint
+/// that *started* after the commit completes. Tracking the start instant of
+/// the last completed checkpoint lets concurrent digests coalesce: whoever
+/// runs the checkpoint covers everyone whose commit (entry instant) preceded
+/// its start.
+#[derive(Default)]
+pub struct CheckpointGate {
+    last_completed_start: Option<std::time::Instant>,
+}
+
+impl CheckpointGate {
+    /// Whether a completed checkpoint already covers a caller that entered at
+    /// `entered` (i.e. whose commit predates that instant).
+    pub fn covers(&self, entered: std::time::Instant) -> bool {
+        self.last_completed_start
+            .is_some_and(|started| started >= entered)
+    }
+
+    /// Records a successfully completed checkpoint by its start instant.
+    pub fn record_completed(&mut self, started: std::time::Instant) {
+        self.last_completed_start = Some(started);
+    }
+}
+
+/// Runs a `FULL` checkpoint unless one already covers this caller's commit.
+///
+/// Callers that pile up behind an in-flight checkpoint coalesce: the first
+/// waiter's own checkpoint (started after every waiter entered) covers the
+/// rest, so N concurrent digests cost at most two checkpoints instead of N.
+#[cfg(feature = "sqlite")]
+pub async fn ensure_checkpointed(
+    pool: &DbPool,
+    gate: &tokio::sync::Mutex<CheckpointGate>,
+) -> Result<bool, sqlx::Error> {
+    let entered = std::time::Instant::now();
+    let mut gate = gate.lock().await;
+    if gate.covers(entered) {
+        return Ok(true);
+    }
+    let started = std::time::Instant::now();
+    let completed = checkpoint_full(pool).await?;
+    if completed {
+        gate.record_completed(started);
+    }
+    Ok(completed)
+}
+
+#[cfg(test)]
+mod checkpoint_gate_tests {
+    use super::CheckpointGate;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn skips_when_a_checkpoint_started_after_entry_has_completed() {
+        let mut gate = CheckpointGate::default();
+        let entered = Instant::now();
+        gate.record_completed(entered + Duration::from_millis(1));
+        assert!(
+            gate.covers(entered),
+            "a checkpoint that started after this caller entered covers its commit"
+        );
+    }
+
+    #[test]
+    fn does_not_skip_when_last_checkpoint_started_before_entry() {
+        let mut gate = CheckpointGate::default();
+        let started = Instant::now();
+        gate.record_completed(started);
+        assert!(
+            !gate.covers(started + Duration::from_millis(1)),
+            "a checkpoint that started before this caller entered may miss its frames"
+        );
+    }
+
+    #[test]
+    fn does_not_skip_when_no_checkpoint_has_completed() {
+        let gate = CheckpointGate::default();
+        assert!(!gate.covers(Instant::now()));
+    }
+}

--- a/apps/server/src/db/mod.rs
+++ b/apps/server/src/db/mod.rs
@@ -152,3 +152,12 @@ pub async fn run_migrations(pool: &DbPool) -> Result<(), sqlx::migrate::MigrateE
 pub async fn health_check(pool: &DbPool) -> bool {
     sqlx::query("SELECT 1").execute(pool).await.is_ok()
 }
+
+/// Runs a full SQLite WAL checkpoint and reports whether it completed.
+#[cfg(feature = "sqlite")]
+pub async fn checkpoint_full(pool: &DbPool) -> Result<bool, sqlx::Error> {
+    let busy: i64 = sqlx::query_scalar("PRAGMA wal_checkpoint(FULL)")
+        .fetch_one(pool)
+        .await?;
+    Ok(busy == 0)
+}

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -8,7 +8,7 @@ use crate::models::{AlertType, Grouping, Issue};
 use crate::services::sourcemap::SourceMapProvider;
 use crate::services::{
     calculate_grouping_key, get_denormalized_fields, hash_grouping_key, AlertService,
-    DenormalizedFields, EventService, IssueService, ProjectService, RateLimitService,
+    DenormalizedFields, EventService, ProjectService, RateLimitService,
 };
 use chrono::Utc;
 use std::path::PathBuf;
@@ -105,28 +105,8 @@ impl ErrorProcessor {
         // 4. Check for duplicates
         if EventService::exists(pool, metadata.project_id, event_id).await? {
             log::warn!("Duplicate event_id: {}", metadata.event_id);
-            if !AlertService::event_alert_exists(pool, event_id).await? {
-                if let Some(issue_id) =
-                    EventService::issue_id_for_event(pool, metadata.project_id, event_id).await?
-                {
-                    let issue = IssueService::get_by_id(pool, issue_id).await?;
-                    let alert_type = if issue.substatus.as_deref() == Some("regressed") {
-                        AlertType::Regression
-                    } else {
-                        AlertType::NewIssue
-                    };
-                    AlertService::trigger_event_alert(
-                        pool,
-                        &project,
-                        &issue,
-                        alert_type,
-                        event_id,
-                        &std::env::var("DASHBOARD_URL")
-                            .unwrap_or_else(|_| "http://localhost:3000".to_string()),
-                    )
-                    .await?;
-                }
-            }
+            // A duplicate event does not tell us whether its original digest
+            // created or regressed the issue; replay must not invent an alert.
             delete_after_success(
                 pool,
                 &self.ingest_dir,

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -15,6 +15,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use uuid::Uuid;
 
+const INVALID_EVENT_JSON_PREFIX: &str = "Invalid event JSON";
+
 /// Processes error/exception events: source-map rewrite → grouping → issue → store.
 ///
 /// Owns the deps the error pipeline needs (`ingest_dir`, `rate_limit_config`,
@@ -72,7 +74,7 @@ impl ErrorProcessor {
 
         // 2. Parse event from filesystem
         let mut event_data: serde_json::Value = serde_json::from_slice(&event_bytes)
-            .map_err(|e| AppError::Internal(format!("Invalid event JSON: {}", e)))?;
+            .map_err(|e| AppError::Internal(format!("{INVALID_EVENT_JSON_PREFIX}: {e}")))?;
 
         // 2b. Rewrite stack frames using source maps (non-fatal)
         if let Err(e) = crate::services::sourcemap::rewrite_frames(
@@ -285,10 +287,9 @@ impl Processor for ErrorProcessor {
 fn should_retain_event(err: &AppError) -> bool {
     match err.kind() {
         AppError::Database(_) => true,
-        AppError::Internal(message) => {
-            message.starts_with("Failed to read event file")
-                || message.starts_with("Invalid pending event")
-        }
+        // Unknown internal failures are safer to replay than to discard: a new
+        // transient failure must not silently become data loss.
+        AppError::Internal(message) => !message.starts_with(INVALID_EVENT_JSON_PREFIX),
         _ => false,
     }
 }
@@ -730,6 +731,12 @@ mod tests {
         )));
         assert!(should_retain_event(&AppError::Internal(
             "Invalid pending event record: truncated".to_string(),
+        )));
+        assert!(should_retain_event(&AppError::Internal(
+            "temporary database connection failure".to_string(),
+        )));
+        assert!(!should_retain_event(&AppError::Internal(
+            "Invalid event JSON: trailing data".to_string(),
         )));
         assert!(!should_retain_event(&AppError::Validation(
             "Invalid event JSON".to_string(),

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -536,7 +536,7 @@ async fn write_digest_rows(
     .await?;
 
     let (installation_count, project_count) =
-        RateLimitService::increment_quota_counters(&mut **tx, write.project_id).await?;
+        RateLimitService::increment_quota_counters(tx, write.project_id).await?;
 
     Ok((issue, created, regressed, installation_count, project_count))
 }

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -2,7 +2,8 @@ use super::{Processor, ProcessorCtx};
 use crate::config::RateLimitConfig;
 use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
-use crate::ingest::{delete_event, read_event, EventMetadata};
+use crate::ingest::storage::{delete_event_at, read_event_with_location};
+use crate::ingest::EventMetadata;
 use crate::models::{Grouping, Issue};
 use crate::services::sourcemap::SourceMapProvider;
 use crate::services::{
@@ -39,28 +40,41 @@ impl ErrorProcessor {
         }
     }
 
-    /// The digest pipeline body. Guarantees the temp file is deleted on failure.
+    /// The digest pipeline body. Retryable contention leaves the durable event queued.
     async fn process_impl(&self, metadata: &EventMetadata, ctx: &ProcessorCtx) -> AppResult<()> {
         let pool = &ctx.pool;
         let _digested_at = Utc::now();
 
-        // 0. Double-check rate limits (for backlog scenarios)
+        // 0. Read the event before quota checks so cleanup can target the exact
+        // project-scoped file that was read.
         let project = ProjectService::get_by_id(pool, metadata.project_id).await?;
-        if let Some(_exceeded) = RateLimitService::check_quota(pool, &project).await? {
+        let (event_bytes, storage_location) =
+            read_event_with_location(&self.ingest_dir, metadata.project_id, &metadata.event_id)
+                .await?;
+
+        // 1. Double-check rate limits (for backlog scenarios)
+        if let Some(_exceeded) =
+            RateLimitService::check_quota(pool, &project, &self.rate_limit_config).await?
+        {
             log::warn!(
                 "Event {} discarded due to quota exceeded (backlog)",
                 metadata.event_id
             );
-            delete_event(&self.ingest_dir, &metadata.event_id).await?;
+            delete_event_at(
+                &self.ingest_dir,
+                metadata.project_id,
+                &metadata.event_id,
+                storage_location,
+            )
+            .await?;
             return Ok(());
         }
 
-        // 1. Read event from filesystem
-        let event_bytes = read_event(&self.ingest_dir, &metadata.event_id).await?;
+        // 2. Parse event from filesystem
         let mut event_data: serde_json::Value = serde_json::from_slice(&event_bytes)
             .map_err(|e| AppError::Internal(format!("Invalid event JSON: {}", e)))?;
 
-        // 1b. Rewrite stack frames using source maps (non-fatal)
+        // 2b. Rewrite stack frames using source maps (non-fatal)
         if let Err(e) = crate::services::sourcemap::rewrite_frames(
             self.sourcemap_provider.as_ref(),
             metadata.project_id,
@@ -75,7 +89,7 @@ impl ErrorProcessor {
             );
         }
 
-        // 1c. Trim oversized fields (deep context windows, frame vars, huge
+        // 2c. Trim oversized fields (deep context windows, frame vars, huge
         // breadcrumb trails) for events whose raw payload came in above the
         // original per-item budget — see services::event_trim. Only runs for
         // the (rare) events that needed the relaxed ingest ceiling, so this
@@ -84,28 +98,34 @@ impl ErrorProcessor {
             crate::services::trim_oversized_event(&mut event_data);
         }
 
-        // 2. Parse event_id as UUID
+        // 3. Parse event_id as UUID
         let event_id = Uuid::parse_str(&metadata.event_id)
             .map_err(|_| AppError::Validation("Invalid event_id".to_string()))?;
 
-        // 3. Check for duplicates
+        // 4. Check for duplicates
         if EventService::exists(pool, metadata.project_id, event_id).await? {
             log::warn!("Duplicate event_id: {}", metadata.event_id);
-            delete_event(&self.ingest_dir, &metadata.event_id).await?;
+            delete_event_at(
+                &self.ingest_dir,
+                metadata.project_id,
+                &metadata.event_id,
+                storage_location,
+            )
+            .await?;
             return Ok(());
         }
 
-        // 4. Calculate grouping key and hash
+        // 5. Calculate grouping key and hash
         let grouping_key = calculate_grouping_key(&event_data);
         let grouping_key_hash = hash_grouping_key(&grouping_key);
 
-        // 5. Extract denormalized fields
+        // 6. Extract denormalized fields
         let denormalized = get_denormalized_fields(&event_data);
 
-        // 6+7. Write the digest: grouping, issue, the event itself and the
+        // 7+8. Write the digest: grouping, issue, the event itself and the
         // project's stored-event counter, in one transaction, retried as a
         // whole when SQLite reports the database busy.
-        let (issue, issue_created, regressed) = write_digest(
+        let (issue, issue_created, regressed, installation_count, project_count) = write_digest(
             pool,
             &DigestWrite {
                 event_id,
@@ -123,18 +143,50 @@ impl ErrorProcessor {
         )
         .await?;
 
-        // 8b. Sentry-parity platform auto-detection (set once, never overwritten)
+        // 9b. Sentry-parity platform auto-detection (set once, never overwritten).
+        // Best-effort: the digest transaction already committed the event, so
+        // ancillary project metadata must not make the durable event fail.
         if let Some(event_platform) = event_data.get("platform").and_then(|p| p.as_str()) {
-            ProjectService::infer_platform_from_event(pool, metadata.project_id, event_platform)
-                .await?;
+            if let Err(e) =
+                ProjectService::infer_platform_from_event(pool, metadata.project_id, event_platform)
+                    .await
+            {
+                log::warn!(
+                    "platform inference failed for project {} (best-effort; a later event can self-heal): {:?}",
+                    metadata.project_id,
+                    e
+                );
+            }
         }
 
-        // Update rate limiting quotas (handles digested_event_count)
-        RateLimitService::update_quota_state(pool, metadata.project_id, &self.rate_limit_config)
-            .await?;
+        // Update rate limiting quotas (handles digested_event_count).
+        // Best-effort: the digest transaction already committed the event and
+        // its counters; a refresh failure must not make the async processor
+        // report a durable event as failed. A later digest can re-advance state.
+        if let Err(e) = RateLimitService::update_quota_state(
+            pool,
+            metadata.project_id,
+            &self.rate_limit_config,
+            installation_count,
+            project_count,
+        )
+        .await
+        {
+            log::warn!(
+                "quota state update failed for project {} (best-effort; a later digest can self-heal): {:?}",
+                metadata.project_id,
+                e
+            );
+        }
 
-        // 9. Delete temporary file
-        delete_event(&self.ingest_dir, &metadata.event_id).await?;
+        // 10. Delete the durable event file
+        delete_event_at(
+            &self.ingest_dir,
+            metadata.project_id,
+            &metadata.event_id,
+            storage_location,
+        )
+        .await?;
 
         log::info!(
             "Digested event {} -> issue {} ({})",
@@ -143,7 +195,7 @@ impl ErrorProcessor {
             if issue_created { "new" } else { "existing" }
         );
 
-        // 10. Trigger alerts for new issues and regressions
+        // 11. Trigger alerts for new issues and regressions
         if issue_created || regressed {
             let pool = pool.clone();
             let project = project.clone();
@@ -174,16 +226,52 @@ impl Processor for ErrorProcessor {
 
     async fn process(&self, metadata: EventMetadata, ctx: &ProcessorCtx) -> AppResult<()> {
         let result = self.process_impl(&metadata, ctx).await;
-        if result.is_err() {
-            if let Err(e) = delete_event(&self.ingest_dir, &metadata.event_id).await {
-                log::warn!(
-                    "Failed to clean up orphaned event file {}: {:?}",
+        if let Err(e) = &result {
+            if should_retain_event(e) {
+                return result;
+            }
+            match read_event_with_location(
+                &self.ingest_dir,
+                metadata.project_id,
+                &metadata.event_id,
+            )
+            .await
+            {
+                Ok((_, location)) => {
+                    if let Err(e) = delete_event_at(
+                        &self.ingest_dir,
+                        metadata.project_id,
+                        &metadata.event_id,
+                        location,
+                    )
+                    .await
+                    {
+                        log::warn!(
+                            "Failed to clean up orphaned event file {}: {:?}",
+                            metadata.event_id,
+                            e
+                        );
+                    }
+                }
+                Err(e) => log::warn!(
+                    "Failed to locate orphaned event file {}: {:?}",
                     metadata.event_id,
                     e
-                );
+                ),
             }
         }
         result
+    }
+}
+
+fn should_retain_event(err: &AppError) -> bool {
+    match err.kind() {
+        AppError::Database(_) => true,
+        AppError::Internal(message) => {
+            message.starts_with("Failed to read event file")
+                || message.starts_with("Invalid pending event")
+        }
+        _ => false,
     }
 }
 
@@ -201,7 +289,7 @@ fn sqlite_retry_delay(attempt: usize) -> std::time::Duration {
 /// 261, 517, 773). Always false on Postgres, whose SQLSTATEs never collide
 /// with these. Pool exhaustion is deliberately excluded: it is a capacity
 /// signal, and retrying it only lengthens the queue that caused it.
-fn is_retryable_write_contention(err: &AppError) -> bool {
+pub(crate) fn is_retryable_write_contention(err: &AppError) -> bool {
     match err.kind() {
         AppError::Database(sqlx::Error::Database(db)) => {
             db.code().as_deref().is_some_and(is_sqlite_busy_code)
@@ -240,8 +328,11 @@ struct DigestWrite<'a> {
 /// triggers: a per-project advisory lock serializes issue creation and no busy
 /// code is ever reported.
 ///
-/// Returns the issue plus whether it was created and whether it regressed.
-async fn write_digest(pool: &DbPool, write: &DigestWrite<'_>) -> AppResult<(Issue, bool, bool)> {
+/// Returns the issue, lifecycle flags, and committed quota-counter values.
+async fn write_digest(
+    pool: &DbPool,
+    write: &DigestWrite<'_>,
+) -> AppResult<(Issue, bool, bool, i64, i64)> {
     let mut attempt = 0usize;
     let event_id = write.raw_event_id;
     loop {
@@ -281,7 +372,7 @@ async fn write_digest(pool: &DbPool, write: &DigestWrite<'_>) -> AppResult<(Issu
 async fn write_digest_once(
     pool: &DbPool,
     write: &DigestWrite<'_>,
-) -> AppResult<(Issue, bool, bool)> {
+) -> AppResult<(Issue, bool, bool, i64, i64)> {
     // Start a write transaction. On SQLite this is `BEGIN IMMEDIATE` so the
     // read-then-write below (SELECT MAX(digest_order) → INSERT) takes the write
     // lock up front instead of failing with "database is locked" on upgrade.
@@ -322,7 +413,7 @@ async fn write_digest_once(
 async fn write_digest_rows(
     tx: &mut sqlx::Transaction<'_, DbBackend>,
     write: &DigestWrite<'_>,
-) -> AppResult<(Issue, bool, bool)> {
+) -> AppResult<(Issue, bool, bool, i64, i64)> {
     let (issue, grouping, created, regressed) = find_or_create_issue_and_grouping_inner(
         tx,
         write.project_id,
@@ -351,12 +442,10 @@ async fn write_digest_rows(
     )
     .await?;
 
-    sqlx::query("UPDATE projects SET stored_event_count = stored_event_count + 1 WHERE id = $1")
-        .bind(write.project_id)
-        .execute(&mut **tx)
-        .await?;
+    let (installation_count, project_count) =
+        RateLimitService::increment_quota_counters(&mut **tx, write.project_id).await?;
 
-    Ok((issue, created, regressed))
+    Ok((issue, created, regressed, installation_count, project_count))
 }
 
 /// Inner function that performs the actual find-or-create logic within a transaction
@@ -552,6 +641,22 @@ mod tests {
         // add three more waiters to the queue that caused it.
         assert!(!is_retryable_write_contention(&AppError::Database(
             sqlx::Error::PoolTimedOut
+        )));
+    }
+
+    #[test]
+    fn database_and_event_read_failures_are_retained_for_recovery() {
+        assert!(should_retain_event(&AppError::Database(
+            sqlx::Error::PoolTimedOut
+        )));
+        assert!(should_retain_event(&AppError::Internal(
+            "Failed to read event file: connection reset".to_string(),
+        )));
+        assert!(should_retain_event(&AppError::Internal(
+            "Invalid pending event record: truncated".to_string(),
+        )));
+        assert!(!should_retain_event(&AppError::Validation(
+            "Invalid event JSON".to_string(),
         )));
     }
 }

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -110,7 +110,14 @@ impl ErrorProcessor {
             let existing =
                 EventService::get_by_event_id(pool, metadata.project_id, event_id).await?;
             if let (Some(alert_type), Some(issue_id)) = (existing.alert_type, existing.issue_id) {
-                if !AlertService::event_alert_exists(pool, event_id, alert_type).await? {
+                if !AlertService::event_alert_exists(
+                    pool,
+                    metadata.project_id,
+                    event_id,
+                    alert_type,
+                )
+                .await?
+                {
                     let issue = IssueService::get_by_id(pool, issue_id).await?;
                     AlertService::trigger_event_alert(
                         pool,

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -182,23 +182,39 @@ impl ErrorProcessor {
         }
 
         // Update rate limiting quotas (handles digested_event_count).
-        // Best-effort: the digest transaction already committed the event and
-        // its counters; a refresh failure must not make the async processor
-        // report a durable event as failed. A later digest can re-advance state.
-        if let Err(e) = RateLimitService::update_quota_state(
-            pool,
-            metadata.project_id,
-            &self.rate_limit_config,
-            installation_count,
-            project_count,
-        )
-        .await
-        {
-            log::warn!(
-                "quota state update failed for project {} (best-effort; a later digest can self-heal): {:?}",
+        // Best-effort: counters already committed with the event; a failed
+        // quota-state refresh self-heals on the next digest and must not
+        // fail an event that is already durable. One retry on contention
+        // absorbs a collision with the next digest's transaction.
+        let mut quota_attempt = 0;
+        loop {
+            match RateLimitService::update_quota_state(
+                pool,
                 metadata.project_id,
-                e
-            );
+                &self.rate_limit_config,
+                installation_count,
+                project_count,
+            )
+            .await
+            {
+                Ok(()) => break,
+                Err(e)
+                    if should_retry_quota_state(
+                        quota_attempt,
+                        is_retryable_write_contention(&e),
+                    ) =>
+                {
+                    tokio::time::sleep(sqlite_retry_delay(quota_attempt)).await;
+                    quota_attempt += 1;
+                }
+                Err(e) => {
+                    log::warn!(
+                        "quota state update failed for project {} (best-effort, will self-heal): {:?}",
+                        metadata.project_id, e
+                    );
+                    break;
+                }
+            }
         }
 
         // 10. Persist alert history before deleting the only durable source.
@@ -297,6 +313,16 @@ fn should_retain_event(err: &AppError) -> bool {
 /// Write attempts per digest on SQLite. Bounded: sustained contention
 /// fails fast instead of piling up more waiters.
 const MAX_SQLITE_WRITE_ATTEMPTS: usize = 3;
+
+/// Attempts for the post-commit quota-state check: one 50ms retry absorbs
+/// a collision with the next digest's transaction, then warn and self-heal.
+const QUOTA_STATE_ATTEMPTS: usize = 2;
+
+/// Whether to retry the quota-state check: transient contention only,
+/// at most [`QUOTA_STATE_ATTEMPTS`] times.
+fn should_retry_quota_state(attempt: usize, contention: bool) -> bool {
+    attempt + 1 < QUOTA_STATE_ATTEMPTS && contention
+}
 
 /// Backoff before retry `attempt` (0-based): 50ms, then 100ms — brief,
 /// so writers that timed out together don't retry in lockstep.
@@ -653,6 +679,9 @@ mod tests {
     fn only_lock_contention_is_retryable() {
         // A busy database is a wait; everything else is a decision the retry
         // loop cannot change by trying again.
+        assert!(should_retry_quota_state(0, true));
+        assert!(!should_retry_quota_state(1, true));
+        assert!(!should_retry_quota_state(0, false));
         assert!(!is_retryable_write_contention(&AppError::Database(
             sqlx::Error::RowNotFound
         )));

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -27,6 +27,8 @@ pub struct ErrorProcessor {
     ingest_dir: PathBuf,
     rate_limit_config: RateLimitConfig,
     sourcemap_provider: Arc<dyn SourceMapProvider>,
+    // Coalesces SQLite durability checkpoints across concurrent digests.
+    checkpoint_gate: tokio::sync::Mutex<crate::db::CheckpointGate>,
 }
 
 impl ErrorProcessor {
@@ -39,6 +41,7 @@ impl ErrorProcessor {
             ingest_dir,
             rate_limit_config,
             sourcemap_provider,
+            checkpoint_gate: tokio::sync::Mutex::new(crate::db::CheckpointGate::default()),
         }
     }
 
@@ -133,6 +136,7 @@ impl ErrorProcessor {
             }
             delete_after_success(
                 pool,
+                &self.checkpoint_gate,
                 &self.ingest_dir,
                 metadata.project_id,
                 &metadata.event_id,
@@ -245,6 +249,7 @@ impl ErrorProcessor {
         // requires a successful durability checkpoint.
         delete_after_success(
             pool,
+            &self.checkpoint_gate,
             &self.ingest_dir,
             metadata.project_id,
             &metadata.event_id,
@@ -319,6 +324,7 @@ fn should_retain_event(err: &AppError) -> bool {
 #[cfg(feature = "sqlite")]
 async fn delete_after_success(
     pool: &DbPool,
+    checkpoint_gate: &tokio::sync::Mutex<crate::db::CheckpointGate>,
     ingest_dir: &std::path::Path,
     project_id: i32,
     event_id: &str,
@@ -333,7 +339,7 @@ async fn delete_after_success(
     }
 
     for attempt in 0..3 {
-        if crate::db::checkpoint_full(pool).await? {
+        if crate::db::ensure_checkpointed(pool, checkpoint_gate).await? {
             delete_event_at(ingest_dir, project_id, event_id, storage_location).await?;
             return Ok(());
         }
@@ -352,6 +358,7 @@ async fn delete_after_success(
 #[cfg(feature = "postgres")]
 async fn delete_after_success(
     _pool: &DbPool,
+    _checkpoint_gate: &tokio::sync::Mutex<crate::db::CheckpointGate>,
     ingest_dir: &std::path::Path,
     project_id: i32,
     event_id: &str,

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -8,7 +8,7 @@ use crate::models::{AlertType, Grouping, Issue};
 use crate::services::sourcemap::SourceMapProvider;
 use crate::services::{
     calculate_grouping_key, get_denormalized_fields, hash_grouping_key, AlertService,
-    DenormalizedFields, EventService, ProjectService, RateLimitService,
+    DenormalizedFields, EventService, IssueService, ProjectService, RateLimitService,
 };
 use chrono::Utc;
 use std::path::PathBuf;
@@ -107,8 +107,23 @@ impl ErrorProcessor {
         // 4. Check for duplicates
         if EventService::exists(pool, metadata.project_id, event_id).await? {
             log::warn!("Duplicate event_id: {}", metadata.event_id);
-            // A duplicate event does not tell us whether its original digest
-            // created or regressed the issue; replay must not invent an alert.
+            let existing =
+                EventService::get_by_event_id(pool, metadata.project_id, event_id).await?;
+            if let (Some(alert_type), Some(issue_id)) = (existing.alert_type, existing.issue_id) {
+                if !AlertService::event_alert_exists(pool, event_id, alert_type).await? {
+                    let issue = IssueService::get_by_id(pool, issue_id).await?;
+                    AlertService::trigger_event_alert(
+                        pool,
+                        &project,
+                        &issue,
+                        alert_type,
+                        event_id,
+                        &std::env::var("DASHBOARD_URL")
+                            .unwrap_or_else(|_| "http://localhost:3000".to_string()),
+                    )
+                    .await?;
+                }
+            }
             delete_after_success(
                 pool,
                 &self.ingest_dir,
@@ -513,6 +528,7 @@ async fn write_digest_rows(
         write.timestamp,
         write.denormalized,
         write.remote_addr,
+        alert_type_for_lifecycle(created, regressed),
     )
     .await?;
 
@@ -683,6 +699,16 @@ async fn find_or_create_issue_and_grouping_inner(
     Ok((issue, grouping, true, false))
 }
 
+fn alert_type_for_lifecycle(created: bool, regressed: bool) -> Option<AlertType> {
+    if created {
+        Some(AlertType::NewIssue)
+    } else if regressed {
+        Some(AlertType::Regression)
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -696,6 +722,19 @@ mod tests {
             !is_sqlite_busy_code("2067"),
             "a unique-constraint code is not a busy error"
         );
+    }
+
+    #[test]
+    fn persists_only_alerting_lifecycles() {
+        assert_eq!(
+            alert_type_for_lifecycle(true, false),
+            Some(AlertType::NewIssue)
+        );
+        assert_eq!(
+            alert_type_for_lifecycle(false, true),
+            Some(AlertType::Regression)
+        );
+        assert_eq!(alert_type_for_lifecycle(false, false), None);
     }
 
     #[test]

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -4,11 +4,11 @@ use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
 use crate::ingest::storage::{delete_event_at, read_event_with_location};
 use crate::ingest::EventMetadata;
-use crate::models::{Grouping, Issue};
+use crate::models::{AlertType, Grouping, Issue};
 use crate::services::sourcemap::SourceMapProvider;
 use crate::services::{
     calculate_grouping_key, get_denormalized_fields, hash_grouping_key, AlertService,
-    DenormalizedFields, EventService, ProjectService, RateLimitService,
+    DenormalizedFields, EventService, IssueService, ProjectService, RateLimitService,
 };
 use chrono::Utc;
 use std::path::PathBuf;
@@ -105,6 +105,28 @@ impl ErrorProcessor {
         // 4. Check for duplicates
         if EventService::exists(pool, metadata.project_id, event_id).await? {
             log::warn!("Duplicate event_id: {}", metadata.event_id);
+            if !AlertService::event_alert_exists(pool, event_id).await? {
+                if let Some(issue_id) =
+                    EventService::issue_id_for_event(pool, metadata.project_id, event_id).await?
+                {
+                    let issue = IssueService::get_by_id(pool, issue_id).await?;
+                    let alert_type = if issue.substatus.as_deref() == Some("regressed") {
+                        AlertType::Regression
+                    } else {
+                        AlertType::NewIssue
+                    };
+                    AlertService::trigger_event_alert(
+                        pool,
+                        &project,
+                        &issue,
+                        alert_type,
+                        event_id,
+                        &std::env::var("DASHBOARD_URL")
+                            .unwrap_or_else(|_| "http://localhost:3000".to_string()),
+                    )
+                    .await?;
+                }
+            }
             delete_event_at(
                 &self.ingest_dir,
                 metadata.project_id,
@@ -179,7 +201,26 @@ impl ErrorProcessor {
             );
         }
 
-        // 10. Delete the durable event file
+        // 10. Persist alert history before deleting the only durable source.
+        if issue_created || regressed {
+            let alert_type = if issue_created {
+                AlertType::NewIssue
+            } else {
+                AlertType::Regression
+            };
+            AlertService::trigger_event_alert(
+                pool,
+                &project,
+                &issue,
+                alert_type,
+                event_id,
+                &std::env::var("DASHBOARD_URL")
+                    .unwrap_or_else(|_| "http://localhost:3000".to_string()),
+            )
+            .await?;
+        }
+
+        // 11. Delete the durable event file only after the alert is enqueued.
         delete_event_at(
             &self.ingest_dir,
             metadata.project_id,
@@ -194,28 +235,6 @@ impl ErrorProcessor {
             issue.id,
             if issue_created { "new" } else { "existing" }
         );
-
-        // 11. Trigger alerts for new issues and regressions
-        if issue_created || regressed {
-            let pool = pool.clone();
-            let project = project.clone();
-            let issue = issue.clone();
-            let dashboard_url = std::env::var("DASHBOARD_URL")
-                .unwrap_or_else(|_| "http://localhost:3000".to_string());
-
-            tokio::spawn(async move {
-                let result = if issue_created {
-                    AlertService::trigger_new_issue_alert(&pool, &project, &issue, &dashboard_url)
-                        .await
-                } else {
-                    AlertService::trigger_regression_alert(&pool, &project, &issue, &dashboard_url)
-                        .await
-                };
-                if let Err(e) = result {
-                    log::error!("Failed to trigger issue alert: {}", e);
-                }
-            });
-        }
 
         Ok(())
     }

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -40,7 +40,7 @@ impl ErrorProcessor {
         }
     }
 
-    /// The digest pipeline body. Retryable contention leaves the durable event queued.
+    /// Runs the digest pipeline; retryable contention leaves the durable event queued.
     async fn process_impl(&self, metadata: &EventMetadata, ctx: &ProcessorCtx) -> AppResult<()> {
         let pool = &ctx.pool;
         let _digested_at = Utc::now();

--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -127,7 +127,8 @@ impl ErrorProcessor {
                     .await?;
                 }
             }
-            delete_event_at(
+            delete_after_success(
+                pool,
                 &self.ingest_dir,
                 metadata.project_id,
                 &metadata.event_id,
@@ -236,8 +237,10 @@ impl ErrorProcessor {
             .await?;
         }
 
-        // 11. Delete the durable event file only after the alert is enqueued.
-        delete_event_at(
+        // 11. Delete after the event and alert writes complete; SQLite also
+        // requires a successful durability checkpoint.
+        delete_after_success(
+            pool,
             &self.ingest_dir,
             metadata.project_id,
             &metadata.event_id,
@@ -308,6 +311,51 @@ fn should_retain_event(err: &AppError) -> bool {
         }
         _ => false,
     }
+}
+
+#[cfg(feature = "sqlite")]
+async fn delete_after_success(
+    pool: &DbPool,
+    ingest_dir: &std::path::Path,
+    project_id: i32,
+    event_id: &str,
+    storage_location: crate::ingest::storage::EventStorageLocation,
+) -> AppResult<()> {
+    if matches!(
+        storage_location,
+        crate::ingest::storage::EventStorageLocation::Legacy
+    ) {
+        delete_event_at(ingest_dir, project_id, event_id, storage_location).await?;
+        return Ok(());
+    }
+
+    for attempt in 0..3 {
+        if crate::db::checkpoint_full(pool).await? {
+            delete_event_at(ingest_dir, project_id, event_id, storage_location).await?;
+            return Ok(());
+        }
+        if attempt < 2 {
+            tokio::time::sleep(sqlite_retry_delay(attempt)).await;
+        }
+    }
+
+    log::warn!(
+        "SQLite durability checkpoint busy; retaining event file {}",
+        event_id
+    );
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+async fn delete_after_success(
+    _pool: &DbPool,
+    ingest_dir: &std::path::Path,
+    project_id: i32,
+    event_id: &str,
+    storage_location: crate::ingest::storage::EventStorageLocation,
+) -> AppResult<()> {
+    delete_event_at(ingest_dir, project_id, event_id, storage_location).await?;
+    Ok(())
 }
 
 /// Write attempts per digest on SQLite. Bounded: sustained contention

--- a/apps/server/src/digest/processors/logs.rs
+++ b/apps/server/src/digest/processors/logs.rs
@@ -28,7 +28,7 @@ impl Processor for LogsProcessor {
 
         for (index, log) in logs.into_iter().enumerate() {
             let id = Uuid::new_v4();
-            let dedupe_key = format!("{container_hash}:{index}");
+            let dedupe_key = dedupe_key(&container_hash, index, ctx.event_id);
             let timestamp = epoch_to_datetime(log.timestamp).unwrap_or(ctx.ingested_at);
             let level = normalize_level(&log.level);
             let severity_number = severity_number(&level);
@@ -68,6 +68,10 @@ impl Processor for LogsProcessor {
         tx.commit().await?;
         Ok(())
     }
+}
+
+fn dedupe_key(container_hash: &str, index: usize, delivery_id: Uuid) -> String {
+    format!("{container_hash}:{delivery_id}:{index}")
 }
 
 /// Converts an epoch-seconds float (with sub-second precision) to a UTC instant.
@@ -124,5 +128,26 @@ fn empty_to_none(s: &str) -> Option<String> {
         None
     } else {
         Some(s.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dedupe_key;
+    use uuid::Uuid;
+
+    #[test]
+    fn log_dedupe_key_distinguishes_deliveries() {
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+
+        assert_eq!(
+            dedupe_key("container", 0, first),
+            dedupe_key("container", 0, first)
+        );
+        assert_ne!(
+            dedupe_key("container", 0, first),
+            dedupe_key("container", 0, second)
+        );
     }
 }

--- a/apps/server/src/digest/processors/logs.rs
+++ b/apps/server/src/digest/processors/logs.rs
@@ -2,6 +2,7 @@ use super::{Processor, ProcessorCtx};
 use crate::error::AppResult;
 use crate::models::log::{LogContainer, LogItem};
 use chrono::{DateTime, TimeZone, Utc};
+use sha1::{Digest as _, Sha1};
 use uuid::Uuid;
 
 /// Processor for standalone logs (Sentry "log" item type).
@@ -23,9 +24,11 @@ impl Processor for LogsProcessor {
         // batch is harder to reason about than an all-or-nothing one, and the
         // SDK will resend on failure.
         let mut tx = ctx.pool.begin().await?;
+        let container_hash = hex::encode(Sha1::digest(&work));
 
-        for log in logs {
+        for (index, log) in logs.into_iter().enumerate() {
             let id = Uuid::new_v4();
+            let dedupe_key = format!("{container_hash}:{index}");
             let timestamp = epoch_to_datetime(log.timestamp).unwrap_or(ctx.ingested_at);
             let level = normalize_level(&log.level);
             let severity_number = severity_number(&level);
@@ -33,20 +36,23 @@ impl Processor for LogsProcessor {
             sqlx::query(
                 r#"
                 INSERT INTO logs (
-                    id, project_id,
+                    id, project_id, dedupe_key,
                     trace_id, span_id,
                     level, severity_number, body, attributes,
                     timestamp, ingested_at
                 ) VALUES (
-                    $1, $2,
-                    $3, $4,
-                    $5, $6, $7, $8,
-                    $9, $10
+                    $1, $2, $3,
+                    $4, $5,
+                    $6, $7, $8, $9,
+                    $10, $11
                 )
+                ON CONFLICT (project_id, dedupe_key)
+                    WHERE dedupe_key IS NOT NULL DO NOTHING
                 "#,
             )
             .bind(id)
             .bind(ctx.project_id)
+            .bind(dedupe_key)
             .bind(empty_to_none(&log.trace_id))
             .bind(log.span_id.as_deref())
             .bind(&level)

--- a/apps/server/src/digest/processors/mod.rs
+++ b/apps/server/src/digest/processors/mod.rs
@@ -5,6 +5,7 @@ pub mod span;
 pub mod span_v2;
 pub mod transaction;
 
+pub(crate) use event::is_retryable_write_contention;
 pub use event::ErrorProcessor;
 pub use logs::LogsProcessor;
 pub use session::{SessionItem, SessionProcessor};

--- a/apps/server/src/digest/processors/session.rs
+++ b/apps/server/src/digest/processors/session.rs
@@ -29,6 +29,13 @@ impl Processor for SessionProcessor {
     type Input = SessionItem;
 
     async fn process(&self, work: SessionItem, ctx: &ProcessorCtx) -> AppResult<()> {
+        // No dedup identity, deliberately: session counts are additive counters
+        // upstream too. Relay never dedups retried session envelopes — its
+        // session pipeline has no idempotency anywhere and extracts plain
+        // Counter metrics (relay-server/src/processing/sessions/,
+        // metrics_extraction/sessions/types.rs BucketValue::Counter), so an SDK
+        // resend double-counts in real Sentry as well. Matching that is
+        // Sentry parity, not a gap.
         if let Some(agg) = &self.aggregator {
             match work {
                 SessionItem::Update(update) => {

--- a/apps/server/src/digest/processors/session.rs
+++ b/apps/server/src/digest/processors/session.rs
@@ -38,6 +38,7 @@ impl Processor for SessionProcessor {
                     agg.ingest_aggregates(ctx.project_id, &aggregates).await;
                 }
             }
+            agg.flush().await?;
         }
         Ok(())
     }

--- a/apps/server/src/digest/processors/span.rs
+++ b/apps/server/src/digest/processors/span.rs
@@ -176,7 +176,9 @@ impl SpanProcessor {
                 $26, $27, $28, $29, $30
             )
             ON CONFLICT (project_id, trace_id, span_id)
-                WHERE transaction_id IS NULL DO NOTHING
+                WHERE transaction_id IS NULL
+                  AND trace_id IS NOT NULL
+                  AND span_id IS NOT NULL DO NOTHING
             "#,
             )
             .bind(Uuid::new_v4())

--- a/apps/server/src/digest/processors/span.rs
+++ b/apps/server/src/digest/processors/span.rs
@@ -6,20 +6,39 @@ use uuid::Uuid;
 
 pub struct SpanProcessor;
 
-impl Processor for SpanProcessor {
-    type Input = Vec<u8>;
+struct ParsedSpan {
+    span_id: String,
+    trace_id: String,
+    start_timestamp: DateTime<Utc>,
+    timestamp: DateTime<Utc>,
+    duration_ms: Option<f64>,
+    exclusive_time_ms: Option<f64>,
+    op: Option<String>,
+    gen_ai: GenAiColumns,
+    parent_span_id: Option<String>,
+    description: Option<String>,
+    status: Option<String>,
+    segment_id: Option<String>,
+    is_segment: bool,
+    platform: Option<String>,
+    release: Option<String>,
+    environment: Option<String>,
+    tags: Option<serde_json::Value>,
+    data: serde_json::Value,
+}
 
-    /// Stores a standalone span payload (Sentry "span" item type — Relay's
-    /// legacy schema, one flat span object per envelope item, NOT a
-    /// container like logs) into the shared `spans` table with
-    /// `transaction_id = NULL`. Mirrors `TransactionProcessor::insert_span`'s
-    /// column extraction so both producers write a consistent row shape.
-    async fn process(&self, work: Vec<u8>, ctx: &ProcessorCtx) -> AppResult<()> {
-        let mut data: serde_json::Value = serde_json::from_slice(&work)
-            .map_err(|e| AppError::Validation(format!("Invalid span JSON: {}", e)))?;
+/// Bound parsed-span memory while batching.
+const SPAN_BATCH_CHUNK: usize = 64;
 
-        // Mirrors Relay's DiscardReason::InvalidSpan — span_id and trace_id
-        // are required for a standalone span to be accepted.
+impl SpanProcessor {
+    /// Parses and validates one standalone span payload (Relay's legacy
+    /// "span" schema — one flat span object per envelope item).
+    fn parse_item(work: &[u8]) -> AppResult<ParsedSpan> {
+        let mut data: serde_json::Value = serde_json::from_slice(work)
+            .map_err(|e| AppError::Validation(format!("Invalid span JSON: {e}")))?;
+
+        // span_id and trace_id are required for a standalone span to be
+        // accepted.
         let span_id = data
             .get("span_id")
             .and_then(|v| v.as_str())
@@ -33,9 +52,8 @@ impl Processor for SpanProcessor {
             .map(str::to_string)
             .ok_or_else(|| AppError::Validation("span missing trace_id".to_string()))?;
 
-        // Both timestamps are required for a standalone span — Relay's
-        // `validate_standalone_span` rejects the span outright when either is
-        // absent, so accepting it here would store rows Sentry would discard.
+        // Both timestamps are required — Relay's `validate_standalone_span`
+        // rejects the span outright when either is absent.
         let start_timestamp = extract_timestamp(&data, "start_timestamp")
             .ok_or_else(|| AppError::Validation("span missing start_timestamp".to_string()))?;
         let timestamp = extract_timestamp(&data, "timestamp")
@@ -102,8 +120,35 @@ impl Processor for SpanProcessor {
 
         let tags = data.get("tags").cloned();
 
-        sqlx::query(
-            r#"
+        Ok(ParsedSpan {
+            span_id,
+            trace_id,
+            start_timestamp,
+            timestamp,
+            duration_ms,
+            exclusive_time_ms,
+            op,
+            gen_ai,
+            parent_span_id,
+            description,
+            status,
+            segment_id,
+            is_segment,
+            platform,
+            release,
+            environment,
+            tags,
+            data,
+        })
+    }
+
+    /// Writes one chunk in one transaction.
+    async fn insert_all(&self, ctx: &ProcessorCtx, parsed: Vec<ParsedSpan>) -> AppResult<()> {
+        let mut tx = ctx.pool.begin().await?;
+
+        for item in parsed {
+            sqlx::query(
+                r#"
             INSERT INTO spans (
                 id, transaction_id, project_id,
                 span_id, trace_id, parent_span_id,
@@ -133,41 +178,73 @@ impl Processor for SpanProcessor {
             ON CONFLICT (project_id, trace_id, span_id)
                 WHERE transaction_id IS NULL DO NOTHING
             "#,
-        )
-        .bind(Uuid::new_v4())
-        .bind(ctx.project_id)
-        .bind(span_id)
-        .bind(trace_id)
-        .bind(parent_span_id)
-        .bind(op)
-        .bind(description)
-        .bind(status)
-        .bind(start_timestamp)
-        .bind(timestamp)
-        .bind(duration_ms)
-        .bind(exclusive_time_ms)
-        .bind(is_segment)
-        .bind(segment_id)
-        .bind(platform)
-        .bind(release)
-        .bind(environment)
-        .bind(tags)
-        .bind(serde_json::json!(data))
-        .bind(gen_ai.operation_type)
-        .bind(gen_ai.agent_name)
-        .bind(gen_ai.request_model)
-        .bind(gen_ai.response_model)
-        .bind(gen_ai.tool_name)
-        .bind(gen_ai.conversation_id)
-        .bind(gen_ai.usage_input_tokens)
-        .bind(gen_ai.usage_output_tokens)
-        .bind(gen_ai.usage_total_tokens)
-        .bind(gen_ai.usage_cached_input_tokens)
-        .bind(gen_ai.usage_reasoning_output_tokens)
-        .execute(&ctx.pool)
-        .await?;
+            )
+            .bind(Uuid::new_v4())
+            .bind(ctx.project_id)
+            .bind(item.span_id)
+            .bind(item.trace_id)
+            .bind(item.parent_span_id)
+            .bind(item.op)
+            .bind(item.description)
+            .bind(item.status)
+            .bind(item.start_timestamp)
+            .bind(item.timestamp)
+            .bind(item.duration_ms)
+            .bind(item.exclusive_time_ms)
+            .bind(item.is_segment)
+            .bind(item.segment_id)
+            .bind(item.platform)
+            .bind(item.release)
+            .bind(item.environment)
+            .bind(item.tags)
+            .bind(item.data)
+            .bind(item.gen_ai.operation_type)
+            .bind(item.gen_ai.agent_name)
+            .bind(item.gen_ai.request_model)
+            .bind(item.gen_ai.response_model)
+            .bind(item.gen_ai.tool_name)
+            .bind(item.gen_ai.conversation_id)
+            .bind(item.gen_ai.usage_input_tokens)
+            .bind(item.gen_ai.usage_output_tokens)
+            .bind(item.gen_ai.usage_total_tokens)
+            .bind(item.gen_ai.usage_cached_input_tokens)
+            .bind(item.gen_ai.usage_reasoning_output_tokens)
+            .execute(&mut *tx)
+            .await?;
+        }
 
+        tx.commit().await?;
         Ok(())
+    }
+
+    /// Writes items in bounded transactions and skips malformed items.
+    pub async fn process_batch(&self, items: Vec<Vec<u8>>, ctx: &ProcessorCtx) -> AppResult<()> {
+        let mut chunk: Vec<ParsedSpan> = Vec::with_capacity(SPAN_BATCH_CHUNK);
+        for work in items {
+            match Self::parse_item(&work) {
+                Ok(item) => {
+                    chunk.push(item);
+                    if chunk.len() == SPAN_BATCH_CHUNK {
+                        self.insert_all(ctx, std::mem::take(&mut chunk)).await?;
+                    }
+                }
+                Err(e) => log::warn!("span item rejected: {e:?}"),
+            }
+        }
+        if !chunk.is_empty() {
+            self.insert_all(ctx, chunk).await?;
+        }
+        Ok(())
+    }
+}
+
+impl Processor for SpanProcessor {
+    type Input = Vec<u8>;
+
+    /// Stores one standalone span through the batched write path.
+    async fn process(&self, work: Vec<u8>, ctx: &ProcessorCtx) -> AppResult<()> {
+        let item = Self::parse_item(&work)?;
+        self.insert_all(ctx, vec![item]).await
     }
 }
 
@@ -184,4 +261,18 @@ fn extract_timestamp(data: &serde_json::Value, key: &str) -> Option<DateTime<Utc
             .map(|dt| dt.with_timezone(&Utc));
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SpanProcessor;
+
+    #[test]
+    fn parse_item_validates_shape() {
+        assert!(SpanProcessor::parse_item(br#"{}"#).is_err());
+        assert!(SpanProcessor::parse_item(
+            br#"{"span_id":"s","trace_id":"t","start_timestamp":1.0,"timestamp":2.0}"#
+        )
+        .is_ok());
+    }
 }

--- a/apps/server/src/digest/processors/span.rs
+++ b/apps/server/src/digest/processors/span.rs
@@ -130,6 +130,8 @@ impl Processor for SpanProcessor {
                 $24, $25,
                 $26, $27, $28, $29, $30
             )
+            ON CONFLICT (project_id, trace_id, span_id)
+                WHERE transaction_id IS NULL DO NOTHING
             "#,
         )
         .bind(Uuid::new_v4())

--- a/apps/server/src/digest/processors/span_v2.rs
+++ b/apps/server/src/digest/processors/span_v2.rs
@@ -103,6 +103,8 @@ impl Processor for SpanV2Processor {
                     $24, $25,
                     $26, $27, $28, $29, $30
                 )
+                ON CONFLICT (project_id, trace_id, span_id)
+                    WHERE transaction_id IS NULL DO NOTHING
                 "#,
             )
             .bind(Uuid::new_v4())

--- a/apps/server/src/digest/processors/span_v2.rs
+++ b/apps/server/src/digest/processors/span_v2.rs
@@ -104,7 +104,9 @@ impl Processor for SpanV2Processor {
                     $26, $27, $28, $29, $30
                 )
                 ON CONFLICT (project_id, trace_id, span_id)
-                    WHERE transaction_id IS NULL DO NOTHING
+                    WHERE transaction_id IS NULL
+                      AND trace_id IS NOT NULL
+                      AND span_id IS NOT NULL DO NOTHING
                 "#,
             )
             .bind(Uuid::new_v4())

--- a/apps/server/src/digest/processors/transaction.rs
+++ b/apps/server/src/digest/processors/transaction.rs
@@ -77,12 +77,10 @@ impl Processor for TransactionProcessor {
         let id = Uuid::new_v4();
 
         // Parent transaction + its extracted spans are written in one DB
-        // transaction: a failed span insert must not leave a committed parent
-        // row behind (a retry would then collide on UNIQUE(project_id, event_id)
-        // and the spans could never be recovered).
+        // transaction, and a retry with the same event id is a no-op.
         let mut tx = ctx.pool.begin().await?;
 
-        sqlx::query(
+        let inserted = sqlx::query(
             r#"
             INSERT INTO transactions (
                 id, event_id, project_id,
@@ -101,6 +99,7 @@ impl Processor for TransactionProcessor {
                 $18, $19, $20,
                 $21, $22, $23
             )
+            ON CONFLICT (project_id, event_id) DO NOTHING
             "#,
         )
         .bind(id)
@@ -128,6 +127,10 @@ impl Processor for TransactionProcessor {
         .bind(ctx.ingested_at)
         .execute(&mut *tx)
         .await?;
+
+        if inserted.rows_affected() == 0 {
+            return Ok(());
+        }
 
         // Extract each span into the indexed `spans` table. Mirrors Relay's span
         // extraction (DataCategory::SpanIndexed): individually queryable rows

--- a/apps/server/src/digest/processors/transaction.rs
+++ b/apps/server/src/digest/processors/transaction.rs
@@ -13,7 +13,7 @@ impl Processor for TransactionProcessor {
     /// Does NOT create an issue, grouping, or source-map rewrite.
     async fn process(&self, work: Vec<u8>, ctx: &ProcessorCtx) -> AppResult<()> {
         // Reject malformed payloads instead of persisting a null-data row.
-        // The caller (ingest spawn) logs the error and discards — envelope still 200.
+        // The ingest route propagates this error so the SDK can retry the envelope.
         let data: serde_json::Value = serde_json::from_slice(&work)
             .map_err(|e| AppError::Validation(format!("Invalid transaction JSON: {}", e)))?;
 

--- a/apps/server/src/ingest/mod.rs
+++ b/apps/server/src/ingest/mod.rs
@@ -6,4 +6,8 @@ pub mod storage;
 pub use decompression::{decompress_body, get_content_encoding, MAX_COMPRESSED_SIZE};
 pub use envelope::{EnvelopeItemKind, EventMetadata};
 pub use parser::EnvelopeParser;
-pub use storage::{delete_event, get_ingest_dir, read_event, store_event};
+pub use storage::{
+    delete_event, delete_event_for_project, get_event_path, get_ingest_dir,
+    list_pending_event_metadata, read_event, read_event_for_project, store_event,
+    store_event_with_metadata,
+};

--- a/apps/server/src/ingest/storage.rs
+++ b/apps/server/src/ingest/storage.rs
@@ -1,61 +1,484 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::io;
 use std::path::{Path, PathBuf};
 use tokio::fs;
+use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
+use crate::ingest::EventMetadata;
 
 /// Default base directory for pending events
 const DEFAULT_INGEST_DIR: &str = "/tmp/rustrak/ingest";
+const PENDING_EVENT_VERSION: u8 = 1;
 
-/// Gets the file path for an event_id
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EventStorageLocation {
+    Project,
+    Legacy,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PendingEventRecord {
+    version: u8,
+    metadata: EventMetadata,
+    event_data: String,
+}
+
+/// Gets the legacy file path for an event_id.
 pub fn get_event_path(base_dir: &Path, event_id: &str) -> AppResult<PathBuf> {
-    // Validate that event_id is a valid UUID (security)
     let uuid = Uuid::parse_str(event_id)
         .map_err(|_| AppError::Validation("Invalid event_id format".to_string()))?;
-
-    // Use hex without dashes for the filename
-    let filename = format!("{}.json", uuid.as_simple());
-
-    Ok(base_dir.join(filename))
+    Ok(base_dir.join(format!("{}.json", uuid.as_simple())))
 }
 
-/// Saves the event to the filesystem
-pub async fn store_event(base_dir: &Path, event_id: &str, event_data: &[u8]) -> AppResult<PathBuf> {
-    // Create directory if it doesn't exist
-    fs::create_dir_all(base_dir)
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to create ingest directory: {}", e)))?;
-
-    let path = get_event_path(base_dir, event_id)?;
-
-    fs::write(&path, event_data)
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to write event file: {}", e)))?;
-
-    Ok(path)
+fn get_event_metadata_path(base_dir: &Path, event_id: &str) -> AppResult<PathBuf> {
+    Ok(get_event_path(base_dir, event_id)?.with_extension("meta.json"))
 }
 
-/// Reads an event from the filesystem
-pub async fn read_event(base_dir: &Path, event_id: &str) -> AppResult<Vec<u8>> {
-    let path = get_event_path(base_dir, event_id)?;
-
-    fs::read(&path)
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to read event file: {}", e)))
+fn get_pending_event_path(base_dir: &Path, event_id: &str) -> AppResult<PathBuf> {
+    Ok(get_event_path(base_dir, event_id)?.with_extension("pending.json"))
 }
 
-/// Deletes an event from the filesystem
-pub async fn delete_event(base_dir: &Path, event_id: &str) -> AppResult<()> {
-    let path = get_event_path(base_dir, event_id)?;
+fn get_project_event_path(base_dir: &Path, project_id: i32, event_id: &str) -> AppResult<PathBuf> {
+    let uuid = Uuid::parse_str(event_id)
+        .map_err(|_| AppError::Validation("Invalid event_id format".to_string()))?;
+    Ok(base_dir.join(format!("project-{project_id}-{}.json", uuid.as_simple())))
+}
 
-    match fs::remove_file(&path).await {
-        Ok(()) => {}
-        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
-        Err(e) => log::warn!("Failed to delete event file {:?}: {}", path, e),
+fn get_project_pending_event_path(
+    base_dir: &Path,
+    project_id: i32,
+    event_id: &str,
+) -> AppResult<PathBuf> {
+    Ok(get_project_event_path(base_dir, project_id, event_id)?.with_extension("pending.json"))
+}
+
+fn same_event_id(left: &str, right: &str) -> bool {
+    Uuid::parse_str(left).ok() == Uuid::parse_str(right).ok()
+}
+
+fn validate_pending_record(
+    record: PendingEventRecord,
+    event_id: &str,
+    project_id: Option<i32>,
+) -> AppResult<Vec<u8>> {
+    if record.version != PENDING_EVENT_VERSION
+        || !same_event_id(&record.metadata.event_id, event_id)
+        || project_id.is_some_and(|id| record.metadata.project_id != id)
+    {
+        return Err(AppError::Internal(
+            "Invalid pending event record identity".to_string(),
+        ));
+    }
+    STANDARD
+        .decode(record.event_data)
+        .map_err(|e| AppError::Internal(format!("Invalid pending event payload: {}", e)))
+}
+
+async fn read_pending_record(
+    path: &Path,
+    event_id: &str,
+    project_id: Option<i32>,
+) -> AppResult<Vec<u8>> {
+    let bytes = fs::read(path)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to read event file: {}", e)))?;
+    let record: PendingEventRecord = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Internal(format!("Invalid pending event record: {}", e)))?;
+    validate_pending_record(record, event_id, project_id)
+}
+
+async fn write_atomically(path: &Path, bytes: &[u8]) -> AppResult<()> {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| AppError::Internal("Invalid ingest file path".to_string()))?;
+    let temporary_path = path.with_file_name(format!(".{file_name}.tmp-{}", Uuid::new_v4()));
+
+    let mut temporary_file = match fs::File::create(&temporary_path).await {
+        Ok(file) => file,
+        Err(e) => {
+            let _ = fs::remove_file(&temporary_path).await;
+            return Err(AppError::Internal(format!(
+                "Failed to write temporary ingest file: {}",
+                e
+            )));
+        }
+    };
+    if let Err(e) = temporary_file.write_all(bytes).await {
+        let _ = fs::remove_file(&temporary_path).await;
+        return Err(AppError::Internal(format!(
+            "Failed to write temporary ingest file: {}",
+            e
+        )));
+    }
+    if let Err(e) = temporary_file.sync_all().await {
+        let _ = fs::remove_file(&temporary_path).await;
+        return Err(AppError::Internal(format!(
+            "Failed to sync temporary ingest file: {}",
+            e
+        )));
+    }
+
+    match fs::hard_link(&temporary_path, path).await {
+        Ok(()) => {
+            let _ = fs::remove_file(&temporary_path).await;
+        }
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+            // A duplicate event ID is idempotent: keep the first complete
+            // record instead of allowing a later payload to win a race.
+            let _ = fs::remove_file(&temporary_path).await;
+            return Ok(());
+        }
+        Err(e) => {
+            let _ = fs::remove_file(&temporary_path).await;
+            return Err(AppError::Internal(format!(
+                "Failed to publish ingest file: {}",
+                e
+            )));
+        }
+    }
+
+    if let Some(parent) = path.parent() {
+        let directory = fs::File::open(parent)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to open ingest directory: {}", e)))?;
+        directory
+            .sync_all()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to sync ingest directory: {}", e)))?;
     }
 
     Ok(())
+}
+
+/// Saves an event using the legacy, unscoped path.
+pub async fn store_event(base_dir: &Path, event_id: &str, event_data: &[u8]) -> AppResult<PathBuf> {
+    fs::create_dir_all(base_dir)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to create ingest directory: {}", e)))?;
+    let path = get_event_path(base_dir, event_id)?;
+    fs::write(&path, event_data)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to write event file: {}", e)))?;
+    Ok(path)
+}
+
+/// Saves an event and the metadata needed to recover it after a worker restart.
+pub async fn store_event_with_metadata(
+    base_dir: &Path,
+    event_id: &str,
+    event_data: &[u8],
+    metadata: &EventMetadata,
+) -> AppResult<PathBuf> {
+    if !same_event_id(&metadata.event_id, event_id) {
+        return Err(AppError::Validation(
+            "Event metadata does not match event_id".to_string(),
+        ));
+    }
+    let path = get_project_event_path(base_dir, metadata.project_id, event_id)?;
+    let pending_path = get_project_pending_event_path(base_dir, metadata.project_id, event_id)?;
+    let record = PendingEventRecord {
+        version: PENDING_EVENT_VERSION,
+        metadata: metadata.clone(),
+        event_data: STANDARD.encode(event_data),
+    };
+    let record_bytes = serde_json::to_vec(&record)
+        .map_err(|e| AppError::Internal(format!("Failed to serialize pending event: {}", e)))?;
+
+    fs::create_dir_all(base_dir)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to create ingest directory: {}", e)))?;
+    write_atomically(&pending_path, &record_bytes).await?;
+    Ok(path)
+}
+
+/// Reads an event from the legacy filesystem path.
+pub async fn read_event(base_dir: &Path, event_id: &str) -> AppResult<Vec<u8>> {
+    let path = get_event_path(base_dir, event_id)?;
+    let pending_path = get_pending_event_path(base_dir, event_id)?;
+    match fs::try_exists(&pending_path).await {
+        Ok(true) => read_pending_record(&pending_path, event_id, None).await,
+        Ok(false) => fs::read(&path)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to read event file: {}", e))),
+        Err(e) => Err(AppError::Internal(format!(
+            "Failed to read event file: {}",
+            e
+        ))),
+    }
+}
+
+pub(crate) async fn read_event_with_location(
+    base_dir: &Path,
+    project_id: i32,
+    event_id: &str,
+) -> AppResult<(Vec<u8>, EventStorageLocation)> {
+    let project_pending_path = get_project_pending_event_path(base_dir, project_id, event_id)?;
+    match fs::try_exists(&project_pending_path).await {
+        Ok(true) => {
+            return Ok((
+                read_pending_record(&project_pending_path, event_id, Some(project_id)).await?,
+                EventStorageLocation::Project,
+            ));
+        }
+        Ok(false) => {}
+        Err(e) => {
+            return Err(AppError::Internal(format!(
+                "Failed to read event file: {}",
+                e
+            )))
+        }
+    }
+
+    let project_path = get_project_event_path(base_dir, project_id, event_id)?;
+    match fs::try_exists(&project_path).await {
+        Ok(true) => {
+            return Ok((
+                fs::read(&project_path)
+                    .await
+                    .map_err(|e| AppError::Internal(format!("Failed to read event file: {}", e)))?,
+                EventStorageLocation::Project,
+            ));
+        }
+        Ok(false) => {}
+        Err(e) => {
+            return Err(AppError::Internal(format!(
+                "Failed to read event file: {}",
+                e
+            )))
+        }
+    }
+
+    let legacy_pending_path = get_pending_event_path(base_dir, event_id)?;
+    match fs::try_exists(&legacy_pending_path).await {
+        Ok(true) => Ok((
+            read_pending_record(&legacy_pending_path, event_id, Some(project_id)).await?,
+            EventStorageLocation::Legacy,
+        )),
+        Ok(false) => {
+            let legacy_path = get_event_path(base_dir, event_id)?;
+            match fs::read(&legacy_path).await {
+                Ok(bytes) => Ok((bytes, EventStorageLocation::Legacy)),
+                Err(e) => Err(AppError::Internal(format!(
+                    "Failed to read event file: {}",
+                    e
+                ))),
+            }
+        }
+        Err(e) => Err(AppError::Internal(format!(
+            "Failed to read event file: {}",
+            e
+        ))),
+    }
+}
+
+pub async fn read_event_for_project(
+    base_dir: &Path,
+    project_id: i32,
+    event_id: &str,
+) -> AppResult<Vec<u8>> {
+    Ok(read_event_with_location(base_dir, project_id, event_id)
+        .await?
+        .0)
+}
+
+/// Deletes an event from the legacy filesystem path.
+pub async fn delete_event(base_dir: &Path, event_id: &str) -> AppResult<()> {
+    delete_paths(vec![
+        get_event_path(base_dir, event_id)?,
+        get_event_metadata_path(base_dir, event_id)?,
+        get_pending_event_path(base_dir, event_id)?,
+    ])
+    .await
+}
+
+pub(crate) async fn delete_event_at(
+    base_dir: &Path,
+    project_id: i32,
+    event_id: &str,
+    location: EventStorageLocation,
+) -> AppResult<()> {
+    let paths = match location {
+        EventStorageLocation::Project => vec![
+            get_project_event_path(base_dir, project_id, event_id)?,
+            get_project_pending_event_path(base_dir, project_id, event_id)?,
+        ],
+        EventStorageLocation::Legacy => vec![
+            get_event_path(base_dir, event_id)?,
+            get_event_metadata_path(base_dir, event_id)?,
+            get_pending_event_path(base_dir, event_id)?,
+        ],
+    };
+    delete_paths(paths).await
+}
+
+pub async fn delete_event_for_project(
+    base_dir: &Path,
+    project_id: i32,
+    event_id: &str,
+) -> AppResult<()> {
+    delete_event_at(
+        base_dir,
+        project_id,
+        event_id,
+        EventStorageLocation::Project,
+    )
+    .await
+}
+
+async fn delete_paths(paths: Vec<PathBuf>) -> AppResult<()> {
+    for path in paths {
+        match fs::remove_file(&path).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => log::warn!("Failed to delete event file {:?}: {}", path, e),
+        }
+    }
+    Ok(())
+}
+
+fn is_orphaned_temporary_file(file_name: &str) -> bool {
+    file_name.starts_with('.') && file_name.contains(".tmp-")
+}
+
+async fn cleanup_orphaned_temporary_files(base_dir: &Path) -> AppResult<()> {
+    let mut entries = match fs::read_dir(base_dir).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(AppError::Internal(format!(
+                "Failed to read ingest directory: {}",
+                e
+            )))
+        }
+    };
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to read ingest entry: {}", e)))?
+    {
+        let path = entry.path();
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(is_orphaned_temporary_file)
+        {
+            match fs::remove_file(&path).await {
+                Ok(()) => log::debug!("Removed orphaned ingest temp file {:?}", path),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(e) => log::warn!(
+                    "Failed to remove orphaned ingest temp file {:?}: {}",
+                    path,
+                    e
+                ),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_project_pending_filename(file_name: &str) -> Option<(i32, Uuid)> {
+    let stem = file_name.strip_suffix(".pending.json")?;
+    let stem = stem.strip_prefix("project-")?;
+    let (project_id, event_id) = stem.rsplit_once('-')?;
+    Some((project_id.parse().ok()?, Uuid::parse_str(event_id).ok()?))
+}
+
+fn pending_filename_matches(file_name: &str, metadata: &EventMetadata, event_id: Uuid) -> bool {
+    match parse_project_pending_filename(file_name) {
+        Some((project_id, filename_id)) => {
+            project_id == metadata.project_id && filename_id == event_id
+        }
+        None => {
+            file_name
+                .strip_suffix(".pending.json")
+                .and_then(|id| Uuid::parse_str(id).ok())
+                == Some(event_id)
+        }
+    }
+}
+
+/// Reads pending event metadata left by an interrupted or exhausted digest.
+pub async fn list_pending_event_metadata(base_dir: &Path) -> AppResult<Vec<EventMetadata>> {
+    cleanup_orphaned_temporary_files(base_dir).await?;
+    let mut entries = match fs::read_dir(base_dir).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(AppError::Internal(format!(
+                "Failed to read ingest directory: {}",
+                e
+            )))
+        }
+    };
+    let mut pending = Vec::new();
+    let mut seen_events = HashSet::new();
+
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to read ingest entry: {}", e)))?
+    {
+        let path = entry.path();
+        let file_name = match path.file_name().and_then(|name| name.to_str()) {
+            Some(file_name) => file_name,
+            None => continue,
+        };
+        let is_pending_record = file_name.ends_with(".pending.json");
+        let is_legacy_metadata = file_name.ends_with(".meta.json");
+        if !is_pending_record && !is_legacy_metadata {
+            continue;
+        }
+
+        let bytes = match fs::read(&path).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                log::warn!("Skipping unreadable pending event file {:?}: {}", path, e);
+                continue;
+            }
+        };
+        if is_pending_record {
+            match serde_json::from_slice::<PendingEventRecord>(&bytes) {
+                Ok(record) if record.version == PENDING_EVENT_VERSION => {
+                    match Uuid::parse_str(&record.metadata.event_id) {
+                        Ok(metadata_id) => {
+                            let filename_matches =
+                                pending_filename_matches(file_name, &record.metadata, metadata_id);
+                            if filename_matches
+                                && seen_events.insert((record.metadata.project_id, metadata_id))
+                            {
+                                pending.push(record.metadata);
+                            } else if !filename_matches {
+                                log::warn!("Skipping invalid pending event identity: {:?}", path);
+                            }
+                        }
+                        Err(_) => log::warn!("Skipping invalid pending event identity: {:?}", path),
+                    }
+                }
+                Ok(_) => log::warn!("Skipping invalid pending event identity: {:?}", path),
+                Err(e) => log::warn!("Skipping malformed pending event {:?}: {}", path, e),
+            }
+        } else {
+            match serde_json::from_slice::<EventMetadata>(&bytes) {
+                Ok(metadata) => {
+                    if let Ok(event_id) = Uuid::parse_str(&metadata.event_id) {
+                        if seen_events.insert((metadata.project_id, event_id)) {
+                            pending.push(metadata);
+                        }
+                    } else {
+                        log::warn!("Skipping invalid event metadata identity: {:?}", path);
+                    }
+                }
+                Err(e) => log::warn!("Skipping malformed event metadata {:?}: {}", path, e),
+            }
+        }
+    }
+
+    Ok(pending)
 }
 
 /// Gets the ingest directory from config or uses default
@@ -68,6 +491,15 @@ pub fn get_ingest_dir(configured_dir: Option<&str>) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn metadata(event_id: &str, project_id: i32) -> EventMetadata {
+        EventMetadata {
+            event_id: event_id.to_string(),
+            project_id,
+            ingested_at: chrono::Utc::now(),
+            remote_addr: None,
+        }
+    }
 
     #[test]
     fn test_get_event_path_valid_uuid() {
@@ -95,5 +527,147 @@ mod tests {
     fn test_get_ingest_dir_custom() {
         let dir = get_ingest_dir(Some("/custom/path"));
         assert_eq!(dir, PathBuf::from("/custom/path"));
+    }
+
+    #[tokio::test]
+    async fn project_scopes_same_event_id_and_recovery_listing() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_id = "9ec79c33-ec99-42ab-8353-589fcb2e04dc";
+        let first = metadata(event_id, 7);
+        let second = metadata(event_id, 8);
+
+        store_event_with_metadata(dir.path(), event_id, br#"{"project":7}"#, &first)
+            .await
+            .unwrap();
+        store_event_with_metadata(dir.path(), event_id, br#"{"project":8}"#, &second)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            read_event_for_project(dir.path(), 7, event_id)
+                .await
+                .unwrap(),
+            br#"{"project":7}"#
+        );
+        assert_eq!(
+            read_event_for_project(dir.path(), 8, event_id)
+                .await
+                .unwrap(),
+            br#"{"project":8}"#
+        );
+        let pending = list_pending_event_metadata(dir.path()).await.unwrap();
+        assert_eq!(pending.len(), 2);
+        assert!(pending.iter().any(|item| item.project_id == 7));
+        assert!(pending.iter().any(|item| item.project_id == 8));
+
+        delete_event_at(dir.path(), 7, event_id, EventStorageLocation::Project)
+            .await
+            .unwrap();
+        assert_eq!(
+            read_event_for_project(dir.path(), 8, event_id)
+                .await
+                .unwrap(),
+            br#"{"project":8}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_event_id_keeps_the_first_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_id = "9ec79c33-ec99-42ab-8353-589fcb2e04dc";
+        let metadata = metadata(event_id, 7);
+
+        store_event_with_metadata(dir.path(), event_id, br#"{"first":true}"#, &metadata)
+            .await
+            .unwrap();
+        store_event_with_metadata(dir.path(), event_id, br#"{"second":true}"#, &metadata)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            read_event_for_project(dir.path(), 7, event_id)
+                .await
+                .unwrap(),
+            br#"{"first":true}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn mismatched_metadata_is_rejected_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_id = "9ec79c33-ec99-42ab-8353-589fcb2e04dc";
+        let result =
+            store_event_with_metadata(dir.path(), event_id, br"{}", &metadata("bad", 7)).await;
+        assert!(result.is_err());
+        let mut entries = fs::read_dir(dir.path()).await.unwrap();
+        assert!(entries.next_entry().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn malformed_pending_record_is_retained_for_recovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_id = "9ec79c33-ec99-42ab-8353-589fcb2e04dc";
+        store_event(dir.path(), event_id, br#"{"legacy":true}"#)
+            .await
+            .unwrap();
+        store_event_with_metadata(dir.path(), event_id, br"{}", &metadata(event_id, 7))
+            .await
+            .unwrap();
+        let pending_path = get_project_pending_event_path(dir.path(), 7, event_id).unwrap();
+        fs::write(&pending_path, b"{").await.unwrap();
+
+        assert!(read_event_for_project(dir.path(), 7, event_id)
+            .await
+            .is_err());
+        assert!(fs::try_exists(pending_path).await.unwrap());
+        assert!(
+            fs::try_exists(get_event_path(dir.path(), event_id).unwrap())
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn orphaned_atomic_write_temp_files_are_cleaned() {
+        let dir = tempfile::tempdir().unwrap();
+        let orphan = dir.path().join(".project-7-event.pending.json.tmp-crash");
+        fs::write(&orphan, b"partial").await.unwrap();
+
+        assert!(list_pending_event_metadata(dir.path())
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(!fs::try_exists(orphan).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn legacy_pending_event_metadata_round_trips_and_deletes_with_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_id = "9ec79c33-ec99-42ab-8353-589fcb2e04dc";
+        let metadata = metadata(event_id, 7);
+
+        let legacy_path = get_pending_event_path(dir.path(), event_id).unwrap();
+        fs::create_dir_all(dir.path()).await.unwrap();
+        let record = PendingEventRecord {
+            version: PENDING_EVENT_VERSION,
+            metadata: metadata.clone(),
+            event_data: STANDARD.encode(br"{}"),
+        };
+        fs::write(&legacy_path, serde_json::to_vec(&record).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            read_event_for_project(dir.path(), 7, event_id)
+                .await
+                .unwrap(),
+            br"{}"
+        );
+        delete_event_at(dir.path(), 7, event_id, EventStorageLocation::Legacy)
+            .await
+            .unwrap();
+        assert!(list_pending_event_metadata(dir.path())
+            .await
+            .unwrap()
+            .is_empty());
     }
 }

--- a/apps/server/src/ingest/storage.rs
+++ b/apps/server/src/ingest/storage.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
@@ -13,6 +14,7 @@ use crate::ingest::EventMetadata;
 /// Default base directory for pending events
 const DEFAULT_INGEST_DIR: &str = "/tmp/rustrak/ingest";
 const PENDING_EVENT_VERSION: u8 = 1;
+const ORPHANED_TEMPORARY_FILE_GRACE: Duration = Duration::from_secs(300);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EventStorageLocation {
@@ -346,6 +348,13 @@ fn is_orphaned_temporary_file(file_name: &str) -> bool {
 }
 
 async fn cleanup_orphaned_temporary_files(base_dir: &Path) -> AppResult<()> {
+    cleanup_orphaned_temporary_files_with_grace(base_dir, ORPHANED_TEMPORARY_FILE_GRACE).await
+}
+
+async fn cleanup_orphaned_temporary_files_with_grace(
+    base_dir: &Path,
+    grace: Duration,
+) -> AppResult<()> {
     let mut entries = match fs::read_dir(base_dir).await {
         Ok(entries) => entries,
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
@@ -366,6 +375,12 @@ async fn cleanup_orphaned_temporary_files(base_dir: &Path) -> AppResult<()> {
             .file_name()
             .and_then(|name| name.to_str())
             .is_some_and(is_orphaned_temporary_file)
+            && fs::metadata(&path)
+                .await
+                .ok()
+                .and_then(|metadata| metadata.modified().ok())
+                .and_then(|modified| modified.elapsed().ok())
+                .is_some_and(|age| age >= grace)
         {
             match fs::remove_file(&path).await {
                 Ok(()) => log::debug!("Removed orphaned ingest temp file {:?}", path),
@@ -633,11 +648,21 @@ mod tests {
         let orphan = dir.path().join(".project-7-event.pending.json.tmp-crash");
         fs::write(&orphan, b"partial").await.unwrap();
 
-        assert!(list_pending_event_metadata(dir.path())
+        cleanup_orphaned_temporary_files_with_grace(dir.path(), Duration::ZERO)
             .await
-            .unwrap()
-            .is_empty());
+            .unwrap();
         assert!(!fs::try_exists(orphan).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn active_atomic_write_temp_files_are_retained() {
+        let dir = tempfile::tempdir().unwrap();
+        let active = dir.path().join(".project-7-event.pending.json.tmp-active");
+        fs::write(&active, b"partial").await.unwrap();
+
+        list_pending_event_metadata(dir.path()).await.unwrap();
+
+        assert!(fs::try_exists(active).await.unwrap());
     }
 
     #[tokio::test]

--- a/apps/server/src/ingest/storage.rs
+++ b/apps/server/src/ingest/storage.rs
@@ -99,6 +99,7 @@ async fn write_atomically(path: &Path, bytes: &[u8]) -> AppResult<()> {
         .and_then(|name| name.to_str())
         .ok_or_else(|| AppError::Internal("Invalid ingest file path".to_string()))?;
     let temporary_path = path.with_file_name(format!(".{file_name}.tmp-{}", Uuid::new_v4()));
+    let expected_record = serde_json::from_slice::<PendingEventRecord>(bytes).ok();
 
     let mut temporary_file = match fs::File::create(&temporary_path).await {
         Ok(file) => file,
@@ -130,10 +131,57 @@ async fn write_atomically(path: &Path, bytes: &[u8]) -> AppResult<()> {
             let _ = fs::remove_file(&temporary_path).await;
         }
         Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
-            // A duplicate event ID is idempotent: keep the first complete
-            // record instead of allowing a later payload to win a race.
+            let existing = match fs::read(path).await {
+                Ok(existing) => existing,
+                Err(read_error) => {
+                    let _ = fs::remove_file(&temporary_path).await;
+                    return Err(AppError::Internal(format!(
+                        "Failed to inspect existing ingest file: {}",
+                        read_error
+                    )));
+                }
+            };
+            let is_complete = match (
+                serde_json::from_slice::<PendingEventRecord>(&existing),
+                expected_record.as_ref(),
+            ) {
+                (Ok(existing), Some(expected)) => validate_pending_record(
+                    existing,
+                    &expected.metadata.event_id,
+                    Some(expected.metadata.project_id),
+                )
+                .is_ok(),
+                _ => false,
+            };
+            if is_complete {
+                // A duplicate event ID is idempotent: keep the first complete
+                // record instead of allowing a later payload to win a race.
+                let _ = fs::remove_file(&temporary_path).await;
+                return Ok(());
+            }
+
+            let quarantine =
+                path.with_file_name(format!(".{file_name}.corrupt-{}", Uuid::new_v4()));
+            log::warn!(
+                "Quarantining malformed pending ingest file {:?} as {:?}",
+                path,
+                quarantine
+            );
+            if let Err(rename_error) = fs::rename(path, &quarantine).await {
+                let _ = fs::remove_file(&temporary_path).await;
+                return Err(AppError::Internal(format!(
+                    "Failed to quarantine ingest file: {}",
+                    rename_error
+                )));
+            }
+            if let Err(link_error) = fs::hard_link(&temporary_path, path).await {
+                let _ = fs::remove_file(&temporary_path).await;
+                return Err(AppError::Internal(format!(
+                    "Failed to publish replacement ingest file: {}",
+                    link_error
+                )));
+            }
             let _ = fs::remove_file(&temporary_path).await;
-            return Ok(());
         }
         Err(e) => {
             let _ = fs::remove_file(&temporary_path).await;
@@ -629,7 +677,14 @@ mod tests {
             .await
             .unwrap();
         let pending_path = get_project_pending_event_path(dir.path(), 7, event_id).unwrap();
-        fs::write(&pending_path, b"{").await.unwrap();
+        let malformed = PendingEventRecord {
+            version: PENDING_EVENT_VERSION,
+            metadata: metadata(event_id, 7),
+            event_data: "not-base64".to_string(),
+        };
+        fs::write(&pending_path, serde_json::to_vec(&malformed).unwrap())
+            .await
+            .unwrap();
 
         assert!(read_event_for_project(dir.path(), 7, event_id)
             .await
@@ -640,6 +695,39 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn malformed_duplicate_record_is_quarantined_before_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_id = "9ec79c33-ec99-42ab-8353-589fcb2e04dc";
+        let pending_path = get_project_pending_event_path(dir.path(), 7, event_id).unwrap();
+        fs::create_dir_all(dir.path()).await.unwrap();
+        fs::write(&pending_path, b"{").await.unwrap();
+
+        store_event_with_metadata(
+            dir.path(),
+            event_id,
+            br#"{"recovered":true}"#,
+            &metadata(event_id, 7),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            read_event_for_project(dir.path(), 7, event_id)
+                .await
+                .unwrap(),
+            br#"{"recovered":true}"#
+        );
+        let mut entries = fs::read_dir(dir.path()).await.unwrap();
+        let mut quarantined = false;
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            if entry.file_name().to_string_lossy().contains(".corrupt-") {
+                quarantined = true;
+            }
+        }
+        assert!(quarantined);
     }
 
     #[tokio::test]

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -150,6 +150,14 @@ async fn main() -> std::io::Result<()> {
         Some(session_aggregator.clone()),
     ));
 
+    // Recovery is a background worker: a large backlog or a temporarily
+    // unavailable database must not prevent the HTTP listener from binding.
+    tokio::spawn(routes::ingest::recover_pending_events(
+        db_pool.clone(),
+        processors_data.clone(),
+        rustrak::ingest::get_ingest_dir(config.ingest_dir.as_deref()),
+    ));
+
     let server = HttpServer::new(move || {
         // CORS configuration - permissive for event ingestion
         // Sentry SDKs can send from any origin. CORS protects the user from

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -161,8 +161,11 @@ async fn main() -> std::io::Result<()> {
     let alert_pool = db_pool.clone();
     tokio::spawn(async move {
         loop {
-            if let Err(e) =
-                rustrak::services::AlertService::process_retry_queue(&alert_pool, 5).await
+            if let Err(e) = rustrak::services::AlertService::process_retry_queue(
+                &alert_pool,
+                rustrak::services::alert::MAX_ALERT_RETRIES,
+            )
+            .await
             {
                 log::error!("Alert retry worker error: {:?}", e);
             }

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -158,6 +158,18 @@ async fn main() -> std::io::Result<()> {
         rustrak::ingest::get_ingest_dir(config.ingest_dir.as_deref()),
     ));
 
+    let alert_pool = db_pool.clone();
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) =
+                rustrak::services::AlertService::process_retry_queue(&alert_pool, 5).await
+            {
+                log::error!("Alert retry worker error: {:?}", e);
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+        }
+    });
+
     let server = HttpServer::new(move || {
         // CORS configuration - permissive for event ingestion
         // Sentry SDKs can send from any origin. CORS protects the user from
@@ -289,7 +301,12 @@ async fn main() -> std::io::Result<()> {
         log::info!("Shutdown signal received, stopping server...");
         // Stop accepting new requests first, then flush remaining buckets
         server_handle.stop(true).await;
-        agg_for_shutdown.flush().await;
+        if let Err(e) = agg_for_shutdown.flush().await {
+            log::error!(
+                "Failed to flush session aggregator during shutdown: {:?}",
+                e
+            );
+        }
     });
 
     server.await

--- a/apps/server/src/models/alert.rs
+++ b/apps/server/src/models/alert.rs
@@ -380,6 +380,7 @@ pub struct AlertHistory {
     pub alert_type: String,
     pub channel_type: String,
     pub channel_name: String,
+    #[serde(skip_serializing)]
     pub payload: serde_json::Value,
     pub status: AlertStatus,
     pub attempt_count: i32,
@@ -441,7 +442,37 @@ pub struct IssueInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
     use serde_json::json;
+
+    #[test]
+    fn alert_history_payload_is_internal_only() {
+        let now = Utc::now();
+        let history = AlertHistory {
+            id: 1,
+            alert_rule_id: None,
+            integration_id: None,
+            issue_id: None,
+            project_id: None,
+            alert_type: "new_issue".into(),
+            channel_type: "webhook".into(),
+            channel_name: "test".into(),
+            payload: json!({"secret": true}),
+            status: AlertStatus::Pending,
+            attempt_count: 0,
+            next_retry_at: None,
+            error_message: None,
+            http_status_code: None,
+            idempotency_key: "key".into(),
+            created_at: now,
+            sent_at: None,
+        };
+        assert!(!serde_json::to_value(history)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .contains_key("payload"));
+    }
 
     // -------------------------------------------------------------------------
     // Task 3 RED→GREEN: Flat routing struct deserialization (NO provider_type tag)

--- a/apps/server/src/models/alert.rs
+++ b/apps/server/src/models/alert.rs
@@ -380,6 +380,7 @@ pub struct AlertHistory {
     pub alert_type: String,
     pub channel_type: String,
     pub channel_name: String,
+    pub payload: serde_json::Value,
     pub status: AlertStatus,
     pub attempt_count: i32,
     pub next_retry_at: Option<DateTime<Utc>>,
@@ -395,7 +396,7 @@ pub struct AlertHistory {
 // =============================================================================
 
 /// Payload sent to notification integrations
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AlertPayload {
     /// Unique alert ID for idempotency
     pub alert_id: String,
@@ -414,7 +415,7 @@ pub struct AlertPayload {
 }
 
 /// Project information for alert payload
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectInfo {
     pub id: i32,
     pub name: String,
@@ -422,7 +423,7 @@ pub struct ProjectInfo {
 }
 
 /// Issue information for alert payload
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IssueInfo {
     pub id: String,
     pub short_id: String,

--- a/apps/server/src/models/event.rs
+++ b/apps/server/src/models/event.rs
@@ -1,3 +1,4 @@
+use crate::models::AlertType;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use sqlx::FromRow;
@@ -31,6 +32,7 @@ pub struct Event {
     pub sdk_name: String,
     pub sdk_version: String,
     pub remote_addr: Option<String>,
+    pub alert_type: Option<AlertType>,
     /// "error" for error events, "transaction" for performance events
     pub event_type: String,
 }

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -76,6 +76,12 @@ pub async fn ingest_envelope(
     let mut span_items: Vec<Vec<u8>> = Vec::new();
     let mut span_v2_items: Vec<Vec<u8>> = Vec::new();
     let mut requires_event_id = false;
+    let delivery_id = envelope
+        .headers
+        .event_id
+        .as_deref()
+        .and_then(|id| uuid::Uuid::parse_str(id).ok())
+        .unwrap_or_else(uuid::Uuid::new_v4);
     for item_kind in envelope.items {
         if item_kind.requires_event() {
             requires_event_id = true;
@@ -92,14 +98,26 @@ pub async fn ingest_envelope(
                 }
             }
             EnvelopeItemKind::Session(s) => {
-                let ctx = direct_store_ctx(&pool, auth.project.id, ingested_at, &remote_addr);
+                let ctx = direct_store_ctx(
+                    &pool,
+                    auth.project.id,
+                    delivery_id,
+                    ingested_at,
+                    &remote_addr,
+                );
                 processors
                     .sessions
                     .process(SessionItem::Update(s), &ctx)
                     .await?;
             }
             EnvelopeItemKind::Sessions(s) => {
-                let ctx = direct_store_ctx(&pool, auth.project.id, ingested_at, &remote_addr);
+                let ctx = direct_store_ctx(
+                    &pool,
+                    auth.project.id,
+                    delivery_id,
+                    ingested_at,
+                    &remote_addr,
+                );
                 processors
                     .sessions
                     .process(SessionItem::Aggregates(s), &ctx)
@@ -108,7 +126,13 @@ pub async fn ingest_envelope(
             EnvelopeItemKind::Log(payload) => {
                 // Logs are processed inline (parse container + store): the work is
                 // bounded and storing before responding keeps the batch durable.
-                let ctx = direct_store_ctx(&pool, auth.project.id, ingested_at, &remote_addr);
+                let ctx = direct_store_ctx(
+                    &pool,
+                    auth.project.id,
+                    delivery_id,
+                    ingested_at,
+                    &remote_addr,
+                );
                 processors.logs.process(payload, &ctx).await?;
             }
             EnvelopeItemKind::Span(payload) => {
@@ -333,13 +357,14 @@ fn next_recovery_delay(
 fn direct_store_ctx(
     pool: &web::Data<DbPool>,
     project_id: i32,
+    event_id: uuid::Uuid,
     ingested_at: chrono::DateTime<Utc>,
     remote_addr: &Option<String>,
 ) -> ProcessorCtx {
     ProcessorCtx {
         pool: pool.get_ref().clone(),
         project_id,
-        event_id: uuid::Uuid::nil(),
+        event_id,
         ingested_at,
         remote_addr: remote_addr.clone(),
     }

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -1,6 +1,7 @@
 use actix_web::{web, HttpRequest, HttpResponse};
 use bytes::Bytes;
 use chrono::Utc;
+use sha2::{Digest as _, Sha256};
 
 use crate::auth::SentryAuth;
 use crate::config::Config;
@@ -76,12 +77,7 @@ pub async fn ingest_envelope(
     let mut span_items: Vec<Vec<u8>> = Vec::new();
     let mut span_v2_items: Vec<Vec<u8>> = Vec::new();
     let mut requires_event_id = false;
-    let delivery_id = envelope
-        .headers
-        .event_id
-        .as_deref()
-        .and_then(|id| uuid::Uuid::parse_str(id).ok())
-        .unwrap_or_else(uuid::Uuid::new_v4);
+    let delivery_id = stable_delivery_id(envelope.headers.event_id.as_deref(), &decompressed);
     for item_kind in envelope.items {
         if item_kind.requires_event() {
             requires_event_id = true;
@@ -370,6 +366,17 @@ fn direct_store_ctx(
     }
 }
 
+fn stable_delivery_id(event_id: Option<&str>, envelope: &[u8]) -> uuid::Uuid {
+    event_id
+        .and_then(|id| uuid::Uuid::parse_str(id).ok())
+        .unwrap_or_else(|| {
+            let digest = Sha256::digest(envelope);
+            let mut bytes = [0; 16];
+            bytes.copy_from_slice(&digest[..16]);
+            uuid::Uuid::from_bytes(bytes)
+        })
+}
+
 /// POST /api/{project_id}/store/
 /// Legacy endpoint (deprecated)
 pub async fn ingest_store(
@@ -409,7 +416,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
 
 #[cfg(test)]
 mod tests {
-    use super::next_recovery_delay;
+    use super::{next_recovery_delay, stable_delivery_id};
     use std::time::Duration;
 
     #[test]
@@ -430,6 +437,22 @@ mod tests {
         assert_eq!(
             next_recovery_delay(Some(Duration::from_secs(16)), false),
             Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn headerless_delivery_id_is_stable_for_retries() {
+        let first = stable_delivery_id(None, b"same envelope");
+        assert_eq!(first, stable_delivery_id(None, b"same envelope"));
+        assert_ne!(first, stable_delivery_id(None, b"different envelope"));
+    }
+
+    #[test]
+    fn valid_event_id_remains_the_delivery_id() {
+        let event_id = uuid::Uuid::new_v4();
+        assert_eq!(
+            stable_delivery_id(Some(&event_id.to_string()), b"ignored"),
+            event_id
         );
     }
 }

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -5,11 +5,14 @@ use chrono::Utc;
 use crate::auth::SentryAuth;
 use crate::config::Config;
 use crate::db::DbPool;
-use crate::digest::processors::{Processor, ProcessorCtx, Processors, SessionItem};
+use crate::digest::processors::{
+    is_retryable_write_contention, Processor, ProcessorCtx, Processors, SessionItem,
+};
 use crate::error::{AppError, AppResult};
 use crate::ingest::{
-    decompress_body, get_content_encoding, get_ingest_dir, store_event, EnvelopeItemKind,
-    EnvelopeParser, EventMetadata, MAX_COMPRESSED_SIZE,
+    decompress_body, get_content_encoding, get_ingest_dir, list_pending_event_metadata,
+    store_event_with_metadata, EnvelopeItemKind, EnvelopeParser, EventMetadata,
+    MAX_COMPRESSED_SIZE,
 };
 use crate::services::RateLimitService;
 
@@ -32,7 +35,9 @@ pub async fn ingest_envelope(
     processors: web::Data<Processors>,
 ) -> AppResult<HttpResponse> {
     // 0. Check rate limits (fail fast before processing)
-    if let Some(exceeded) = RateLimitService::check_quota(pool.get_ref(), &auth.project).await? {
+    if let Some(exceeded) =
+        RateLimitService::check_quota(pool.get_ref(), &auth.project, &config.rate_limit).await?
+    {
         log::warn!(
             "Rate limit exceeded for project {}: retry_after={}s",
             auth.project.id,
@@ -242,18 +247,17 @@ pub async fn ingest_envelope(
     let _: serde_json::Value = serde_json::from_slice(&event_item)
         .map_err(|e| AppError::Validation(format!("Invalid event JSON: {}", e)))?;
 
-    // 7. Store event in filesystem
-    store_event(&ingest_dir, &event_id, &event_item).await?;
-
-    // 8. Create metadata
+    // 7. Create metadata and store it beside the raw event so a failed digest
+    // can be recovered after the process restarts.
     let metadata = EventMetadata {
         event_id: event_id.clone(),
         project_id: auth.project.id,
         ingested_at,
         remote_addr,
     };
+    store_event_with_metadata(&ingest_dir, &event_id, &event_item, &metadata).await?;
 
-    // 9. Spawn digest task — the ErrorProcessor reads the temp file and runs
+    // 8. Spawn digest task — the ErrorProcessor reads the temp file and runs
     //    grouping/issue creation. It owns ingest_dir/rate_limit/sourcemap deps.
     let processors = processors.clone();
     let pool_clone = pool.get_ref().clone();
@@ -267,13 +271,78 @@ pub async fn ingest_envelope(
             ingested_at: metadata.ingested_at,
             remote_addr: metadata.remote_addr.clone(),
         };
-        if let Err(e) = processors.errors.process(metadata, &ctx).await {
-            log::error!("Failed to digest event {}: {:?}", event_id_log, e);
+        for attempt in 0..4 {
+            match processors.errors.process(metadata.clone(), &ctx).await {
+                Ok(()) => break,
+                Err(e) if is_retryable_write_contention(&e) && attempt < 3 => {
+                    let delay = std::time::Duration::from_millis(250 << attempt);
+                    log::warn!(
+                        "Digest {} remains locked; retrying after {:?}: {:?}",
+                        event_id_log,
+                        delay,
+                        e
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+                Err(e) => {
+                    log::error!(
+                        "Failed to digest event {}; it remains queued: {:?}",
+                        event_id_log,
+                        e
+                    );
+                    break;
+                }
+            }
         }
     });
 
-    // 10. Return immediately (CORS handled by middleware)
+    // 9. Return immediately (CORS handled by middleware)
     Ok(HttpResponse::Ok().json(IngestResponse { id: Some(event_id) }))
+}
+
+/// Replays event files left by a previous process after a digest failure.
+pub async fn recover_pending_events(
+    pool: DbPool,
+    processors: web::Data<Processors>,
+    ingest_dir: std::path::PathBuf,
+) {
+    const RECOVERY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+    loop {
+        recover_pending_events_once(pool.clone(), processors.clone(), ingest_dir.clone()).await;
+        tokio::time::sleep(RECOVERY_INTERVAL).await;
+    }
+}
+
+/// Performs one bounded recovery scan; kept separate so startup workers and
+/// tests can exercise exactly one replay pass.
+pub async fn recover_pending_events_once(
+    pool: DbPool,
+    processors: web::Data<Processors>,
+    ingest_dir: std::path::PathBuf,
+) {
+    let pending = match list_pending_event_metadata(&ingest_dir).await {
+        Ok(pending) => pending,
+        Err(e) => {
+            log::error!("Failed to scan pending event metadata: {:?}", e);
+            return;
+        }
+    };
+
+    for metadata in pending {
+        let event_id = metadata.event_id.clone();
+        let ctx = ProcessorCtx {
+            pool: pool.clone(),
+            project_id: metadata.project_id,
+            event_id: uuid::Uuid::parse_str(&metadata.event_id)
+                .unwrap_or_else(|_| uuid::Uuid::nil()),
+            ingested_at: metadata.ingested_at,
+            remote_addr: metadata.remote_addr.clone(),
+        };
+        if let Err(e) = processors.errors.process(metadata, &ctx).await {
+            log::warn!("Pending digest {} remains queued: {:?}", event_id, e);
+        }
+    }
 }
 
 /// Builds a [`ProcessorCtx`] for session items, which carry no event id.

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -171,9 +171,7 @@ pub async fn ingest_envelope(
             ingested_at,
             remote_addr: remote_addr.clone(),
         };
-        for span_payload in span_items {
-            processors.spans.process(span_payload, &ctx).await?;
-        }
+        processors.spans.process_batch(span_items, &ctx).await?;
     }
 
     // Persist v2 span batches inline for the same reason.

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -69,6 +69,25 @@ pub async fn ingest_envelope(
     let mut parser = EnvelopeParser::new(&decompressed);
     let envelope = parser.parse()?;
 
+    // Relay parity for item payloads: a malformed item is dropped and its
+    // siblings continue (relay-server/src/processing/relay.rs run_one — "This
+    // is not a fatal error case ... other items from the same original
+    // envelope must still be processed"). Only infrastructure failures
+    // (database, storage) may fail the envelope: they return 5xx so the SDK
+    // retries, preserving the commit-before-ack durability promise. A 4xx here
+    // would make the SDK drop the sibling data permanently.
+    fn drop_malformed_item(result: AppResult<()>, item_type: &str) -> AppResult<()> {
+        match result {
+            Err(AppError::Validation(message)) => {
+                log::warn!(
+                    "dropping malformed {item_type} item, keeping envelope siblings: {message}"
+                );
+                Ok(())
+            }
+            other => other,
+        }
+    }
+
     // 4. Typed dispatch — exhaustive, compiler-verified.
     //    event_id validation is deferred until after the loop — session-only envelopes never need
     //    one (Relay: Item::requires_event() returns false for Session/Sessions).
@@ -101,10 +120,13 @@ pub async fn ingest_envelope(
                     ingested_at,
                     &remote_addr,
                 );
-                processors
-                    .sessions
-                    .process(SessionItem::Update(s), &ctx)
-                    .await?;
+                drop_malformed_item(
+                    processors
+                        .sessions
+                        .process(SessionItem::Update(s), &ctx)
+                        .await,
+                    "session",
+                )?;
             }
             EnvelopeItemKind::Sessions(s) => {
                 let ctx = direct_store_ctx(
@@ -114,10 +136,13 @@ pub async fn ingest_envelope(
                     ingested_at,
                     &remote_addr,
                 );
-                processors
-                    .sessions
-                    .process(SessionItem::Aggregates(s), &ctx)
-                    .await?;
+                drop_malformed_item(
+                    processors
+                        .sessions
+                        .process(SessionItem::Aggregates(s), &ctx)
+                        .await,
+                    "sessions",
+                )?;
             }
             EnvelopeItemKind::Log(payload) => {
                 // Logs are processed inline (parse container + store): the work is
@@ -129,7 +154,7 @@ pub async fn ingest_envelope(
                     ingested_at,
                     &remote_addr,
                 );
-                processors.logs.process(payload, &ctx).await?;
+                drop_malformed_item(processors.logs.process(payload, &ctx).await, "log")?;
             }
             EnvelopeItemKind::Span(payload) => {
                 // Unlike Event/Transaction, an envelope may carry many standalone
@@ -175,7 +200,10 @@ pub async fn ingest_envelope(
             ingested_at,
             remote_addr: remote_addr.clone(),
         };
-        processors.transactions.process(txn_payload, &ctx).await?;
+        drop_malformed_item(
+            processors.transactions.process(txn_payload, &ctx).await,
+            "transaction",
+        )?;
     }
 
     // Persist standalone spans inline; they have no grouping or issue path.
@@ -187,7 +215,10 @@ pub async fn ingest_envelope(
             ingested_at,
             remote_addr: remote_addr.clone(),
         };
-        processors.spans.process_batch(span_items, &ctx).await?;
+        drop_malformed_item(
+            processors.spans.process_batch(span_items, &ctx).await,
+            "span",
+        )?;
     }
 
     // Persist v2 span batches inline for the same reason.
@@ -200,7 +231,10 @@ pub async fn ingest_envelope(
             remote_addr: remote_addr.clone(),
         };
         for batch_payload in span_v2_items {
-            processors.spans_v2.process(batch_payload, &ctx).await?;
+            drop_malformed_item(
+                processors.spans_v2.process(batch_payload, &ctx).await,
+                "span container",
+            )?;
         }
     }
 

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -258,28 +258,44 @@ pub async fn recover_pending_events(
     processors: web::Data<Processors>,
     ingest_dir: std::path::PathBuf,
 ) {
-    const RECOVERY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+    let mut previous_delay = None;
 
     loop {
-        recover_pending_events_once(pool.clone(), processors.clone(), ingest_dir.clone()).await;
-        tokio::time::sleep(RECOVERY_INTERVAL).await;
+        let has_pending = recover_pending_events_once_with_status(
+            pool.clone(),
+            processors.clone(),
+            ingest_dir.clone(),
+        )
+        .await;
+        let delay = next_recovery_delay(previous_delay, has_pending);
+        previous_delay = has_pending.then_some(delay);
+        tokio::time::sleep(delay).await;
     }
 }
 
-/// Performs one bounded recovery scan.
+/// Processes the current set of pending event files once.
 pub async fn recover_pending_events_once(
     pool: DbPool,
     processors: web::Data<Processors>,
     ingest_dir: std::path::PathBuf,
 ) {
+    let _ = recover_pending_events_once_with_status(pool, processors, ingest_dir).await;
+}
+
+async fn recover_pending_events_once_with_status(
+    pool: DbPool,
+    processors: web::Data<Processors>,
+    ingest_dir: std::path::PathBuf,
+) -> bool {
     let pending = match list_pending_event_metadata(&ingest_dir).await {
         Ok(pending) => pending,
         Err(e) => {
             log::error!("Failed to scan pending event metadata: {:?}", e);
-            return;
+            return true;
         }
     };
 
+    let mut has_pending = false;
     for metadata in pending {
         let event_id = metadata.event_id.clone();
         let ctx = ProcessorCtx {
@@ -291,9 +307,26 @@ pub async fn recover_pending_events_once(
             remote_addr: metadata.remote_addr.clone(),
         };
         if let Err(e) = processors.errors.process(metadata, &ctx).await {
+            has_pending = true;
             log::warn!("Pending digest {} remains queued: {:?}", event_id, e);
         }
     }
+    has_pending
+}
+
+fn next_recovery_delay(
+    previous_delay: Option<std::time::Duration>,
+    has_pending: bool,
+) -> std::time::Duration {
+    const MIN: std::time::Duration = std::time::Duration::from_secs(1);
+    const MAX: std::time::Duration = std::time::Duration::from_secs(30);
+
+    if !has_pending {
+        return MAX;
+    }
+    previous_delay
+        .map(|delay| delay.saturating_mul(2).min(MAX))
+        .unwrap_or(MIN)
 }
 
 /// Builds a [`ProcessorCtx`] for session items, which carry no event id.
@@ -347,4 +380,31 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
                 web::method(actix_web::http::Method::OPTIONS).to(options),
             ),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::next_recovery_delay;
+    use std::time::Duration;
+
+    #[test]
+    fn recovery_backoff_starts_small_and_caps() {
+        assert_eq!(next_recovery_delay(None, true), Duration::from_secs(1));
+        assert_eq!(
+            next_recovery_delay(Some(Duration::from_secs(8)), true),
+            Duration::from_secs(16)
+        );
+        assert_eq!(
+            next_recovery_delay(Some(Duration::from_secs(30)), true),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn recovery_backoff_resets_when_idle() {
+        assert_eq!(
+            next_recovery_delay(Some(Duration::from_secs(16)), false),
+            Duration::from_secs(30)
+        );
+    }
 }

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -149,7 +149,7 @@ pub async fn ingest_envelope(
         }
     }
 
-    // 5. Resolve event_id — only required when there is an event item.
+    // 5. Resolve event_id — only required for event-bearing item types.
     //    If the SDK omitted it, derive it from the durable delivery identity.
     //    For session-only envelopes, pass through whatever the SDK provided (may be None).
     let event_id = resolve_event_id(envelope.headers.event_id, delivery_id, requires_event_id);

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -93,32 +93,23 @@ pub async fn ingest_envelope(
             }
             EnvelopeItemKind::Session(s) => {
                 let ctx = direct_store_ctx(&pool, auth.project.id, ingested_at, &remote_addr);
-                if let Err(e) = processors
+                processors
                     .sessions
                     .process(SessionItem::Update(s), &ctx)
-                    .await
-                {
-                    log::warn!("session item processing failed: {:?}", e);
-                }
+                    .await?;
             }
             EnvelopeItemKind::Sessions(s) => {
                 let ctx = direct_store_ctx(&pool, auth.project.id, ingested_at, &remote_addr);
-                if let Err(e) = processors
+                processors
                     .sessions
                     .process(SessionItem::Aggregates(s), &ctx)
-                    .await
-                {
-                    log::warn!("sessions item processing failed: {:?}", e);
-                }
+                    .await?;
             }
             EnvelopeItemKind::Log(payload) => {
                 // Logs are processed inline (parse container + store): the work is
-                // bounded and storing before responding keeps the batch durable —
-                // a spawned task could lose logs on shutdown. Mirrors sessions.
+                // bounded and storing before responding keeps the batch durable.
                 let ctx = direct_store_ctx(&pool, auth.project.id, ingested_at, &remote_addr);
-                if let Err(e) = processors.logs.process(payload, &ctx).await {
-                    log::warn!("log item processing failed: {:?}", e);
-                }
+                processors.logs.process(payload, &ctx).await?;
             }
             EnvelopeItemKind::Span(payload) => {
                 // Unlike Event/Transaction, an envelope may carry many standalone
@@ -153,85 +144,53 @@ pub async fn ingest_envelope(
         envelope.headers.event_id.clone()
     };
 
-    // 6. Spawn transaction processing (direct, bypasses filesystem and digest worker).
-    //    Must happen BEFORE the early-return so transaction-only envelopes are stored.
+    // Persist direct items before the early return; otherwise 200 could suppress
+    // an SDK retry for data that was never stored.
     if let Some(txn_payload) = transaction_item {
-        let processors = processors.clone();
-        let pool_clone = pool.get_ref().clone();
         let event_id_txn = event_id
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().replace("-", ""));
-        let project_id = auth.project.id;
-        let ingested = ingested_at;
-        let remote = remote_addr.clone();
-        tokio::spawn(async move {
-            let parsed_id =
-                uuid::Uuid::parse_str(&event_id_txn).unwrap_or_else(|_| uuid::Uuid::new_v4());
-            let ctx = ProcessorCtx {
-                pool: pool_clone,
-                project_id,
-                event_id: parsed_id,
-                ingested_at: ingested,
-                remote_addr: remote,
-            };
-            if let Err(e) = processors.transactions.process(txn_payload, &ctx).await {
-                log::error!("Failed to store transaction {}: {:?}", event_id_txn, e);
-            }
-        });
+        let parsed_id =
+            uuid::Uuid::parse_str(&event_id_txn).unwrap_or_else(|_| uuid::Uuid::new_v4());
+        let ctx = ProcessorCtx {
+            pool: pool.get_ref().clone(),
+            project_id: auth.project.id,
+            event_id: parsed_id,
+            ingested_at,
+            remote_addr: remote_addr.clone(),
+        };
+        processors.transactions.process(txn_payload, &ctx).await?;
     }
 
-    // 6b. Spawn standalone span processing (direct, bypasses filesystem and
-    //     digest worker) — same rationale as transactions: no grouping/issue
-    //     concept, so no need for the durable temp-file path. Must happen
-    //     BEFORE the early-return so span-only envelopes are stored.
+    // Persist standalone spans inline; they have no grouping or issue path.
     if !span_items.is_empty() {
-        let processors = processors.clone();
-        let pool_clone = pool.get_ref().clone();
-        let project_id = auth.project.id;
-        let ingested = ingested_at;
-        let remote = remote_addr.clone();
-        tokio::spawn(async move {
-            let ctx = ProcessorCtx {
-                pool: pool_clone,
-                project_id,
-                event_id: uuid::Uuid::nil(),
-                ingested_at: ingested,
-                remote_addr: remote,
-            };
-            for span_payload in span_items {
-                if let Err(e) = processors.spans.process(span_payload, &ctx).await {
-                    log::warn!("Failed to store standalone span: {:?}", e);
-                }
-            }
-        });
+        let ctx = ProcessorCtx {
+            pool: pool.get_ref().clone(),
+            project_id: auth.project.id,
+            event_id: uuid::Uuid::nil(),
+            ingested_at,
+            remote_addr: remote_addr.clone(),
+        };
+        for span_payload in span_items {
+            processors.spans.process(span_payload, &ctx).await?;
+        }
     }
 
-    // 6c. Spawn Spans Protocol v2 batch processing — same rationale as 6b,
-    //     just a different (batched, typed-attribute) wire format. Must
-    //     happen BEFORE the early-return so v2-span-only envelopes are stored.
+    // Persist v2 span batches inline for the same reason.
     if !span_v2_items.is_empty() {
-        let processors = processors.clone();
-        let pool_clone = pool.get_ref().clone();
-        let project_id = auth.project.id;
-        let ingested = ingested_at;
-        let remote = remote_addr.clone();
-        tokio::spawn(async move {
-            let ctx = ProcessorCtx {
-                pool: pool_clone,
-                project_id,
-                event_id: uuid::Uuid::nil(),
-                ingested_at: ingested,
-                remote_addr: remote,
-            };
-            for batch_payload in span_v2_items {
-                if let Err(e) = processors.spans_v2.process(batch_payload, &ctx).await {
-                    log::warn!("Failed to store span v2 batch: {:?}", e);
-                }
-            }
-        });
+        let ctx = ProcessorCtx {
+            pool: pool.get_ref().clone(),
+            project_id: auth.project.id,
+            event_id: uuid::Uuid::nil(),
+            ingested_at,
+            remote_addr: remote_addr.clone(),
+        };
+        for batch_payload in span_v2_items {
+            processors.spans_v2.process(batch_payload, &ctx).await?;
+        }
     }
 
-    // 7. Early return for session-only (and other non-event) envelopes.
+    // Return for session-only and other non-event envelopes.
     let event_item = match event_item {
         Some(item) => item,
         None => {
@@ -240,15 +199,12 @@ pub async fn ingest_envelope(
         }
     };
 
-    // event_id is guaranteed Some from this point: event_item.is_some() was true above.
     let event_id = event_id.expect("event_id is Some when event_item is Some");
 
-    // 6. Validate that payload is valid JSON
     let _: serde_json::Value = serde_json::from_slice(&event_item)
         .map_err(|e| AppError::Validation(format!("Invalid event JSON: {}", e)))?;
 
-    // 7. Create metadata and store it beside the raw event so a failed digest
-    // can be recovered after the process restarts.
+    // Store metadata beside the raw event so a failed digest can be recovered.
     let metadata = EventMetadata {
         event_id: event_id.clone(),
         project_id: auth.project.id,
@@ -257,8 +213,7 @@ pub async fn ingest_envelope(
     };
     store_event_with_metadata(&ingest_dir, &event_id, &event_item, &metadata).await?;
 
-    // 8. Spawn digest task — the ErrorProcessor reads the temp file and runs
-    //    grouping/issue creation. It owns ingest_dir/rate_limit/sourcemap deps.
+    // The digest worker owns grouping, issue creation, and its durable retry path.
     let processors = processors.clone();
     let pool_clone = pool.get_ref().clone();
     tokio::spawn(async move {
@@ -296,7 +251,6 @@ pub async fn ingest_envelope(
         }
     });
 
-    // 9. Return immediately (CORS handled by middleware)
     Ok(HttpResponse::Ok().json(IngestResponse { id: Some(event_id) }))
 }
 
@@ -314,8 +268,7 @@ pub async fn recover_pending_events(
     }
 }
 
-/// Performs one bounded recovery scan; kept separate so startup workers and
-/// tests can exercise exactly one replay pass.
+/// Performs one bounded recovery scan.
 pub async fn recover_pending_events_once(
     pool: DbPool,
     processors: web::Data<Processors>,

--- a/apps/server/src/routes/ingest.rs
+++ b/apps/server/src/routes/ingest.rs
@@ -150,26 +150,22 @@ pub async fn ingest_envelope(
     }
 
     // 5. Resolve event_id — only required when there is an event item.
-    //    If the SDK omitted it, auto-generate (mirrors Relay's get_or_insert_with(EventId::new)).
+    //    If the SDK omitted it, derive it from the durable delivery identity.
     //    For session-only envelopes, pass through whatever the SDK provided (may be None).
-    let event_id: Option<String> = if requires_event_id {
-        let id = envelope
-            .headers
-            .event_id
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().replace("-", ""));
-        uuid::Uuid::parse_str(&id)
-            .map_err(|_| AppError::Validation("event_id must be a valid UUID".to_string()))?;
-        Some(id)
-    } else {
-        envelope.headers.event_id.clone()
-    };
+    let event_id = resolve_event_id(envelope.headers.event_id, delivery_id, requires_event_id);
+    if requires_event_id {
+        if let Some(id) = &event_id {
+            uuid::Uuid::parse_str(id)
+                .map_err(|_| AppError::Validation("event_id must be a valid UUID".to_string()))?;
+        }
+    }
 
     // Persist direct items before the early return; otherwise 200 could suppress
     // an SDK retry for data that was never stored.
     if let Some(txn_payload) = transaction_item {
         let event_id_txn = event_id
             .clone()
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().replace("-", ""));
+            .unwrap_or_else(|| delivery_id.simple().to_string());
         let parsed_id =
             uuid::Uuid::parse_str(&event_id_txn).unwrap_or_else(|_| uuid::Uuid::new_v4());
         let ctx = ProcessorCtx {
@@ -377,6 +373,18 @@ fn stable_delivery_id(event_id: Option<&str>, envelope: &[u8]) -> uuid::Uuid {
         })
 }
 
+fn resolve_event_id(
+    event_id: Option<String>,
+    delivery_id: uuid::Uuid,
+    requires_event_id: bool,
+) -> Option<String> {
+    if requires_event_id {
+        Some(event_id.unwrap_or_else(|| delivery_id.simple().to_string()))
+    } else {
+        event_id
+    }
+}
+
 /// POST /api/{project_id}/store/
 /// Legacy endpoint (deprecated)
 pub async fn ingest_store(
@@ -416,7 +424,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
 
 #[cfg(test)]
 mod tests {
-    use super::{next_recovery_delay, stable_delivery_id};
+    use super::{next_recovery_delay, resolve_event_id, stable_delivery_id};
     use std::time::Duration;
 
     #[test]
@@ -453,6 +461,24 @@ mod tests {
         assert_eq!(
             stable_delivery_id(Some(&event_id.to_string()), b"ignored"),
             event_id
+        );
+    }
+
+    #[test]
+    fn headerless_required_event_uses_delivery_id() {
+        let delivery_id = uuid::Uuid::nil();
+        assert_eq!(
+            resolve_event_id(None, delivery_id, true),
+            Some(delivery_id.simple().to_string())
+        );
+    }
+
+    #[test]
+    fn session_event_id_is_not_synthesized() {
+        assert_eq!(resolve_event_id(None, uuid::Uuid::nil(), false), None);
+        assert_eq!(
+            resolve_event_id(Some("session-id".to_string()), uuid::Uuid::nil(), false),
+            Some("session-id".to_string())
         );
     }
 }

--- a/apps/server/src/routes/sourcemaps.rs
+++ b/apps/server/src/routes/sourcemaps.rs
@@ -294,7 +294,10 @@ pub async fn artifact_bundle_assemble(
     }
 
     // INSERT ... ON CONFLICT: re-queue if the existing job errored, otherwise leave it.
-    // chunks = EXCLUDED.chunks: update the chunk list so a re-submit with corrected chunks is honoured.
+    // Keep ownership rows in the same transaction so a worker cannot complete
+    // between the job update and the reference insert.
+    let mut tx = pool.begin().await?;
+
     #[cfg(feature = "postgres")]
     let job: Option<crate::models::source_file::AssemblyJob> = sqlx::query_as(
         r#"
@@ -309,7 +312,7 @@ pub async fn artifact_bundle_assemble(
     .bind(&body.checksum)
     .bind(project_id)
     .bind(&body.chunks as &Vec<String>)
-    .fetch_optional(pool.get_ref())
+    .fetch_optional(&mut *tx)
     .await?;
 
     #[cfg(not(feature = "postgres"))]
@@ -329,11 +332,12 @@ pub async fn artifact_bundle_assemble(
         .bind(&body.checksum)
         .bind(project_id)
         .bind(&chunks_json)
-        .fetch_optional(pool.get_ref())
+        .fetch_optional(&mut *tx)
         .await?
     };
 
     // If None (conflict — job already exists): fetch existing
+    let inserted_job = job.is_some();
     let job = match job {
         Some(j) => j,
         None => {
@@ -342,10 +346,28 @@ pub async fn artifact_bundle_assemble(
             )
             .bind(&body.checksum)
             .bind(project_id)
-            .fetch_one(pool.get_ref())
+            .fetch_one(&mut *tx)
             .await?
         }
     };
+
+    if inserted_job {
+        sqlx::query("DELETE FROM assembly_job_chunks WHERE job_id = $1")
+            .bind(job.id)
+            .execute(&mut *tx)
+            .await?;
+        for checksum in &body.chunks {
+            sqlx::query(
+                "INSERT INTO assembly_job_chunks(job_id, checksum) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+            )
+            .bind(job.id)
+            .bind(checksum)
+            .execute(&mut *tx)
+            .await?;
+        }
+    }
+
+    tx.commit().await?;
 
     Ok(assembly_state_response(
         job.state.as_str(),

--- a/apps/server/src/routes/sourcemaps.rs
+++ b/apps/server/src/routes/sourcemaps.rs
@@ -297,6 +297,24 @@ pub async fn artifact_bundle_assemble(
     // Keep ownership rows in the same transaction so a worker cannot complete
     // between the job update and the reference insert.
     let mut tx = pool.begin().await?;
+    let mut missing = Vec::new();
+    for checksum in &body.chunks {
+        let present: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM chunk WHERE checksum = $1)")
+                .bind(checksum)
+                .fetch_one(&mut *tx)
+                .await?;
+        if !present {
+            missing.push(checksum.clone());
+        }
+    }
+    if !missing.is_empty() {
+        return Ok(HttpResponse::Ok().json(AssembleResponse {
+            state: "not_found".to_string(),
+            missing_chunks: missing,
+            detail: None,
+        }));
+    }
 
     #[cfg(feature = "postgres")]
     let job: Option<crate::models::source_file::AssemblyJob> = sqlx::query_as(

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -767,7 +767,7 @@ impl AlertService {
             .execute(pool)
             .await?;
         } else {
-            let delay_secs = retry_delay(attempt_count);
+            let delay_secs = retry_delay(attempt_count, history_id);
             let next_retry = Utc::now() + Duration::seconds(delay_secs);
             sqlx::query(
                 "UPDATE alert_history SET status = 'pending', attempt_count = $2, error_message = $3, http_status_code = $4, next_retry_at = $5 WHERE id = $1",
@@ -922,9 +922,11 @@ impl AlertService {
     }
 }
 
-fn retry_delay(attempt_count: i32) -> i64 {
+fn retry_delay(attempt_count: i32, history_id: i64) -> i64 {
     let exponent = attempt_count.saturating_sub(1).min(6) as u32;
-    std::cmp::min(60 * 2_i64.pow(exponent), 3600)
+    let base = 60 * 2_i64.pow(exponent);
+    let jitter = history_id.rem_euclid(30);
+    std::cmp::min(base + jitter, 3600)
 }
 
 #[cfg(test)]
@@ -972,7 +974,8 @@ mod tests {
 
     #[test]
     fn retry_delay_is_bounded_for_large_attempt_counts() {
-        assert_eq!(retry_delay(1), 60);
-        assert_eq!(retry_delay(i32::MAX), 3600);
+        assert_eq!(retry_delay(1, 0), 60);
+        assert_eq!(retry_delay(1, 29), 89);
+        assert_eq!(retry_delay(i32::MAX, i64::MAX), 3600);
     }
 }

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -23,6 +23,8 @@ fn event_alert_id(event_id: Uuid, alert_type: &AlertType) -> String {
 
 pub struct AlertService;
 
+pub const MAX_ALERT_RETRIES: i32 = 5;
+
 impl AlertService {
     // =========================================================================
     // Alert Integration CRUD (replaces Notification Channel CRUD)
@@ -681,7 +683,15 @@ impl AlertService {
         // 5. Attempt each durable delivery before the event worker deletes its
         // source record; committed pending rows cover a crash during dispatch.
         for (history_id, rule_channel) in history_ids {
-            Self::dispatch_history(pool, history_id, 0, &payload, &rule_channel, 5).await?;
+            Self::dispatch_history(
+                pool,
+                history_id,
+                0,
+                &payload,
+                &rule_channel,
+                MAX_ALERT_RETRIES,
+            )
+            .await?;
         }
 
         Ok(())

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -767,8 +767,7 @@ impl AlertService {
             .execute(pool)
             .await?;
         } else {
-            let delay_secs =
-                std::cmp::min(60 * 2_i64.pow(attempt_count.saturating_sub(1) as u32), 3600);
+            let delay_secs = retry_delay(attempt_count);
             let next_retry = Utc::now() + Duration::seconds(delay_secs);
             sqlx::query(
                 "UPDATE alert_history SET status = 'pending', attempt_count = $2, error_message = $3, http_status_code = $4, next_retry_at = $5 WHERE id = $1",
@@ -923,6 +922,11 @@ impl AlertService {
     }
 }
 
+fn retry_delay(attempt_count: i32) -> i64 {
+    let exponent = attempt_count.saturating_sub(1).min(6) as u32;
+    std::cmp::min(60 * 2_i64.pow(exponent), 3600)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -964,5 +968,11 @@ mod tests {
         });
         let payload: AlertPayload = serde_json::from_value(stored.clone()).unwrap();
         assert_eq!(serde_json::to_value(payload).unwrap(), stored);
+    }
+
+    #[test]
+    fn retry_delay_is_bounded_for_large_attempt_counts() {
+        assert_eq!(retry_delay(1), 60);
+        assert_eq!(retry_delay(i32::MAX), 3600);
     }
 }

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -752,7 +752,7 @@ impl AlertService {
         let result = create_dispatcher(integration.provider_type)
             .send(&integration, &rule_channel.routing_override, payload)
             .await;
-        let attempt_count = previous_attempt_count + 1;
+        let attempt_count = next_attempt_count(previous_attempt_count);
 
         if result.success {
             sqlx::query(
@@ -941,6 +941,10 @@ fn retry_delay(attempt_count: i32, history_id: i64) -> i64 {
     std::cmp::min(base + jitter, 3600)
 }
 
+fn next_attempt_count(previous: i32) -> i32 {
+    previous.max(0).saturating_add(1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -990,5 +994,11 @@ mod tests {
         assert_eq!(retry_delay(1, 29), 89);
         assert_eq!(retry_delay(-1, 0), 60);
         assert_eq!(retry_delay(i32::MAX, i64::MAX), 3600);
+    }
+
+    #[test]
+    fn next_attempt_count_is_bounded() {
+        assert_eq!(next_attempt_count(-1), 1);
+        assert_eq!(next_attempt_count(i32::MAX), i32::MAX);
     }
 }

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -17,8 +17,8 @@ use crate::models::{
 };
 use crate::services::notification::create_dispatcher;
 
-fn event_alert_id(event_id: Uuid, alert_type: &AlertType) -> String {
-    format!("event-{event_id}-{alert_type}")
+fn event_alert_id(project_id: i32, event_id: Uuid, alert_type: &AlertType) -> String {
+    format!("event-{project_id}-{event_id}-{alert_type}")
 }
 
 pub struct AlertService;
@@ -484,7 +484,7 @@ impl AlertService {
             issue,
             alert_type,
             dashboard_url,
-            Some(event_alert_id(event_id, &alert_type)),
+            Some(event_alert_id(project.id, event_id, &alert_type)),
         )
         .await
     }
@@ -700,14 +700,18 @@ impl AlertService {
     /// Returns whether durable history already exists for an event alert.
     pub async fn event_alert_exists(
         pool: &DbPool,
+        project_id: i32,
         event_id: Uuid,
         alert_type: AlertType,
     ) -> AppResult<bool> {
-        let prefix = format!("event-{event_id}-{alert_type}-%");
+        let prefix = format!("event-{project_id}-{event_id}-{alert_type}-%");
+        let legacy_prefix = format!("event-{event_id}-{alert_type}-%");
         let exists: bool = sqlx::query_scalar(
-            "SELECT EXISTS(SELECT 1 FROM alert_history WHERE idempotency_key LIKE $1)",
+            "SELECT EXISTS(SELECT 1 FROM alert_history WHERE project_id = $1 AND (idempotency_key LIKE $2 OR idempotency_key LIKE $3))",
         )
+        .bind(project_id)
         .bind(prefix)
+        .bind(legacy_prefix)
         .fetch_one(pool)
         .await?;
         Ok(exists)
@@ -968,12 +972,16 @@ mod tests {
     fn event_alert_id_is_stable_across_retries() {
         let event_id = Uuid::nil();
         assert_eq!(
-            event_alert_id(event_id, &AlertType::NewIssue),
-            event_alert_id(event_id, &AlertType::NewIssue)
+            event_alert_id(1, event_id, &AlertType::NewIssue),
+            event_alert_id(1, event_id, &AlertType::NewIssue)
         );
         assert_ne!(
-            event_alert_id(event_id, &AlertType::NewIssue),
-            event_alert_id(event_id, &AlertType::Regression)
+            event_alert_id(1, event_id, &AlertType::NewIssue),
+            event_alert_id(1, event_id, &AlertType::Regression)
+        );
+        assert_ne!(
+            event_alert_id(1, event_id, &AlertType::NewIssue),
+            event_alert_id(2, event_id, &AlertType::NewIssue)
         );
     }
 

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -17,6 +17,10 @@ use crate::models::{
 };
 use crate::services::notification::create_dispatcher;
 
+fn event_alert_id(event_id: Uuid, alert_type: &AlertType) -> String {
+    format!("event-{event_id}-{alert_type}")
+}
+
 pub struct AlertService;
 
 impl AlertService {
@@ -434,7 +438,15 @@ impl AlertService {
         issue: &Issue,
         dashboard_url: &str,
     ) -> AppResult<()> {
-        Self::trigger_alert(pool, project, issue, AlertType::NewIssue, dashboard_url).await
+        Self::trigger_alert(
+            pool,
+            project,
+            issue,
+            AlertType::NewIssue,
+            dashboard_url,
+            None,
+        )
+        .await
     }
 
     /// Triggers an alert for a regression
@@ -444,7 +456,35 @@ impl AlertService {
         issue: &Issue,
         dashboard_url: &str,
     ) -> AppResult<()> {
-        Self::trigger_alert(pool, project, issue, AlertType::Regression, dashboard_url).await
+        Self::trigger_alert(
+            pool,
+            project,
+            issue,
+            AlertType::Regression,
+            dashboard_url,
+            None,
+        )
+        .await
+    }
+
+    /// Enqueues the alert for one durable event with a retry-stable identity.
+    pub async fn trigger_event_alert(
+        pool: &DbPool,
+        project: &Project,
+        issue: &Issue,
+        alert_type: AlertType,
+        event_id: Uuid,
+        dashboard_url: &str,
+    ) -> AppResult<()> {
+        Self::trigger_alert(
+            pool,
+            project,
+            issue,
+            alert_type,
+            dashboard_url,
+            Some(event_alert_id(event_id, &alert_type)),
+        )
+        .await
     }
 
     /// Triggers an alert for an unmute
@@ -455,7 +495,7 @@ impl AlertService {
         issue: &Issue,
         dashboard_url: &str,
     ) -> AppResult<()> {
-        Self::trigger_alert(pool, project, issue, AlertType::Unmute, dashboard_url).await
+        Self::trigger_alert(pool, project, issue, AlertType::Unmute, dashboard_url, None).await
     }
 
     /// Builds the dashboard URL for viewing an issue.
@@ -477,6 +517,7 @@ impl AlertService {
         issue: &Issue,
         alert_type: AlertType,
         dashboard_url: &str,
+        stable_alert_id: Option<String>,
     ) -> AppResult<()> {
         // 1. Find enabled rule for this project and alert type
         let rule: Option<AlertRule> = sqlx::query_as(
@@ -504,43 +545,7 @@ impl AlertService {
             }
         };
 
-        // 2. Atomically check cooldown and update last_triggered_at
-        let cooldown_threshold = Utc::now() - Duration::minutes(rule.cooldown_minutes as i64);
-
-        #[cfg(feature = "postgres")]
-        let updated = sqlx::query(
-            r#"
-            UPDATE alert_rules
-            SET last_triggered_at = CURRENT_TIMESTAMP
-            WHERE id = $1
-              AND (last_triggered_at IS NULL OR last_triggered_at < $2)
-            "#,
-        )
-        .bind(rule.id)
-        .bind(cooldown_threshold)
-        .execute(pool)
-        .await?;
-
-        #[cfg(feature = "sqlite")]
-        let updated = sqlx::query(
-            r#"
-            UPDATE alert_rules
-            SET last_triggered_at = datetime('now')
-            WHERE id = $1
-              AND (last_triggered_at IS NULL OR datetime(last_triggered_at) < datetime($2))
-            "#,
-        )
-        .bind(rule.id)
-        .bind(cooldown_threshold.naive_utc())
-        .execute(pool)
-        .await?;
-
-        if updated.rows_affected() == 0 {
-            log::debug!("Alert rule {} not found or in cooldown period", rule.id);
-            return Ok(());
-        }
-
-        // 3. Get associated rule channels (only enabled integrations — SCL-1)
+        // 2. Get associated rule channels (only enabled integrations — SCL-1)
         let rule_channels: Vec<AlertRuleChannel> = sqlx::query_as(
             r#"
             SELECT arc.alert_rule_id, arc.integration_id, arc.routing_override
@@ -558,14 +563,22 @@ impl AlertService {
             return Ok(());
         }
 
-        // 4. Build payload
+        let mut channels = Vec::with_capacity(rule_channels.len());
+        for rule_channel in rule_channels {
+            let integration = Self::get_channel(pool, rule_channel.integration_id).await?;
+            channels.push((rule_channel, integration));
+        }
+
+        // 3. Build payload
         let payload = AlertPayload {
-            alert_id: format!(
-                "{}-{}-{}",
-                project.id,
-                issue.id,
-                Utc::now().timestamp_millis()
-            ),
+            alert_id: stable_alert_id.unwrap_or_else(|| {
+                format!(
+                    "{}-{}-{}",
+                    project.id,
+                    issue.id,
+                    Utc::now().timestamp_millis()
+                )
+            }),
             alert_type: alert_type.to_string(),
             triggered_at: Utc::now(),
             project: ProjectInfo {
@@ -593,162 +606,180 @@ impl AlertService {
             project.name
         );
 
-        // 5. Dispatch to all rule channels (spawn tasks for parallel execution)
-        for rule_channel in rule_channels {
-            let pool = pool.clone();
-            let payload = payload.clone();
-            let rule_id = rule.id;
+        // 4. Reserve the cooldown and enqueue every delivery atomically. A
+        // failed enqueue must leave the rule eligible for durable event retry.
+        let cooldown_threshold = Utc::now() - Duration::minutes(rule.cooldown_minutes as i64);
+        let mut tx = pool.begin().await?;
 
-            tokio::spawn(async move {
-                if let Err(e) =
-                    Self::dispatch_to_channel(&pool, &rule_channel, &payload, rule_id).await
-                {
-                    log::error!(
-                        "Failed to dispatch alert to integration {} (rule {}): {}",
-                        rule_channel.integration_id,
-                        rule_id,
-                        e
-                    );
-                }
-            });
+        #[cfg(feature = "postgres")]
+        let updated = sqlx::query(
+            r#"
+            UPDATE alert_rules
+            SET last_triggered_at = CURRENT_TIMESTAMP
+            WHERE id = $1
+              AND (last_triggered_at IS NULL OR last_triggered_at < $2)
+            "#,
+        )
+        .bind(rule.id)
+        .bind(cooldown_threshold)
+        .execute(&mut *tx)
+        .await?;
+
+        #[cfg(feature = "sqlite")]
+        let updated = sqlx::query(
+            r#"
+            UPDATE alert_rules
+            SET last_triggered_at = datetime('now')
+            WHERE id = $1
+              AND (last_triggered_at IS NULL OR datetime(last_triggered_at) < datetime($2))
+            "#,
+        )
+        .bind(rule.id)
+        .bind(cooldown_threshold.naive_utc())
+        .execute(&mut *tx)
+        .await?;
+
+        if updated.rows_affected() == 0 {
+            log::debug!("Alert rule {} not found or in cooldown period", rule.id);
+            return Ok(());
+        }
+
+        let mut history_ids = Vec::with_capacity(channels.len());
+        for (rule_channel, integration) in &channels {
+            let idempotency_key = format!("{}-{}", payload.alert_id, integration.id);
+            let issue_uuid = Uuid::parse_str(&payload.issue.id).ok();
+            let history_id: Option<(i64,)> = sqlx::query_as(
+                r#"
+                INSERT INTO alert_history (
+                    alert_rule_id, integration_id, issue_id, project_id,
+                    alert_type, channel_type, channel_name, payload,
+                    status, idempotency_key
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending', $9)
+                ON CONFLICT (idempotency_key) DO NOTHING
+                RETURNING id
+                "#,
+            )
+            .bind(rule.id)
+            .bind(rule_channel.integration_id)
+            .bind(issue_uuid)
+            .bind(payload.project.id)
+            .bind(&payload.alert_type)
+            .bind(integration.provider_type.to_string())
+            .bind(&integration.name)
+            .bind(serde_json::to_value(&payload).map_err(|e| AppError::Internal(e.to_string()))?)
+            .bind(&idempotency_key)
+            .fetch_optional(&mut *tx)
+            .await?;
+
+            if let Some(history_id) = history_id {
+                history_ids.push((history_id.0, rule_channel.clone()));
+            }
+        }
+        tx.commit().await?;
+
+        // 5. Attempt each durable delivery before the event worker deletes its
+        // source record; committed pending rows cover a crash during dispatch.
+        for (history_id, rule_channel) in history_ids {
+            Self::dispatch_history(pool, history_id, 0, &payload, &rule_channel, 5).await?;
         }
 
         Ok(())
     }
 
-    /// Dispatches an alert to a single rule channel (integration + routing)
-    async fn dispatch_to_channel(
-        pool: &DbPool,
-        rule_channel: &AlertRuleChannel,
-        payload: &AlertPayload,
-        rule_id: i32,
-    ) -> AppResult<()> {
-        let integration_id = rule_channel.integration_id;
-        let idempotency_key = format!("{}-{}", payload.alert_id, integration_id);
-
-        // Fetch integration record
-        let integration = Self::get_channel(pool, integration_id).await?;
-
-        // Parse issue_id as UUID
-        let issue_uuid = Uuid::parse_str(&payload.issue.id).ok();
-
-        // Create history record with idempotent insert
-        let history_id: Option<(i64,)> = sqlx::query_as(
-            r#"
-            INSERT INTO alert_history (
-                alert_rule_id, integration_id, issue_id, project_id,
-                alert_type, channel_type, channel_name,
-                status, idempotency_key
-            )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8)
-            ON CONFLICT (idempotency_key) DO NOTHING
-            RETURNING id
-            "#,
+    /// Returns whether durable history already exists for an event alert.
+    pub async fn event_alert_exists(pool: &DbPool, event_id: Uuid) -> AppResult<bool> {
+        let prefix = format!("event-{}-%", event_id);
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM alert_history WHERE idempotency_key LIKE $1)",
         )
-        .bind(rule_id)
-        .bind(integration_id)
-        .bind(issue_uuid)
-        .bind(payload.project.id)
-        .bind(&payload.alert_type)
-        .bind(integration.provider_type.to_string())
-        .bind(&integration.name)
-        .bind(&idempotency_key)
-        .fetch_optional(pool)
+        .bind(prefix)
+        .fetch_one(pool)
         .await?;
+        Ok(exists)
+    }
 
-        let history_id = match history_id {
-            Some(id) => id,
-            None => {
-                log::debug!("Alert {} already processed, skipping", idempotency_key);
-                return Ok(());
-            }
-        };
+    async fn dispatch_existing_history(
+        pool: &DbPool,
+        history: &AlertHistory,
+        rule_channel: &AlertRuleChannel,
+        max_retries: i32,
+    ) -> AppResult<()> {
+        let payload: AlertPayload = serde_json::from_value(history.payload.clone())
+            .map_err(|e| AppError::Internal(format!("invalid alert payload: {}", e)))?;
+        Self::dispatch_history(
+            pool,
+            history.id,
+            history.attempt_count,
+            &payload,
+            rule_channel,
+            max_retries,
+        )
+        .await
+    }
 
-        // Dispatch using appropriate notifier with routing_override
-        let dispatcher = create_dispatcher(integration.provider_type);
-        let result = dispatcher
-            .send(&integration, &rule_channel.routing_override, payload)
+    async fn dispatch_history(
+        pool: &DbPool,
+        history_id: i64,
+        previous_attempt_count: i32,
+        payload: &AlertPayload,
+        rule_channel: &AlertRuleChannel,
+        max_retries: i32,
+    ) -> AppResult<()> {
+        let integration = Self::get_channel(pool, rule_channel.integration_id).await?;
+        let result = create_dispatcher(integration.provider_type)
+            .send(&integration, &rule_channel.routing_override, &payload)
             .await;
+        let attempt_count = previous_attempt_count + 1;
 
-        // Update history and integration stats based on result
         if result.success {
             sqlx::query(
-                r#"
-                UPDATE alert_history
-                SET status = 'sent', sent_at = CURRENT_TIMESTAMP, http_status_code = $2
-                WHERE id = $1
-                "#,
+                "UPDATE alert_history SET status = 'sent', sent_at = CURRENT_TIMESTAMP, http_status_code = $2 WHERE id = $1",
             )
-            .bind(history_id.0)
+            .bind(history_id)
             .bind(result.http_status.map(|s| s as i32))
             .execute(pool)
             .await?;
-
             sqlx::query(
-                r#"
-                UPDATE alert_integrations
-                SET last_success_at = CURRENT_TIMESTAMP, failure_count = 0
-                WHERE id = $1
-                "#,
+                "UPDATE alert_integrations SET last_success_at = CURRENT_TIMESTAMP, failure_count = 0 WHERE id = $1",
             )
-            .bind(integration_id)
+            .bind(integration.id)
             .execute(pool)
             .await?;
-
-            log::info!(
-                "Alert sent successfully to integration {} ({})",
-                integration_id,
-                integration.name
-            );
-        } else {
-            // Calculate next retry with exponential backoff + jitter
-            let attempt_count = 1;
-            let base_delay = 60i64;
-            let max_delay = 3600i64;
-            let delay_secs = std::cmp::min(
-                base_delay * (2_i64.pow(attempt_count as u32 - 1)),
-                max_delay,
-            );
-            let jitter = (delay_secs as f64 * 0.1 * rand::random::<f64>()) as i64;
-            let next_retry = Utc::now() + Duration::seconds(delay_secs + jitter);
-
+        } else if attempt_count >= max_retries {
             sqlx::query(
-                r#"
-                UPDATE alert_history
-                SET status = 'pending', attempt_count = $2,
-                    error_message = $3, http_status_code = $4,
-                    next_retry_at = $5
-                WHERE id = $1
-                "#,
+                "UPDATE alert_history SET status = 'failed', attempt_count = $2, error_message = $3, http_status_code = $4 WHERE id = $1",
             )
-            .bind(history_id.0)
+            .bind(history_id)
+            .bind(attempt_count)
+            .bind(&result.error_message)
+            .bind(result.http_status.map(|s| s as i32))
+            .execute(pool)
+            .await?;
+        } else {
+            let delay_secs =
+                std::cmp::min(60 * 2_i64.pow(attempt_count.saturating_sub(1) as u32), 3600);
+            let next_retry = Utc::now() + Duration::seconds(delay_secs);
+            sqlx::query(
+                "UPDATE alert_history SET status = 'pending', attempt_count = $2, error_message = $3, http_status_code = $4, next_retry_at = $5 WHERE id = $1",
+            )
+            .bind(history_id)
             .bind(attempt_count)
             .bind(&result.error_message)
             .bind(result.http_status.map(|s| s as i32))
             .bind(next_retry)
             .execute(pool)
             .await?;
+        }
 
+        if !result.success {
             sqlx::query(
-                r#"
-                UPDATE alert_integrations
-                SET last_failure_at = CURRENT_TIMESTAMP,
-                    last_failure_message = $2,
-                    failure_count = failure_count + 1
-                WHERE id = $1
-                "#,
+                "UPDATE alert_integrations SET last_failure_at = CURRENT_TIMESTAMP, last_failure_message = $2, failure_count = failure_count + 1 WHERE id = $1",
             )
-            .bind(integration_id)
+            .bind(integration.id)
             .bind(&result.error_message)
             .execute(pool)
             .await?;
-
-            log::warn!(
-                "Alert to integration {} ({}) failed: {:?}",
-                integration_id,
-                integration.name,
-                result.error_message
-            );
         }
 
         Ok(())
@@ -767,7 +798,7 @@ impl AlertService {
         let history = sqlx::query_as::<_, AlertHistory>(
             r#"
             SELECT id, alert_rule_id, integration_id, issue_id, project_id,
-                   alert_type, channel_type, channel_name, status,
+                   alert_type, channel_type, channel_name, payload, status,
                    attempt_count, next_retry_at, error_message,
                    http_status_code, idempotency_key, created_at, sent_at
             FROM alert_history
@@ -791,7 +822,7 @@ impl AlertService {
         let pending: Vec<AlertHistory> = sqlx::query_as(
             r#"
             SELECT id, alert_rule_id, integration_id, issue_id, project_id,
-                   alert_type, channel_type, channel_name, status,
+                   alert_type, channel_type, channel_name, payload, status,
                    attempt_count, next_retry_at, error_message,
                    http_status_code, idempotency_key, created_at, sent_at
             FROM alert_history
@@ -808,7 +839,7 @@ impl AlertService {
         let pending: Vec<AlertHistory> = sqlx::query_as(
             r#"
             SELECT id, alert_rule_id, integration_id, issue_id, project_id,
-                   alert_type, channel_type, channel_name, status,
+                   alert_type, channel_type, channel_name, payload, status,
                    attempt_count, next_retry_at, error_message,
                    http_status_code, idempotency_key, created_at, sent_at
             FROM alert_history
@@ -838,13 +869,42 @@ impl AlertService {
                 continue;
             }
 
-            // For now, just mark as failed — full retry would require storing payload
-            sqlx::query(
-                "UPDATE alert_history SET status = 'failed', error_message = 'Retry not implemented' WHERE id = $1",
+            let (Some(rule_id), Some(integration_id)) =
+                (history.alert_rule_id, history.integration_id)
+            else {
+                sqlx::query(
+                    "UPDATE alert_history SET status = 'failed', error_message = 'Alert rule deleted' WHERE id = $1",
+                )
+                .bind(history.id)
+                .execute(pool)
+                .await?;
+                processed += 1;
+                continue;
+            };
+
+            let channel: Option<AlertRuleChannel> = sqlx::query_as(
+                "SELECT alert_rule_id, integration_id, routing_override FROM alert_rule_channels WHERE alert_rule_id = $1 AND integration_id = $2",
             )
-            .bind(history.id)
-            .execute(pool)
+            .bind(rule_id)
+            .bind(integration_id)
+            .fetch_optional(pool)
             .await?;
+            let Some(channel) = channel else {
+                sqlx::query(
+                    "UPDATE alert_history SET status = 'failed', error_message = 'Alert channel deleted' WHERE id = $1",
+                )
+                .bind(history.id)
+                .execute(pool)
+                .await?;
+                processed += 1;
+                continue;
+            };
+
+            if let Err(e) =
+                Self::dispatch_existing_history(pool, &history, &channel, max_retries).await
+            {
+                log::error!("Failed to retry alert history {}: {}", history.id, e);
+            }
 
             processed += 1;
         }
@@ -856,6 +916,7 @@ impl AlertService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_issue_url_uses_numeric_project_id_not_slug() {
@@ -865,5 +926,33 @@ mod tests {
             "URL must use numeric project id, got: {}",
             url
         );
+    }
+
+    #[test]
+    fn event_alert_id_is_stable_across_retries() {
+        let event_id = Uuid::nil();
+        assert_eq!(
+            event_alert_id(event_id, &AlertType::NewIssue),
+            event_alert_id(event_id, &AlertType::NewIssue)
+        );
+        assert_ne!(
+            event_alert_id(event_id, &AlertType::NewIssue),
+            event_alert_id(event_id, &AlertType::Regression)
+        );
+    }
+
+    #[test]
+    fn alert_payload_round_trips_for_retry_storage() {
+        let stored = json!({
+            "alert_id": "alert-1", "alert_type": "new_issue",
+            "triggered_at": "2026-08-21T10:00:00Z",
+            "project": {"id": 1, "name": "Project", "slug": "project"},
+            "issue": {"id": Uuid::new_v4().to_string(), "short_id": "PROJECT-1",
+                "title": "Issue", "level": "error", "first_seen": "2026-08-21T10:00:00Z",
+                "last_seen": "2026-08-21T10:00:00Z", "event_count": 1},
+            "issue_url": "http://localhost/issues/1", "actor": "Rustrak"
+        });
+        let payload: AlertPayload = serde_json::from_value(stored.clone()).unwrap();
+        assert_eq!(serde_json::to_value(payload).unwrap(), stored);
     }
 }

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -698,8 +698,12 @@ impl AlertService {
     }
 
     /// Returns whether durable history already exists for an event alert.
-    pub async fn event_alert_exists(pool: &DbPool, event_id: Uuid) -> AppResult<bool> {
-        let prefix = format!("event-{}-%", event_id);
+    pub async fn event_alert_exists(
+        pool: &DbPool,
+        event_id: Uuid,
+        alert_type: AlertType,
+    ) -> AppResult<bool> {
+        let prefix = format!("event-{event_id}-{alert_type}-%");
         let exists: bool = sqlx::query_scalar(
             "SELECT EXISTS(SELECT 1 FROM alert_history WHERE idempotency_key LIKE $1)",
         )

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -728,7 +728,7 @@ impl AlertService {
     ) -> AppResult<()> {
         let integration = Self::get_channel(pool, rule_channel.integration_id).await?;
         let result = create_dispatcher(integration.provider_type)
-            .send(&integration, &rule_channel.routing_override, &payload)
+            .send(&integration, &rule_channel.routing_override, payload)
             .await;
         let attempt_count = previous_attempt_count + 1;
 

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -25,6 +25,12 @@ pub struct AlertService;
 
 pub const MAX_ALERT_RETRIES: i32 = 5;
 
+/// How long a claimed pending row stays invisible to other claimers. Must
+/// exceed the longest single dispatch (30s webhook timeout plus DB writes) so
+/// an in-flight delivery is never re-claimed and double-sent; a crashed
+/// claimer's rows become eligible again once the lease expires.
+const RETRY_CLAIM_LEASE_SECS: i64 = 120;
+
 impl AlertService {
     // =========================================================================
     // Alert Integration CRUD (replaces Notification Channel CRUD)
@@ -650,6 +656,13 @@ impl AlertService {
             "pending"
         };
 
+        // Pending rows are born leased to the dispatch task spawned below:
+        // the retry worker only claims rows whose next_retry_at has passed, so
+        // it cannot double-send a delivery that is still in flight. Skipped
+        // (cooldown) rows never dispatch and carry no lease.
+        let dispatch_lease =
+            (!cooldown_suppressed).then(|| Utc::now() + Duration::seconds(RETRY_CLAIM_LEASE_SECS));
+
         let mut history_ids = Vec::with_capacity(channels.len());
         for (rule_channel, integration) in &channels {
             let idempotency_key = format!("{}-{}", payload.alert_id, integration.id);
@@ -659,9 +672,9 @@ impl AlertService {
                 INSERT INTO alert_history (
                     alert_rule_id, integration_id, issue_id, project_id,
                     alert_type, channel_type, channel_name, payload,
-                    status, idempotency_key
+                    status, idempotency_key, next_retry_at
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
                 ON CONFLICT (idempotency_key) DO NOTHING
                 RETURNING id
                 "#,
@@ -676,6 +689,7 @@ impl AlertService {
             .bind(serde_json::to_value(&payload).map_err(|e| AppError::Internal(e.to_string()))?)
             .bind(history_status)
             .bind(&idempotency_key)
+            .bind(dispatch_lease)
             .fetch_optional(&mut *tx)
             .await?;
 
@@ -691,19 +705,30 @@ impl AlertService {
             return Ok(());
         }
 
-        // 5. Attempt each durable delivery before the event worker deletes its
-        // source record; committed pending rows cover a crash during dispatch.
-        for (history_id, rule_channel) in history_ids {
-            Self::dispatch_history(
-                pool,
-                history_id,
-                0,
-                &payload,
-                &rule_channel,
-                MAX_ALERT_RETRIES,
-            )
-            .await?;
-        }
+        // 5. Deliver off the caller's path. The committed pending rows are the
+        // durability guarantee (they survive a crash and the retry worker picks
+        // them up once the lease expires); the caller — the digest pipeline —
+        // must not stall on notification I/O, matching Relay, which never
+        // couples ingestion to delivery.
+        let dispatch_pool = pool.clone();
+        tokio::spawn(async move {
+            for (history_id, rule_channel) in history_ids {
+                if let Err(error) = Self::dispatch_history(
+                    &dispatch_pool,
+                    history_id,
+                    0,
+                    &payload,
+                    &rule_channel,
+                    MAX_ALERT_RETRIES,
+                )
+                .await
+                {
+                    log::error!(
+                        "Alert dispatch for history {history_id} failed; the retry worker owns it after the lease expires: {error}"
+                    );
+                }
+            }
+        });
 
         Ok(())
     }
@@ -855,46 +880,77 @@ impl AlertService {
         Ok(history)
     }
 
-    /// Processes pending retries (for background worker)
-    #[allow(dead_code)]
-    pub async fn process_retry_queue(pool: &DbPool, max_retries: i32) -> AppResult<u32> {
+    /// Atomically leases due pending history rows for dispatch.
+    ///
+    /// Each returned row had its `next_retry_at` pushed into the future in the
+    /// same statement that selected it, so a concurrent claimer (another worker
+    /// tick, or another server process sharing the database) cannot pick up the
+    /// same row and double-deliver the alert.
+    pub async fn claim_due_retries(
+        pool: &DbPool,
+        max_retries: i32,
+        limit: i64,
+    ) -> AppResult<Vec<AlertHistory>> {
         #[cfg(feature = "postgres")]
-        let pending: Vec<AlertHistory> = sqlx::query_as(
+        let claimed: Vec<AlertHistory> = sqlx::query_as(
             r#"
-            SELECT id, alert_rule_id, integration_id, issue_id, project_id,
-                   alert_type, channel_type, channel_name, payload, status,
-                   attempt_count, next_retry_at, error_message,
-                   http_status_code, idempotency_key, created_at, sent_at
-            FROM alert_history
-            WHERE status = 'pending'
+            UPDATE alert_history
+            SET next_retry_at = CURRENT_TIMESTAMP + ($3 * INTERVAL '1 second')
+            WHERE id IN (
+                SELECT id FROM alert_history
+                WHERE status = 'pending'
+                  AND (next_retry_at IS NULL OR next_retry_at <= CURRENT_TIMESTAMP)
+                  AND attempt_count < $1
+                ORDER BY next_retry_at
+                LIMIT $2
+                FOR UPDATE SKIP LOCKED
+            )
+              AND status = 'pending'
               AND (next_retry_at IS NULL OR next_retry_at <= CURRENT_TIMESTAMP)
-              AND attempt_count < $1
-            ORDER BY next_retry_at
-            LIMIT 100
+            RETURNING id, alert_rule_id, integration_id, issue_id, project_id,
+                      alert_type, channel_type, channel_name, payload, status,
+                      attempt_count, next_retry_at, error_message,
+                      http_status_code, idempotency_key, created_at, sent_at
             "#,
         )
         .bind(max_retries)
+        .bind(limit)
+        .bind(RETRY_CLAIM_LEASE_SECS)
         .fetch_all(pool)
         .await?;
 
         #[cfg(feature = "sqlite")]
-        let pending: Vec<AlertHistory> = sqlx::query_as(
+        let claimed: Vec<AlertHistory> = sqlx::query_as(
             r#"
-            SELECT id, alert_rule_id, integration_id, issue_id, project_id,
-                   alert_type, channel_type, channel_name, payload, status,
-                   attempt_count, next_retry_at, error_message,
-                   http_status_code, idempotency_key, created_at, sent_at
-            FROM alert_history
-            WHERE status = 'pending'
-              AND (next_retry_at IS NULL OR datetime(next_retry_at) <= datetime('now'))
-              AND attempt_count < $1
-            ORDER BY next_retry_at
-            LIMIT 100
+            UPDATE alert_history
+            SET next_retry_at = datetime('now', '+' || $3 || ' seconds')
+            WHERE id IN (
+                SELECT id FROM alert_history
+                WHERE status = 'pending'
+                  AND (next_retry_at IS NULL OR datetime(next_retry_at) <= datetime('now'))
+                  AND attempt_count < $1
+                ORDER BY next_retry_at
+                LIMIT $2
+            )
+            RETURNING id, alert_rule_id, integration_id, issue_id, project_id,
+                      alert_type, channel_type, channel_name, payload, status,
+                      attempt_count, next_retry_at, error_message,
+                      http_status_code, idempotency_key, created_at, sent_at
             "#,
         )
         .bind(max_retries)
+        .bind(limit)
+        .bind(RETRY_CLAIM_LEASE_SECS)
         .fetch_all(pool)
         .await?;
+
+        Ok(claimed)
+    }
+
+    /// Processes pending retries (for background worker)
+    #[allow(dead_code)]
+    pub async fn process_retry_queue(pool: &DbPool, max_retries: i32) -> AppResult<u32> {
+        let pending = Self::claim_due_retries(pool, max_retries, 100).await?;
 
         let mut processed = 0u32;
 

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -855,7 +855,9 @@ impl AlertService {
                    attempt_count, next_retry_at, error_message,
                    http_status_code, idempotency_key, created_at, sent_at
             FROM alert_history
-            WHERE status = 'pending' AND next_retry_at <= CURRENT_TIMESTAMP AND attempt_count < $1
+            WHERE status = 'pending'
+              AND (next_retry_at IS NULL OR next_retry_at <= CURRENT_TIMESTAMP)
+              AND attempt_count < $1
             ORDER BY next_retry_at
             LIMIT 100
             "#,
@@ -873,7 +875,7 @@ impl AlertService {
                    http_status_code, idempotency_key, created_at, sent_at
             FROM alert_history
             WHERE status = 'pending'
-              AND datetime(next_retry_at) <= datetime('now')
+              AND (next_retry_at IS NULL OR datetime(next_retry_at) <= datetime('now'))
               AND attempt_count < $1
             ORDER BY next_retry_at
             LIMIT 100

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -715,8 +715,20 @@ impl AlertService {
         rule_channel: &AlertRuleChannel,
         max_retries: i32,
     ) -> AppResult<()> {
-        let payload: AlertPayload = serde_json::from_value(history.payload.clone())
-            .map_err(|e| AppError::Internal(format!("invalid alert payload: {}", e)))?;
+        let payload: AlertPayload = match serde_json::from_value(history.payload.clone()) {
+            Ok(payload) => payload,
+            Err(error) => {
+                let message = format!("invalid alert payload: {error}");
+                sqlx::query(
+                    "UPDATE alert_history SET status = 'failed', next_retry_at = NULL, error_message = $2 WHERE id = $1",
+                )
+                .bind(history.id)
+                .bind(message)
+                .execute(pool)
+                .await?;
+                return Ok(());
+            }
+        };
         Self::dispatch_history(
             pool,
             history.id,

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -923,7 +923,7 @@ impl AlertService {
 }
 
 fn retry_delay(attempt_count: i32, history_id: i64) -> i64 {
-    let exponent = attempt_count.saturating_sub(1).min(6) as u32;
+    let exponent = attempt_count.saturating_sub(1).clamp(0, 6) as u32;
     let base = 60 * 2_i64.pow(exponent);
     let jitter = history_id.rem_euclid(30);
     std::cmp::min(base + jitter, 3600)
@@ -976,6 +976,7 @@ mod tests {
     fn retry_delay_is_bounded_for_large_attempt_counts() {
         assert_eq!(retry_delay(1, 0), 60);
         assert_eq!(retry_delay(1, 29), 89);
+        assert_eq!(retry_delay(-1, 0), 60);
         assert_eq!(retry_delay(i32::MAX, i64::MAX), 3600);
     }
 }

--- a/apps/server/src/services/alert.rs
+++ b/apps/server/src/services/alert.rs
@@ -608,8 +608,7 @@ impl AlertService {
             project.name
         );
 
-        // 4. Reserve the cooldown and enqueue every delivery atomically. A
-        // failed enqueue must leave the rule eligible for durable event retry.
+        // 4. Reserve the cooldown and record every delivery atomically.
         let cooldown_threshold = Utc::now() - Duration::minutes(rule.cooldown_minutes as i64);
         let mut tx = pool.begin().await?;
 
@@ -641,10 +640,15 @@ impl AlertService {
         .execute(&mut *tx)
         .await?;
 
-        if updated.rows_affected() == 0 {
+        let cooldown_suppressed = updated.rows_affected() == 0;
+        if cooldown_suppressed {
             log::debug!("Alert rule {} not found or in cooldown period", rule.id);
-            return Ok(());
         }
+        let history_status = if cooldown_suppressed {
+            "skipped"
+        } else {
+            "pending"
+        };
 
         let mut history_ids = Vec::with_capacity(channels.len());
         for (rule_channel, integration) in &channels {
@@ -657,7 +661,7 @@ impl AlertService {
                     alert_type, channel_type, channel_name, payload,
                     status, idempotency_key
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending', $9)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                 ON CONFLICT (idempotency_key) DO NOTHING
                 RETURNING id
                 "#,
@@ -670,15 +674,22 @@ impl AlertService {
             .bind(integration.provider_type.to_string())
             .bind(&integration.name)
             .bind(serde_json::to_value(&payload).map_err(|e| AppError::Internal(e.to_string()))?)
+            .bind(history_status)
             .bind(&idempotency_key)
             .fetch_optional(&mut *tx)
             .await?;
 
-            if let Some(history_id) = history_id {
-                history_ids.push((history_id.0, rule_channel.clone()));
+            if !cooldown_suppressed {
+                if let Some(history_id) = history_id {
+                    history_ids.push((history_id.0, rule_channel.clone()));
+                }
             }
         }
         tx.commit().await?;
+
+        if cooldown_suppressed {
+            return Ok(());
+        }
 
         // 5. Attempt each durable delivery before the event worker deletes its
         // source record; committed pending rows cover a crash during dispatch.

--- a/apps/server/src/services/event.rs
+++ b/apps/server/src/services/event.rs
@@ -252,4 +252,18 @@ impl EventService {
 
         Ok(count > 0)
     }
+
+    /// Finds the issue for an already-digested event during durable retry.
+    pub async fn issue_id_for_event(
+        pool: &DbPool,
+        project_id: i32,
+        event_id: Uuid,
+    ) -> AppResult<Option<Uuid>> {
+        sqlx::query_scalar("SELECT issue_id FROM events WHERE project_id = $1 AND event_id = $2")
+            .bind(project_id)
+            .bind(event_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(AppError::Database)
+    }
 }

--- a/apps/server/src/services/event.rs
+++ b/apps/server/src/services/event.rs
@@ -275,11 +275,14 @@ impl EventService {
         project_id: i32,
         event_id: Uuid,
     ) -> AppResult<Option<Uuid>> {
-        sqlx::query_scalar("SELECT issue_id FROM events WHERE project_id = $1 AND event_id = $2")
-            .bind(project_id)
-            .bind(event_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(AppError::Database)
+        sqlx::query_scalar::<_, Option<Uuid>>(
+            "SELECT issue_id FROM events WHERE project_id = $1 AND event_id = $2",
+        )
+        .bind(project_id)
+        .bind(event_id)
+        .fetch_optional(pool)
+        .await
+        .map(|issue_id| issue_id.flatten())
+        .map_err(AppError::Database)
     }
 }

--- a/apps/server/src/services/event.rs
+++ b/apps/server/src/services/event.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
-use crate::models::Event;
+use crate::models::{AlertType, Event};
 use crate::pagination::{EventCursor, SortOrder};
 use crate::services::grouping::DenormalizedFields;
 
@@ -118,6 +118,20 @@ impl EventService {
         Ok(event)
     }
 
+    /// Gets an event by the client-supplied event id within its project.
+    pub async fn get_by_event_id(
+        pool: &DbPool,
+        project_id: i32,
+        event_id: Uuid,
+    ) -> AppResult<Event> {
+        sqlx::query_as::<_, Event>("SELECT * FROM events WHERE project_id = $1 AND event_id = $2")
+            .bind(project_id)
+            .bind(event_id)
+            .fetch_optional(pool)
+            .await?
+            .ok_or_else(|| AppError::NotFound(format!("Event {} not found", event_id)))
+    }
+
     /// Creates a new event.
     ///
     /// Takes an executor rather than the pool so the digest can insert the
@@ -135,6 +149,7 @@ impl EventService {
         ingested_at: DateTime<Utc>,
         denormalized: &DenormalizedFields,
         remote_addr: Option<&str>,
+        alert_type: Option<AlertType>,
     ) -> AppResult<Event>
     where
         E: sqlx::Executor<'e, Database = crate::db::Db>,
@@ -206,9 +221,9 @@ impl EventService {
                 calculated_type, calculated_value, "transaction",
                 last_frame_filename, last_frame_module, last_frame_function,
                 level, platform, release, environment, server_name,
-                sdk_name, sdk_version, remote_addr
+                sdk_name, sdk_version, remote_addr, alert_type
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
             RETURNING *
             "#,
         )
@@ -234,6 +249,7 @@ impl EventService {
         .bind(sdk_name)
         .bind(sdk_version)
         .bind(remote_addr_str)
+        .bind(alert_type)
         .fetch_one(executor)
         .await?;
 

--- a/apps/server/src/services/rate_limit.rs
+++ b/apps/server/src/services/rate_limit.rs
@@ -154,11 +154,20 @@ impl RateLimitService {
     ) -> AppResult<()> {
         let now = Utc::now();
 
-        // Counters were committed with the digest; only refresh derived quota
-        // state outside the write transaction.
-        Self::update_installation_quota(pool, config, now, installation_count).await?;
+        // The counters are committed already; refresh derived quota rows
+        // independently where the backend can benefit from it. SQLite keeps
+        // its two writes serial because it has one writer at a time.
+        #[cfg(feature = "postgres")]
+        tokio::try_join!(
+            Self::update_installation_quota(pool, config, now, installation_count),
+            Self::update_project_quota(pool, project_id, config, now, project_count),
+        )?;
 
-        Self::update_project_quota(pool, project_id, config, now, project_count).await?;
+        #[cfg(feature = "sqlite")]
+        {
+            Self::update_installation_quota(pool, config, now, installation_count).await?;
+            Self::update_project_quota(pool, project_id, config, now, project_count).await?;
+        }
 
         Ok(())
     }

--- a/apps/server/src/services/rate_limit.rs
+++ b/apps/server/src/services/rate_limit.rs
@@ -2,10 +2,37 @@ use chrono::{Duration, Utc};
 
 use crate::config::RateLimitConfig;
 use crate::db::DbPool;
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::models::{Installation, Project};
 
 pub struct RateLimitService;
+
+const MAX_QUOTA_REFRESH_ATTEMPTS: usize = 3;
+
+fn is_retryable_quota_refresh(err: &AppError) -> bool {
+    #[cfg(feature = "sqlite")]
+    {
+        matches!(
+            err,
+            AppError::Database(sqlx::Error::Database(db))
+                if db.code().as_deref().is_some_and(is_sqlite_busy_code)
+        )
+    }
+    #[cfg(feature = "postgres")]
+    {
+        let _ = err;
+        false
+    }
+}
+
+#[cfg(feature = "sqlite")]
+fn is_sqlite_busy_code(code: &str) -> bool {
+    matches!(code, "5" | "261" | "517" | "773")
+}
+
+fn quota_refresh_is_due(digested_count: i64, next_quota_check: i64) -> bool {
+    digested_count >= next_quota_check
+}
 
 /// Result when quota is exceeded
 #[derive(Debug)]
@@ -38,11 +65,58 @@ impl RateLimitService {
 
     /// Checks if quota is exceeded for installation or project (call during ingest)
     /// Returns Some(QuotaExceeded) if rate limited, None if allowed
-    pub async fn check_quota(pool: &DbPool, project: &Project) -> AppResult<Option<QuotaExceeded>> {
+    pub async fn check_quota(
+        pool: &DbPool,
+        project: &Project,
+        config: &RateLimitConfig,
+    ) -> AppResult<Option<QuotaExceeded>> {
         let now = Utc::now();
 
         // 1. Check installation (global) quota
-        let installation = Self::get_installation(pool).await?;
+        let mut installation = Self::get_installation(pool).await?;
+        let mut current_project: Project = sqlx::query_as("SELECT * FROM projects WHERE id = $1")
+            .bind(project.id)
+            .fetch_one(pool)
+            .await?;
+        let project_is_stale = quota_refresh_is_due(
+            i64::from(current_project.digested_event_count),
+            current_project.next_quota_check,
+        );
+        let installation_is_stale = quota_refresh_is_due(
+            installation.digested_event_count,
+            installation.next_quota_check,
+        );
+        if installation_is_stale || project_is_stale {
+            let mut attempt = 0;
+            loop {
+                match Self::update_quota_state(
+                    pool,
+                    project.id,
+                    config,
+                    installation.digested_event_count,
+                    i64::from(current_project.digested_event_count),
+                )
+                .await
+                {
+                    Err(e)
+                        if is_retryable_quota_refresh(&e)
+                            && attempt + 1 < MAX_QUOTA_REFRESH_ATTEMPTS =>
+                    {
+                        tokio::time::sleep(std::time::Duration::from_millis(50 << attempt)).await;
+                        attempt += 1;
+                    }
+                    result => {
+                        result?;
+                        break;
+                    }
+                }
+            }
+            installation = Self::get_installation(pool).await?;
+            current_project = sqlx::query_as("SELECT * FROM projects WHERE id = $1")
+                .bind(project.id)
+                .fetch_one(pool)
+                .await?;
+        }
         if let Some(until) = installation.quota_exceeded_until {
             if now < until {
                 let retry_after = (until - now).num_seconds().max(1) as u64;
@@ -54,7 +128,7 @@ impl RateLimitService {
         }
 
         // 2. Check project quota
-        if let Some(until) = project.quota_exceeded_until {
+        if let Some(until) = current_project.quota_exceeded_until {
             if now < until {
                 let retry_after = (until - now).num_seconds().max(1) as u64;
                 return Ok(Some(QuotaExceeded {
@@ -67,22 +141,48 @@ impl RateLimitService {
         Ok(None)
     }
 
-    /// Updates quota state after digesting an event
-    /// Call this during digest, after the event is processed
+    /// Refreshes derived quota state after digesting an event.
+    ///
+    /// The counters are already committed by the digest transaction; only the
+    /// time-window checks and cached quota fields are updated here.
     pub async fn update_quota_state(
         pool: &DbPool,
         project_id: i32,
         config: &RateLimitConfig,
+        installation_count: i64,
+        project_count: i64,
     ) -> AppResult<()> {
         let now = Utc::now();
 
-        // Update installation quota
-        Self::update_installation_quota(pool, config, now).await?;
+        // Counters were committed with the digest; only refresh derived quota
+        // state outside the write transaction.
+        Self::update_installation_quota(pool, config, now, installation_count).await?;
 
-        // Update project quota
-        Self::update_project_quota(pool, project_id, config, now).await?;
+        Self::update_project_quota(pool, project_id, config, now, project_count).await?;
 
         Ok(())
+    }
+
+    /// Increments both quota counters atomically with the digest transaction.
+    /// Returns the committed values for the post-commit quota refresh.
+    pub async fn increment_quota_counters(
+        executor: &mut <crate::db::Db as sqlx::Database>::Connection,
+        project_id: i32,
+    ) -> AppResult<(i64, i64)> {
+        let installation_count: i64 = sqlx::query_scalar(
+            "UPDATE installation SET digested_event_count = digested_event_count + 1 WHERE id = 1 RETURNING digested_event_count",
+        )
+        .fetch_one(&mut *executor)
+        .await?;
+
+        let project_count: i32 = sqlx::query_scalar(
+            "UPDATE projects SET stored_event_count = stored_event_count + 1, digested_event_count = digested_event_count + 1 WHERE id = $1 RETURNING digested_event_count",
+        )
+        .bind(project_id)
+        .fetch_one(&mut *executor)
+        .await?;
+
+        Ok((installation_count, project_count as i64))
     }
 
     /// Counts events in a time window for the whole installation
@@ -139,14 +239,8 @@ impl RateLimitService {
         pool: &DbPool,
         config: &RateLimitConfig,
         now: chrono::DateTime<Utc>,
+        new_count: i64,
     ) -> AppResult<()> {
-        // Atomically increment and get the new count
-        let new_count: i64 = sqlx::query_scalar(
-            "UPDATE installation SET digested_event_count = digested_event_count + 1 WHERE id = 1 RETURNING digested_event_count",
-        )
-        .fetch_one(pool)
-        .await?;
-
         let installation = Self::get_installation(pool).await?;
 
         // Calculate minimum threshold for optimization
@@ -193,12 +287,13 @@ impl RateLimitService {
                 SET quota_exceeded_until = $1,
                     quota_exceeded_reason = $2,
                     next_quota_check = $3
-                WHERE id = 1
+                WHERE id = 1 AND next_quota_check <= $4
                 "#,
             )
             .bind(exceeded_until)
             .bind(exceeded_reason)
             .bind(new_count + check_again_after)
+            .bind(new_count)
             .execute(pool)
             .await?;
         }
@@ -212,16 +307,8 @@ impl RateLimitService {
         project_id: i32,
         config: &RateLimitConfig,
         now: chrono::DateTime<Utc>,
+        new_count: i64,
     ) -> AppResult<()> {
-        // Atomically increment and get the new count
-        let new_count: i32 = sqlx::query_scalar(
-            "UPDATE projects SET digested_event_count = digested_event_count + 1 WHERE id = $1 RETURNING digested_event_count",
-        )
-        .bind(project_id)
-        .fetch_one(pool)
-        .await?;
-        let new_count = new_count as i64;
-
         // Get current project quota state
         let project: Project = sqlx::query_as("SELECT * FROM projects WHERE id = $1")
             .bind(project_id)
@@ -274,17 +361,40 @@ impl RateLimitService {
                 SET quota_exceeded_until = $2,
                     quota_exceeded_reason = $3,
                     next_quota_check = $4
-                WHERE id = $1
+                WHERE id = $1 AND next_quota_check <= $5
                 "#,
             )
             .bind(project_id)
             .bind(exceeded_until)
             .bind(exceeded_reason)
             .bind(new_count + check_again_after)
+            .bind(new_count)
             .execute(pool)
             .await?;
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quota_refresh_is_due;
+
+    #[cfg(feature = "sqlite")]
+    use super::is_sqlite_busy_code;
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_busy_codes_are_retryable() {
+        let codes = ["5", "261", "517", "773"];
+        assert!(codes.into_iter().all(is_sqlite_busy_code));
+        assert!(!is_sqlite_busy_code("2067"));
+    }
+
+    #[test]
+    fn quota_refresh_is_due_handles_initial_and_advanced_watermarks() {
+        assert!(quota_refresh_is_due(0, 0) && quota_refresh_is_due(12, 10));
+        assert!(!quota_refresh_is_due(9, 10));
     }
 }

--- a/apps/server/src/services/rate_limit.rs
+++ b/apps/server/src/services/rate_limit.rs
@@ -88,7 +88,7 @@ impl RateLimitService {
         );
         if installation_is_stale || project_is_stale {
             let mut attempt = 0;
-            loop {
+            let refresh = loop {
                 match Self::update_quota_state(
                     pool,
                     project.id,
@@ -105,17 +105,26 @@ impl RateLimitService {
                         tokio::time::sleep(std::time::Duration::from_millis(50 << attempt)).await;
                         attempt += 1;
                     }
-                    result => {
-                        result?;
-                        break;
-                    }
+                    result => break result,
+                }
+            };
+            match refresh {
+                Ok(()) => {
+                    installation = Self::get_installation(pool).await?;
+                    current_project = sqlx::query_as("SELECT * FROM projects WHERE id = $1")
+                        .bind(project.id)
+                        .fetch_one(pool)
+                        .await?;
+                }
+                // The refresh is derived bookkeeping; the digest path already
+                // treats it as best-effort. Admit or reject on the stale state
+                // rather than failing an ingest request nothing else objects to.
+                Err(e) => {
+                    log::warn!(
+                        "quota refresh failed; using stale quota state for this request: {e}"
+                    );
                 }
             }
-            installation = Self::get_installation(pool).await?;
-            current_project = sqlx::query_as("SELECT * FROM projects WHERE id = $1")
-                .bind(project.id)
-                .fetch_one(pool)
-                .await?;
         }
         if let Some(until) = installation.quota_exceeded_until {
             if now < until {

--- a/apps/server/src/services/sourcemap.rs
+++ b/apps/server/src/services/sourcemap.rs
@@ -258,6 +258,50 @@ pub async fn assemble_bundle(
     chunk_checksums: &[String],
     max_bundle_size_bytes: usize,
 ) -> AppResult<()> {
+    assemble_bundle_inner(
+        pool,
+        store,
+        project_id,
+        bundle_checksum,
+        chunk_checksums,
+        max_bundle_size_bytes,
+        None,
+    )
+    .await
+}
+
+/// Assembles a worker-owned job and commits its terminal state with the source
+/// metadata and chunk deletion.
+pub async fn assemble_bundle_for_job(
+    pool: &DbPool,
+    store: &dyn SourceMapStore,
+    project_id: i32,
+    bundle_checksum: &str,
+    chunk_checksums: &[String],
+    max_bundle_size_bytes: usize,
+    job_id: i64,
+) -> AppResult<()> {
+    assemble_bundle_inner(
+        pool,
+        store,
+        project_id,
+        bundle_checksum,
+        chunk_checksums,
+        max_bundle_size_bytes,
+        Some(job_id),
+    )
+    .await
+}
+
+async fn assemble_bundle_inner(
+    pool: &DbPool,
+    store: &dyn SourceMapStore,
+    project_id: i32,
+    bundle_checksum: &str,
+    chunk_checksums: &[String],
+    max_bundle_size_bytes: usize,
+    job_id: Option<i64>,
+) -> AppResult<()> {
     // --- Step 1: fetch + join chunk bytes ---
     let mut joined: Vec<u8> = Vec::new();
     for checksum in chunk_checksums {
@@ -532,9 +576,19 @@ pub async fn assemble_bundle(
         .await?;
     }
 
-    // --- Step 8: delete chunk rows ---
+    // --- Step 8: release this job's chunk references and delete only chunks
+    // no other pending or retryable job still owns. ---
+    if let Some(job_id) = job_id {
+        sqlx::query("DELETE FROM assembly_job_chunks WHERE job_id = $1")
+            .bind(job_id)
+            .execute(&mut *tx)
+            .await?;
+    }
+
     #[cfg(feature = "postgres")]
-    sqlx::query("DELETE FROM chunk WHERE checksum = ANY($1)")
+    sqlx::query(
+        "DELETE FROM chunk c WHERE c.checksum = ANY($1) AND NOT EXISTS (SELECT 1 FROM assembly_job_chunks r WHERE r.checksum = c.checksum)",
+    )
         .bind(chunk_checksums)
         .execute(&mut *tx)
         .await?;
@@ -548,8 +602,33 @@ pub async fn assemble_bundle(
             for c in chunk_checksums {
                 sep.push_bind(c);
             }
-            qb.push(")");
+            qb.push(") AND NOT EXISTS (SELECT 1 FROM assembly_job_chunks r WHERE r.checksum = chunk.checksum)");
             qb.build().execute(&mut *tx).await?;
+        }
+    }
+
+    if let Some(job_id) = job_id {
+        #[cfg(feature = "postgres")]
+        let updated = sqlx::query(
+            "UPDATE assembly_jobs SET state = 'ok', detail = NULL, updated_at = NOW() WHERE id = $1 AND state = 'assembling'",
+        )
+        .bind(job_id)
+        .execute(&mut *tx)
+        .await?;
+
+        #[cfg(not(feature = "postgres"))]
+        let updated = sqlx::query(
+            "UPDATE assembly_jobs SET state = 'ok', detail = NULL, updated_at = datetime('now') WHERE id = $1 AND state = 'assembling'",
+        )
+        .bind(job_id)
+        .execute(&mut *tx)
+        .await?;
+
+        if updated.rows_affected() != 1 {
+            return Err(AppError::Internal(format!(
+                "assembly job {} was not assembling",
+                job_id
+            )));
         }
     }
 

--- a/apps/server/src/services/sourcemap.rs
+++ b/apps/server/src/services/sourcemap.rs
@@ -409,10 +409,7 @@ async fn assemble_bundle_inner(
     let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes)
         .map_err(|e| AppError::Validation(format!("invalid manifest.json: {}", e)))?;
 
-    let files = match manifest.get("files").and_then(|f| f.as_object()) {
-        Some(f) => f.clone(),
-        None => return Ok(()), // no files to process
-    };
+    let files = manifest_files(&manifest);
 
     // --- Steps 7+8: process each file entry, then delete chunks ---
     // We run in a transaction for the DB writes; store writes are outside (idempotent CAS).
@@ -635,6 +632,14 @@ async fn assemble_bundle_inner(
     tx.commit().await?;
 
     Ok(())
+}
+
+fn manifest_files(manifest: &serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    manifest
+        .get("files")
+        .and_then(|files| files.as_object())
+        .cloned()
+        .unwrap_or_default()
 }
 
 // ---------------------------------------------------------------------------
@@ -1026,5 +1031,11 @@ mod tests {
             matches!(decoded, sourcemap::DecodedMap::Hermes(_)),
             "DecodedMap must detect Hermes from x_facebook_sources"
         );
+    }
+
+    #[test]
+    fn invalid_manifest_files_are_treated_as_empty() {
+        assert!(manifest_files(&serde_json::json!({})).is_empty());
+        assert!(manifest_files(&serde_json::json!({"files": []})).is_empty());
     }
 }

--- a/apps/server/src/workers/session_aggregator.rs
+++ b/apps/server/src/workers/session_aggregator.rs
@@ -218,6 +218,7 @@ impl SessionAggregator {
             return Ok(());
         }
 
+        let mut commit_started = false;
         let result = async {
             let mut tx = self.pool.begin().await?;
             for (key, c) in &counts {
@@ -226,13 +227,20 @@ impl SessionAggregator {
             for (key, &crashed) in &users {
                 self.upsert_user(key, crashed, &mut *tx).await?;
             }
+            commit_started = true;
             tx.commit().await
         }
         .await;
 
         if let Err(error) = result {
-            let mut state = self.state.lock().await;
-            merge_state(&mut state, counts, users);
+            if !commit_started {
+                let mut state = self.state.lock().await;
+                merge_state(&mut state, counts, users);
+            } else {
+                log::error!(
+                    "session_aggregator: commit outcome unknown; counters will not be replayed"
+                );
+            }
             return Err(error.into());
         }
 

--- a/apps/server/src/workers/session_aggregator.rs
+++ b/apps/server/src/workers/session_aggregator.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, NaiveDate, Timelike, Utc};
 use tokio::sync::Mutex;
 
 use crate::db::DbPool;
+use crate::error::AppResult;
 use crate::models::session::{
     classify, parse_ts, SessionAggregateItem, SessionAggregates, SessionOutcome, SessionStatus,
     SessionUpdate,
@@ -63,8 +64,8 @@ impl SessionAggregatorHandle {
     }
 
     /// Flush all in-memory state to DB.  Called on shutdown.
-    pub async fn flush(&self) {
-        self.0.flush().await;
+    pub async fn flush(&self) -> AppResult<()> {
+        self.0.flush().await
     }
 }
 
@@ -205,7 +206,7 @@ impl SessionAggregator {
     }
 
     /// Flush all in-memory counters to the DB via batched UPSERT.
-    pub async fn flush(&self) {
+    pub async fn flush(&self) -> AppResult<()> {
         let (counts, users) = {
             let mut state = self.state.lock().await;
             let counts = std::mem::take(&mut state.counts);
@@ -214,22 +215,39 @@ impl SessionAggregator {
         };
 
         if counts.is_empty() && users.is_empty() {
-            return;
+            return Ok(());
         }
 
-        for (key, c) in &counts {
-            if let Err(e) = self.upsert_count(key, c).await {
-                log::error!("session_aggregator: flush_counts error: {:?}", e);
+        let result = async {
+            let mut tx = self.pool.begin().await?;
+            for (key, c) in &counts {
+                self.upsert_count(key, c, &mut *tx).await?;
             }
-        }
-        for (key, &crashed) in &users {
-            if let Err(e) = self.upsert_user(key, crashed).await {
-                log::error!("session_aggregator: flush_users error: {:?}", e);
+            for (key, &crashed) in &users {
+                self.upsert_user(key, crashed, &mut *tx).await?;
             }
+            tx.commit().await
         }
+        .await;
+
+        if let Err(error) = result {
+            let mut state = self.state.lock().await;
+            merge_state(&mut state, counts, users);
+            return Err(error.into());
+        }
+
+        Ok(())
     }
 
-    async fn upsert_count(&self, key: &BucketKey, c: &Counters) -> Result<(), sqlx::Error> {
+    async fn upsert_count<'e, E>(
+        &self,
+        key: &BucketKey,
+        c: &Counters,
+        executor: E,
+    ) -> Result<(), sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = crate::db::Db>,
+    {
         #[cfg(feature = "postgres")]
         sqlx::query(
             r#"
@@ -251,7 +269,7 @@ impl SessionAggregator {
         .bind(c.errored)
         .bind(c.crashed)
         .bind(c.abnormal)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         #[cfg(not(feature = "postgres"))]
@@ -275,13 +293,21 @@ impl SessionAggregator {
         .bind(c.errored)
         .bind(c.crashed)
         .bind(c.abnormal)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(())
     }
 
-    async fn upsert_user(&self, key: &UserKey, crashed: bool) -> Result<(), sqlx::Error> {
+    async fn upsert_user<'e, E>(
+        &self,
+        key: &UserKey,
+        crashed: bool,
+        executor: E,
+    ) -> Result<(), sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = crate::db::Db>,
+    {
         #[cfg(feature = "postgres")]
         sqlx::query(
             r#"
@@ -297,7 +323,7 @@ impl SessionAggregator {
         .bind(key.day)
         .bind(&key.did)
         .bind(crashed)
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         #[cfg(not(feature = "postgres"))]
@@ -315,7 +341,7 @@ impl SessionAggregator {
         .bind(key.day.to_string())
         .bind(&key.did)
         .bind(if crashed { 1i64 } else { 0i64 })
-        .execute(&self.pool)
+        .execute(executor)
         .await?;
 
         Ok(())
@@ -329,8 +355,31 @@ impl SessionAggregator {
         interval.tick().await; // consume the immediate first tick
         loop {
             interval.tick().await;
-            handle.0.flush().await;
+            if let Err(e) = handle.0.flush().await {
+                log::error!("session_aggregator: flush error: {:?}", e);
+            }
         }
+    }
+}
+
+fn merge_state(
+    state: &mut AggregatorState,
+    counts: HashMap<BucketKey, Counters>,
+    users: HashMap<UserKey, bool>,
+) {
+    for (key, counters) in counts {
+        let current = state.counts.entry(key).or_default();
+        current.total += counters.total;
+        current.errored += counters.errored;
+        current.crashed += counters.crashed;
+        current.abnormal += counters.abnormal;
+    }
+    for (key, crashed) in users {
+        state
+            .users
+            .entry(key)
+            .and_modify(|current| *current |= crashed)
+            .or_insert(crashed);
     }
 }
 
@@ -603,5 +652,45 @@ mod tests {
         state.counts.insert(key, Counters::default());
         let result = apply_cardinality_cap(&state, 1, "v1.0.0".to_string(), 1);
         assert_eq!(result, "v1.0.0");
+    }
+
+    #[test]
+    fn failed_flush_merges_counts_and_crash_flags_back_into_state() {
+        let key = BucketKey {
+            project_id: 1,
+            release: "v1".to_string(),
+            environment: "prod".to_string(),
+            bucket: Utc::now(),
+        };
+        let user = UserKey {
+            project_id: 1,
+            release: "v1".to_string(),
+            environment: "prod".to_string(),
+            day: key.bucket.date_naive(),
+            did: "did".to_string(),
+        };
+        let mut state = AggregatorState {
+            counts: HashMap::from([(
+                key.clone(),
+                Counters {
+                    total: 1,
+                    ..Default::default()
+                },
+            )]),
+            users: HashMap::from([(user.clone(), false)]),
+        };
+        merge_state(
+            &mut state,
+            HashMap::from([(
+                key.clone(),
+                Counters {
+                    total: 2,
+                    ..Default::default()
+                },
+            )]),
+            HashMap::from([(user.clone(), true)]),
+        );
+        assert_eq!(state.counts[&key].total, 3);
+        assert!(state.users[&user]);
     }
 }

--- a/apps/server/src/workers/sourcemap_assembly.rs
+++ b/apps/server/src/workers/sourcemap_assembly.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use crate::db::DbPool;
+use crate::error::AppResult;
 use crate::models::source_file::AssemblyJob;
 use crate::services::sourcemap::assemble_bundle_for_job;
 use crate::services::sourcemap_store::SourceMapStore;
@@ -46,7 +47,7 @@ impl AssemblyWorker {
         }
     }
 
-    pub async fn run_once(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn run_once(&self) -> AppResult<()> {
         self.poll_once().await
     }
 
@@ -79,7 +80,7 @@ impl AssemblyWorker {
     }
 
     /// Claim and process one job, if available.
-    async fn poll_once(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn poll_once(&self) -> AppResult<()> {
         #[cfg(feature = "postgres")]
         let job: Option<AssemblyJob> = {
             sqlx::query_as(

--- a/apps/server/src/workers/sourcemap_assembly.rs
+++ b/apps/server/src/workers/sourcemap_assembly.rs
@@ -224,6 +224,14 @@ impl AssemblyWorker {
                 .fetch_one(&mut *tx)
                 .await?;
         if retry_count >= max_retries {
+            // Delete only chunks that this terminal job owns exclusively;
+            // shared chunks remain available to the other assembly.
+            sqlx::query(
+                "DELETE FROM chunk WHERE EXISTS (SELECT 1 FROM assembly_job_chunks owned WHERE owned.job_id = $1 AND owned.checksum = chunk.checksum) AND NOT EXISTS (SELECT 1 FROM assembly_job_chunks retained WHERE retained.checksum = chunk.checksum AND retained.job_id <> $1)",
+            )
+            .bind(job_id)
+            .execute(&mut *tx)
+            .await?;
             sqlx::query("DELETE FROM assembly_job_chunks WHERE job_id = $1")
                 .bind(job_id)
                 .execute(&mut *tx)

--- a/apps/server/src/workers/sourcemap_assembly.rs
+++ b/apps/server/src/workers/sourcemap_assembly.rs
@@ -182,6 +182,8 @@ impl AssemblyWorker {
     }
 
     async fn mark_failure(&self, job_id: i64, detail: &str) -> Result<(), sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
         #[cfg(feature = "postgres")]
         sqlx::query(
             r#"
@@ -196,7 +198,7 @@ impl AssemblyWorker {
         )
         .bind(job_id)
         .bind(detail)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
 
         #[cfg(not(feature = "postgres"))]
@@ -213,9 +215,21 @@ impl AssemblyWorker {
         )
         .bind(job_id)
         .bind(detail)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
 
-        Ok(())
+        let (retry_count, max_retries): (i32, i32) =
+            sqlx::query_as("SELECT retry_count, max_retries FROM assembly_jobs WHERE id = $1")
+                .bind(job_id)
+                .fetch_one(&mut *tx)
+                .await?;
+        if retry_count >= max_retries {
+            sqlx::query("DELETE FROM assembly_job_chunks WHERE job_id = $1")
+                .bind(job_id)
+                .execute(&mut *tx)
+                .await?;
+        }
+
+        tx.commit().await
     }
 }

--- a/apps/server/src/workers/sourcemap_assembly.rs
+++ b/apps/server/src/workers/sourcemap_assembly.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::db::DbPool;
 use crate::models::source_file::AssemblyJob;
-use crate::services::sourcemap::assemble_bundle;
+use crate::services::sourcemap::assemble_bundle_for_job;
 use crate::services::sourcemap_store::SourceMapStore;
 
 pub struct AssemblyWorker {
@@ -156,20 +156,20 @@ impl AssemblyWorker {
             job.bundle_checksum
         );
 
-        let result = assemble_bundle(
+        let result = assemble_bundle_for_job(
             &self.pool,
             self.store.as_ref(),
             job.project_id,
             &job.bundle_checksum,
             job.chunk_list(),
             self.max_bundle_size_bytes,
+            job.id,
         )
         .await;
 
         match result {
             Ok(()) => {
                 log::info!("Assembly worker: job {} completed successfully", job.id);
-                self.mark_success(job.id).await?;
             }
             Err(e) => {
                 let detail = format!("{:?}", e);
@@ -177,26 +177,6 @@ impl AssemblyWorker {
                 self.mark_failure(job.id, &detail).await?;
             }
         }
-
-        Ok(())
-    }
-
-    async fn mark_success(&self, job_id: i64) -> Result<(), sqlx::Error> {
-        #[cfg(feature = "postgres")]
-        sqlx::query(
-            "UPDATE assembly_jobs SET state = 'ok', detail = NULL, updated_at = NOW() WHERE id = $1",
-        )
-        .bind(job_id)
-        .execute(&self.pool)
-        .await?;
-
-        #[cfg(not(feature = "postgres"))]
-        sqlx::query(
-            "UPDATE assembly_jobs SET state = 'ok', detail = NULL, updated_at = datetime('now') WHERE id = $1",
-        )
-        .bind(job_id)
-        .execute(&self.pool)
-        .await?;
 
         Ok(())
     }

--- a/apps/server/src/workers/sourcemap_assembly.rs
+++ b/apps/server/src/workers/sourcemap_assembly.rs
@@ -40,10 +40,14 @@ impl AssemblyWorker {
         let mut interval = tokio::time::interval(Duration::from_secs(1));
         loop {
             interval.tick().await;
-            if let Err(e) = self.poll_once().await {
+            if let Err(e) = self.run_once().await {
                 log::error!("Assembly worker poll error: {:?}", e);
             }
         }
+    }
+
+    pub async fn run_once(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.poll_once().await
     }
 
     /// Reset assembling jobs whose lock has expired (crash recovery).
@@ -224,18 +228,23 @@ impl AssemblyWorker {
                 .fetch_one(&mut *tx)
                 .await?;
         if retry_count >= max_retries {
-            // Delete only chunks that this terminal job owns exclusively;
-            // shared chunks remain available to the other assembly.
-            sqlx::query(
-                "DELETE FROM chunk WHERE EXISTS (SELECT 1 FROM assembly_job_chunks owned WHERE owned.job_id = $1 AND owned.checksum = chunk.checksum) AND NOT EXISTS (SELECT 1 FROM assembly_job_chunks retained WHERE retained.checksum = chunk.checksum AND retained.job_id <> $1)",
-            )
-            .bind(job_id)
-            .execute(&mut *tx)
-            .await?;
+            let owned_checksums: Vec<String> =
+                sqlx::query_scalar("SELECT checksum FROM assembly_job_chunks WHERE job_id = $1")
+                    .bind(job_id)
+                    .fetch_all(&mut *tx)
+                    .await?;
             sqlx::query("DELETE FROM assembly_job_chunks WHERE job_id = $1")
                 .bind(job_id)
                 .execute(&mut *tx)
                 .await?;
+            for checksum in owned_checksums {
+                sqlx::query(
+                    "DELETE FROM chunk WHERE checksum = $1 AND NOT EXISTS (SELECT 1 FROM assembly_job_chunks WHERE checksum = $1)",
+                )
+                .bind(checksum)
+                .execute(&mut *tx)
+                .await?;
+            }
         }
 
         tx.commit().await

--- a/apps/server/tests/integration/alerts_api_test.rs
+++ b/apps/server/tests/integration/alerts_api_test.rs
@@ -828,3 +828,137 @@ async fn test_create_rule_success() {
 async fn test_test_channel_endpoint() {
     // This test requires proper session cookie handling
 }
+
+#[tokio::test]
+async fn test_claim_due_retries_leases_rows_exclusively() {
+    // A pending history row must be dispatchable by exactly one worker:
+    // claiming it takes a lease, so a concurrent (or immediately following)
+    // claim cannot pick up the same row and double-deliver the alert.
+    let db = TestDb::new().await;
+    let project_id = create_test_project(&db.pool).await;
+
+    sqlx::query(
+        "INSERT INTO alert_history (project_id, alert_type, channel_type, channel_name, status, idempotency_key) VALUES ($1, 'new_issue', 'webhook', 'unconfigured', 'pending', $2)",
+    )
+    .bind(project_id)
+    .bind(format!("claim-lease-{project_id}"))
+    .execute(&db.pool)
+    .await
+    .expect("pending alert history insert must succeed");
+
+    let first = AlertService::claim_due_retries(&db.pool, 5, 100)
+        .await
+        .expect("first claim must succeed");
+    assert_eq!(first.len(), 1, "first claim must lease the pending row");
+
+    let second = AlertService::claim_due_retries(&db.pool, 5, 100)
+        .await
+        .expect("second claim must succeed");
+    assert!(
+        second.is_empty(),
+        "a leased row must not be claimable again while its lease holds"
+    );
+}
+
+#[tokio::test]
+async fn test_trigger_alert_does_not_block_on_slow_webhook_delivery() {
+    // Relay never couples ingestion latency to notification I/O. Rustrak's
+    // digest awaits trigger_*_alert for durability, so the durable part
+    // (history rows) must commit synchronously while the network dispatch
+    // happens off the digest path: a hung webhook endpoint must not stall
+    // the caller for the 30s HTTP timeout.
+    let db = TestDb::new().await;
+    let project_id = create_test_project(&db.pool).await;
+    let project = ProjectService::get_by_id(&db.pool, project_id)
+        .await
+        .expect("project lookup must succeed");
+
+    // A webhook endpoint that accepts connections and never responds.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind hanging webhook listener");
+    let addr = listener.local_addr().expect("listener addr");
+    tokio::spawn(async move {
+        loop {
+            let Ok((socket, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let _socket = socket;
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+            });
+        }
+    });
+
+    let channel = AlertService::create_channel(
+        &db.pool,
+        CreateNotificationChannel {
+            name: "Hanging Webhook".to_string(),
+            provider_type: ChannelType::Webhook,
+            credentials: json!({ "url": format!("http://{addr}/hook") }),
+            is_enabled: true,
+        },
+    )
+    .await
+    .expect("channel creation must succeed");
+    AlertService::create_rule(
+        &db.pool,
+        project_id,
+        CreateAlertRule {
+            name: "Slow Webhook Rule".to_string(),
+            alert_type: AlertType::NewIssue,
+            channels: vec![AlertRuleChannelInput {
+                integration_id: channel.id,
+                routing_override: json!({}),
+            }],
+            conditions: json!({}),
+            cooldown_minutes: 0,
+        },
+    )
+    .await
+    .expect("rule creation must succeed");
+
+    let issue = IssueService::create(
+        &db.pool,
+        project_id,
+        Utc::now(),
+        &DenormalizedFields {
+            calculated_type: "Error".to_string(),
+            calculated_value: "slow webhook".to_string(),
+            transaction: "/test".to_string(),
+            last_frame_filename: "test.rs".to_string(),
+            last_frame_module: "test".to_string(),
+            last_frame_function: "test".to_string(),
+            culprit: "test".to_string(),
+            logger: String::new(),
+            release: String::new(),
+        },
+        Some("error"),
+        Some("rust"),
+    )
+    .await
+    .expect("issue creation must succeed");
+
+    let trigger =
+        AlertService::trigger_new_issue_alert(&db.pool, &project, &issue, "http://localhost:3000");
+    tokio::time::timeout(Duration::from_secs(2), trigger)
+        .await
+        .expect("trigger must return without waiting for webhook I/O")
+        .expect("trigger must succeed");
+
+    // The durable delivery record is committed before the caller returns,
+    // leased to the in-flight dispatcher so the retry worker cannot
+    // double-send it while the dispatch is still running.
+    let (status, leased): (String, bool) = sqlx::query_as(
+        "SELECT status, next_retry_at IS NOT NULL AND datetime(next_retry_at) > datetime('now') FROM alert_history WHERE project_id = $1",
+    )
+    .bind(project_id)
+    .fetch_one(&db.pool)
+    .await
+    .expect("history row must exist before trigger returns");
+    assert_eq!(status, "pending");
+    assert!(
+        leased,
+        "in-flight delivery must hold a future next_retry_at lease"
+    );
+}

--- a/apps/server/tests/integration/alerts_api_test.rs
+++ b/apps/server/tests/integration/alerts_api_test.rs
@@ -6,13 +6,15 @@
 use crate::common::TestDb;
 use actix_session::{storage::CookieSessionStore, SessionMiddleware};
 use actix_web::{cookie::Key, test, web, App};
+use chrono::Utc;
 use rustrak::config::{Config, DatabaseConfig, RateLimitConfig};
 use rustrak::models::{
     AlertRuleChannelInput, AlertType, ChannelType, CreateAlertRule, CreateNotificationChannel,
     UpdateAlertRule, UpdateNotificationChannel,
 };
 use rustrak::routes;
-use rustrak::services::{AlertService, ProjectService};
+use rustrak::services::grouping::DenormalizedFields;
+use rustrak::services::{AlertService, IssueService, ProjectService};
 use serde_json::json;
 use std::time::Duration;
 use uuid::Uuid;
@@ -152,6 +154,94 @@ async fn test_alert_retry_queue_processes_pending_history_without_retry_time() {
             .await
             .expect("retry status lookup must succeed");
     assert_eq!(status, "failed");
+}
+
+#[tokio::test]
+async fn test_event_alert_cooldown_is_a_durable_replay_barrier() {
+    let db = TestDb::new().await;
+    let project_id = create_test_project(&db.pool).await;
+    let project = ProjectService::get_by_id(&db.pool, project_id)
+        .await
+        .expect("project lookup must succeed");
+    let channel = AlertService::create_channel(
+        &db.pool,
+        CreateNotificationChannel {
+            name: "Cooldown Webhook".to_string(),
+            provider_type: ChannelType::Webhook,
+            credentials: json!({ "url": "https://example.com/webhook" }),
+            is_enabled: true,
+        },
+    )
+    .await
+    .expect("channel creation must succeed");
+    let rule = AlertService::create_rule(
+        &db.pool,
+        project_id,
+        CreateAlertRule {
+            name: "Cooldown Rule".to_string(),
+            alert_type: AlertType::NewIssue,
+            channels: vec![AlertRuleChannelInput {
+                integration_id: channel.id,
+                routing_override: json!({}),
+            }],
+            conditions: json!({}),
+            cooldown_minutes: 60,
+        },
+    )
+    .await
+    .expect("rule creation must succeed");
+    sqlx::query("UPDATE alert_rules SET last_triggered_at = $1 WHERE id = $2")
+        .bind(Utc::now())
+        .bind(rule.id)
+        .execute(&db.pool)
+        .await
+        .expect("cooldown setup must succeed");
+
+    let issue = IssueService::create(
+        &db.pool,
+        project_id,
+        Utc::now(),
+        &DenormalizedFields {
+            calculated_type: "Error".to_string(),
+            calculated_value: "cooldown replay".to_string(),
+            transaction: "/test".to_string(),
+            last_frame_filename: "test.rs".to_string(),
+            last_frame_module: "test".to_string(),
+            last_frame_function: "test".to_string(),
+            culprit: "test".to_string(),
+            logger: String::new(),
+            release: String::new(),
+        },
+        Some("error"),
+        Some("rust"),
+    )
+    .await
+    .expect("issue creation must succeed");
+    let event_id = Uuid::new_v4();
+
+    AlertService::trigger_event_alert(
+        &db.pool,
+        &project,
+        &issue,
+        AlertType::NewIssue,
+        event_id,
+        "https://dashboard.example.com",
+    )
+    .await
+    .expect("cooldown suppression must succeed");
+
+    let status: String =
+        sqlx::query_scalar("SELECT status FROM alert_history WHERE idempotency_key LIKE $1")
+            .bind(format!("event-{project_id}-{event_id}-new_issue-%"))
+            .fetch_one(&db.pool)
+            .await
+            .expect("suppressed alert history must exist");
+    assert_eq!(status, "skipped");
+    assert!(
+        AlertService::event_alert_exists(&db.pool, project_id, event_id, AlertType::NewIssue,)
+            .await
+            .expect("replay barrier lookup must succeed")
+    );
 }
 
 // =============================================================================

--- a/apps/server/tests/integration/alerts_api_test.rs
+++ b/apps/server/tests/integration/alerts_api_test.rs
@@ -95,6 +95,16 @@ async fn test_event_alert_history_is_scoped_to_project() {
     )
     .await
     .expect("first project lookup must succeed"));
+
+    sqlx::query(
+        "INSERT INTO alert_history (project_id, alert_type, channel_type, channel_name, status, idempotency_key) VALUES ($1, 'new_issue', 'webhook', 'legacy', 'pending', $2)",
+    )
+    .bind(first_project)
+    .bind(format!("event-{event_id}-new_issue-integration"))
+    .execute(&db.pool)
+    .await
+    .expect("legacy alert history insert must succeed");
+
     assert!(!AlertService::event_alert_exists(
         &db.pool,
         second_project,

--- a/apps/server/tests/integration/alerts_api_test.rs
+++ b/apps/server/tests/integration/alerts_api_test.rs
@@ -115,6 +115,36 @@ async fn test_event_alert_history_is_scoped_to_project() {
     .expect("second project lookup must succeed"));
 }
 
+#[tokio::test]
+async fn test_alert_retry_queue_processes_pending_history_without_retry_time() {
+    let db = TestDb::new().await;
+    let project_id = create_test_project(&db.pool).await;
+
+    sqlx::query(
+        "INSERT INTO alert_history (project_id, alert_type, channel_type, channel_name, status, idempotency_key) VALUES ($1, 'new_issue', 'webhook', 'unconfigured', 'pending', $2)",
+    )
+    .bind(project_id)
+    .bind(format!("retry-null-next-{project_id}"))
+    .execute(&db.pool)
+    .await
+    .expect("pending alert history insert must succeed");
+
+    assert_eq!(
+        AlertService::process_retry_queue(&db.pool, 5)
+            .await
+            .expect("retry queue processing must succeed"),
+        1
+    );
+
+    let status: String =
+        sqlx::query_scalar("SELECT status FROM alert_history WHERE idempotency_key = $1")
+            .bind(format!("retry-null-next-{project_id}"))
+            .fetch_one(&db.pool)
+            .await
+            .expect("retry status lookup must succeed");
+    assert_eq!(status, "failed");
+}
+
 // =============================================================================
 // Service-Level Tests (Direct Database)
 // =============================================================================

--- a/apps/server/tests/integration/alerts_api_test.rs
+++ b/apps/server/tests/integration/alerts_api_test.rs
@@ -105,6 +105,15 @@ async fn test_event_alert_history_is_scoped_to_project() {
     .await
     .expect("legacy alert history insert must succeed");
 
+    assert!(AlertService::event_alert_exists(
+        &db.pool,
+        first_project,
+        event_id,
+        AlertType::NewIssue,
+    )
+    .await
+    .expect("first project legacy lookup must succeed"));
+
     assert!(!AlertService::event_alert_exists(
         &db.pool,
         second_project,

--- a/apps/server/tests/integration/alerts_api_test.rs
+++ b/apps/server/tests/integration/alerts_api_test.rs
@@ -15,6 +15,7 @@ use rustrak::routes;
 use rustrak::services::{AlertService, ProjectService};
 use serde_json::json;
 use std::time::Duration;
+use uuid::Uuid;
 
 /// Creates a test config
 fn create_test_config() -> Config {
@@ -66,6 +67,42 @@ async fn create_test_project(pool: &rustrak::db::DbPool) -> i32 {
     .await
     .expect("Failed to create test project");
     project.id
+}
+
+#[tokio::test]
+async fn test_event_alert_history_is_scoped_to_project() {
+    let db = TestDb::new().await;
+    let first_project = create_test_project(&db.pool).await;
+    let second_project = create_test_project(&db.pool).await;
+    let event_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO alert_history (project_id, alert_type, channel_type, channel_name, status, idempotency_key) VALUES ($1, 'new_issue', 'webhook', 'test', 'pending', $2)",
+    )
+    .bind(first_project)
+    .bind(format!(
+        "event-{first_project}-{event_id}-new_issue-integration"
+    ))
+    .execute(&db.pool)
+    .await
+    .expect("alert history insert must succeed");
+
+    assert!(AlertService::event_alert_exists(
+        &db.pool,
+        first_project,
+        event_id,
+        AlertType::NewIssue
+    )
+    .await
+    .expect("first project lookup must succeed"));
+    assert!(!AlertService::event_alert_exists(
+        &db.pool,
+        second_project,
+        event_id,
+        AlertType::NewIssue,
+    )
+    .await
+    .expect("second project lookup must succeed"));
 }
 
 // =============================================================================

--- a/apps/server/tests/integration/concurrency_test.rs
+++ b/apps/server/tests/integration/concurrency_test.rs
@@ -7,7 +7,7 @@ use crate::common::process_error_event;
 use crate::common::TestDb;
 use chrono::Utc;
 use rustrak::config::RateLimitConfig;
-use rustrak::ingest::{store_event, EventMetadata};
+use rustrak::ingest::{get_event_path, store_event, EventMetadata};
 use rustrak::models::CreateProject;
 use rustrak::pagination::{IssueSort, SortOrder};
 use rustrak::services::{IssueService, ProjectService};
@@ -955,6 +955,12 @@ async fn test_digest_fails_after_exhausting_sqlite_write_retries() {
         result.is_err(),
         "exhausted retries must fail, not drop the event silently"
     );
+    assert!(
+        get_event_path(&ingest_dir, &metadata.event_id)
+            .unwrap()
+            .exists(),
+        "a retryable failure must retain the durable event file"
+    );
 
     // The rolled-back transaction left no partial issue/grouping behind.
     let (issues, _) = IssueService::list_paginated(
@@ -1331,4 +1337,130 @@ async fn test_a_digest_that_cannot_store_its_event_leaves_no_issue_behind() {
         .await
         .expect("Failed to count groupings");
     assert_eq!(groupings, 0, "the grouping must roll back with the issue");
+}
+
+/// A post-commit platform refresh must not turn an already durable digest into
+/// a failed processor result.
+#[cfg(feature = "sqlite")]
+#[actix_web::test]
+async fn test_post_commit_platform_refresh_failure_does_not_fail_digest() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let pool = Arc::new(production_pool(&temp_dir.path().join("rustrak_quota.db"), 5).await);
+    let project = create_test_project(&pool, "Post Commit Platform").await;
+    let ingest_dir = temp_dir.path().to_path_buf();
+
+    sqlx::query(
+        "CREATE TRIGGER reject_platform_inference BEFORE UPDATE OF platform ON projects \
+         BEGIN SELECT RAISE(ABORT, 'injected: platform inference unavailable'); END",
+    )
+    .execute(pool.as_ref())
+    .await
+    .expect("Failed to install the platform fault-injection trigger");
+
+    let (event_id, event_json) = create_unique_event_json("PlatformRefreshError", "Msg");
+    let mut event_json = event_json;
+    event_json["platform"] = serde_json::json!("python");
+    store_event(
+        &ingest_dir,
+        &event_id,
+        &serde_json::to_vec(&event_json).unwrap(),
+    )
+    .await
+    .expect("Failed to store event");
+    let metadata = EventMetadata {
+        event_id,
+        project_id: project.id,
+        ingested_at: Utc::now(),
+        remote_addr: None,
+    };
+
+    process_error_event(
+        &pool,
+        &metadata,
+        &ingest_dir,
+        &create_rate_limit_config(),
+        crate::common::null_sourcemap_provider(),
+    )
+    .await
+    .expect("post-commit platform refresh failure must not fail the digest");
+
+    let events: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE project_id = $1")
+        .bind(project.id)
+        .fetch_one(pool.as_ref())
+        .await
+        .expect("Failed to count durable events");
+    assert_eq!(events, 1, "the digest must remain durable");
+}
+
+/// Quota counters are part of the digest transaction: a partial counter write
+/// must roll back the event, issue, and both counter values together.
+#[cfg(feature = "sqlite")]
+#[actix_web::test]
+async fn test_quota_counter_failure_rolls_back_digest_and_counters() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let pool = Arc::new(production_pool(&temp_dir.path().join("rustrak_counter.db"), 5).await);
+    let project = create_test_project(&pool, "Atomic Quota Counters").await;
+    let initial_project = ProjectService::get_by_id(&pool, project.id).await.unwrap();
+    let initial_installation: i64 =
+        sqlx::query_scalar("SELECT digested_event_count FROM installation WHERE id = 1")
+            .fetch_one(pool.as_ref())
+            .await
+            .unwrap();
+    let ingest_dir = temp_dir.path().to_path_buf();
+
+    sqlx::query(
+        "CREATE TRIGGER reject_project_counter BEFORE UPDATE OF digested_event_count ON projects \
+         BEGIN SELECT RAISE(ABORT, 'injected: project counter unavailable'); END",
+    )
+    .execute(pool.as_ref())
+    .await
+    .expect("Failed to install the counter fault-injection trigger");
+
+    let (event_id, event_json) = create_unique_event_json("AtomicCounterError", "Msg");
+    store_event(
+        &ingest_dir,
+        &event_id,
+        &serde_json::to_vec(&event_json).unwrap(),
+    )
+    .await
+    .unwrap();
+    let metadata = EventMetadata {
+        event_id,
+        project_id: project.id,
+        ingested_at: Utc::now(),
+        remote_addr: None,
+    };
+
+    assert!(process_error_event(
+        &pool,
+        &metadata,
+        &ingest_dir,
+        &create_rate_limit_config(),
+        crate::common::null_sourcemap_provider(),
+    )
+    .await
+    .is_err());
+
+    let updated_project = ProjectService::get_by_id(&pool, project.id).await.unwrap();
+    let installation_count: i64 =
+        sqlx::query_scalar("SELECT digested_event_count FROM installation WHERE id = 1")
+            .fetch_one(pool.as_ref())
+            .await
+            .unwrap();
+    let events: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE project_id = $1")
+        .bind(project.id)
+        .fetch_one(pool.as_ref())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        updated_project.stored_event_count,
+        initial_project.stored_event_count
+    );
+    assert_eq!(
+        updated_project.digested_event_count,
+        initial_project.digested_event_count
+    );
+    assert_eq!(installation_count, initial_installation);
+    assert_eq!(events, 0);
 }

--- a/apps/server/tests/integration/concurrency_test.rs
+++ b/apps/server/tests/integration/concurrency_test.rs
@@ -7,7 +7,9 @@ use crate::common::process_error_event;
 use crate::common::TestDb;
 use chrono::Utc;
 use rustrak::config::RateLimitConfig;
-use rustrak::ingest::{get_event_path, store_event, EventMetadata};
+#[cfg(feature = "sqlite")]
+use rustrak::ingest::get_event_path;
+use rustrak::ingest::{store_event, EventMetadata};
 use rustrak::models::CreateProject;
 use rustrak::pagination::{IssueSort, SortOrder};
 use rustrak::services::{IssueService, ProjectService};

--- a/apps/server/tests/integration/envelope_v2_test.rs
+++ b/apps/server/tests/integration/envelope_v2_test.rs
@@ -340,3 +340,85 @@ async fn pending_event_recovery_replays_a_scoped_event() {
         .unwrap();
     assert_eq!(count, 1);
 }
+
+/// Relay parity: a malformed item payload never fails the envelope — the
+/// invalid item is dropped (Relay records an Invalid outcome) and every
+/// sibling item is still processed, with the endpoint returning 200.
+/// (relay-server/src/processing/relay.rs run_one: "This is not a fatal error
+/// case ... other items from the same original envelope must still be
+/// processed.")
+#[actix_web::test]
+async fn malformed_log_item_is_dropped_and_sibling_event_still_ingests() {
+    let db = TestDb::new().await;
+    let (project_id, sentry_key) = create_test_project(&db.pool, "Malformed Log Sibling").await;
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = create_test_config();
+    config.ingest_dir = Some(temp_dir.path().to_string_lossy().into_owned());
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(web::Data::new(config.clone()))
+            .app_data(web::Data::new(crate::common::null_sourcemap_provider()))
+            .app_data(web::Data::new(
+                rustrak::digest::processors::Processors::new(
+                    rustrak::ingest::get_ingest_dir(config.ingest_dir.as_deref()),
+                    config.rate_limit.clone(),
+                    crate::common::null_sourcemap_provider(),
+                    None,
+                ),
+            ))
+            .configure(routes::ingest::configure),
+    )
+    .await;
+
+    let event_id = Uuid::new_v4().simple().to_string();
+    let event = json!({
+        "event_id": event_id,
+        "timestamp": 1704801600.0_f64,
+        "platform": "python",
+        "level": "error",
+        "exception": {
+            "values": [{ "type": "ValueError", "value": "sibling survives" }]
+        }
+    })
+    .to_string();
+    let broken_log_container = "{this is not json";
+    let envelope = format!(
+        "{}\n{}\n{}\n{}\n{}\n",
+        json!({ "event_id": event_id }),
+        json!({ "type": "log", "item_count": 1, "content_type": "application/vnd.sentry.items.log+json" }),
+        broken_log_container,
+        json!({ "type": "event" }),
+        event,
+    );
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/api/{project_id}/envelope/"))
+        .insert_header(("X-Sentry-Auth", format!("Sentry sentry_key={sentry_key}")))
+        .insert_header(("Content-Type", "application/x-sentry-envelope"))
+        .set_payload(envelope)
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, req).await.status(),
+        200,
+        "a malformed log item must be dropped, not fail the envelope"
+    );
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE project_id = $1")
+            .bind(project_id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+        if count == 1 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the sibling event must still be ingested"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}

--- a/apps/server/tests/integration/envelope_v2_test.rs
+++ b/apps/server/tests/integration/envelope_v2_test.rs
@@ -5,11 +5,13 @@
 use crate::common::TestDb;
 use actix_web::{test, web, App};
 use rustrak::config::{Config, DatabaseConfig, RateLimitConfig};
+use rustrak::ingest::{store_event_with_metadata, EventMetadata};
 use rustrak::routes;
 use rustrak::services::{DbSourceMapProvider, LocalSourceMapStore, ProjectService};
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
+use tempfile::TempDir;
 use uuid::Uuid;
 
 fn create_test_config() -> Config {
@@ -225,4 +227,116 @@ async fn test_transaction_envelope_returns_200_with_id() {
         stored, 1,
         "transaction must be stored in the dedicated transactions table"
     );
+}
+
+#[actix_web::test]
+async fn same_event_id_isolated_between_projects_over_http() {
+    let db = TestDb::new().await;
+    let (first_project, first_key) = create_test_project(&db.pool, "Scoped Event One").await;
+    let (second_project, second_key) = create_test_project(&db.pool, "Scoped Event Two").await;
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = create_test_config();
+    config.ingest_dir = Some(temp_dir.path().to_string_lossy().into_owned());
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .app_data(web::Data::new(config.clone()))
+            .app_data(web::Data::new(crate::common::null_sourcemap_provider()))
+            .app_data(web::Data::new(
+                rustrak::digest::processors::Processors::new(
+                    rustrak::ingest::get_ingest_dir(config.ingest_dir.as_deref()),
+                    config.rate_limit.clone(),
+                    crate::common::null_sourcemap_provider(),
+                    None,
+                ),
+            ))
+            .configure(routes::ingest::configure),
+    )
+    .await;
+
+    let event_id = Uuid::new_v4().simple().to_string();
+    for (project_id, sentry_key) in [(first_project, first_key), (second_project, second_key)] {
+        let req = test::TestRequest::post()
+            .uri(&format!("/api/{project_id}/envelope/"))
+            .insert_header(("X-Sentry-Auth", format!("Sentry sentry_key={sentry_key}")))
+            .insert_header(("Content-Type", "application/x-sentry-envelope"))
+            .set_payload(error_envelope(&event_id))
+            .to_request();
+        assert_eq!(test::call_service(&app, req).await.status(), 200);
+    }
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        let first_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE project_id = $1")
+                .bind(first_project)
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        let second_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE project_id = $1")
+                .bind(second_project)
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        if first_count == 1 && second_count == 1 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "both project events must be stored"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[actix_web::test]
+async fn pending_event_recovery_replays_a_scoped_event() {
+    let db = TestDb::new().await;
+    let (project, _) = create_test_project(&db.pool, "Recovery Replay Test").await;
+    let temp_dir = TempDir::new().unwrap();
+    let config = create_test_config();
+    let event_id = Uuid::new_v4().simple().to_string();
+    let metadata = EventMetadata {
+        event_id: event_id.clone(),
+        project_id: project,
+        ingested_at: chrono::Utc::now(),
+        remote_addr: None,
+    };
+    let event_data = serde_json::json!({
+        "event_id": event_id,
+        "timestamp": 1704801600.0_f64,
+        "platform": "rust",
+        "level": "error",
+        "exception": {"values": [{"type": "Recovered", "value": "after restart"}]}
+    });
+    store_event_with_metadata(
+        temp_dir.path(),
+        &metadata.event_id,
+        &serde_json::to_vec(&event_data).unwrap(),
+        &metadata,
+    )
+    .await
+    .unwrap();
+
+    let processors = web::Data::new(rustrak::digest::processors::Processors::new(
+        temp_dir.path().to_path_buf(),
+        config.rate_limit,
+        crate::common::null_sourcemap_provider(),
+        None,
+    ));
+    routes::ingest::recover_pending_events_once(
+        db.pool.clone(),
+        processors,
+        temp_dir.path().to_path_buf(),
+    )
+    .await;
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE project_id = $1")
+        .bind(project)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1);
 }

--- a/apps/server/tests/integration/events_api_test.rs
+++ b/apps/server/tests/integration/events_api_test.rs
@@ -161,6 +161,7 @@ async fn create_test_event(
         timestamp,
         &denormalized,
         None,
+        None,
     )
     .await
     .expect("Failed to create test event")

--- a/apps/server/tests/integration/rate_limit_test.rs
+++ b/apps/server/tests/integration/rate_limit_test.rs
@@ -572,3 +572,47 @@ async fn test_rate_limit_affects_only_specific_project() {
     let resp_b = test::call_service(&app, req_b).await;
     assert!(resp_b.status().is_success());
 }
+
+#[tokio::test]
+async fn test_check_quota_degrades_to_stale_state_when_refresh_fails() {
+    // Quota refresh is derived bookkeeping. When it cannot run (e.g. SQLite
+    // busy under write load), ingestion must proceed on the stale quota state
+    // instead of failing the request: the digest side already treats the same
+    // refresh as best-effort, and a 5xx here would reject an event that
+    // nothing else objects to.
+    let db = TestDb::new().await;
+    let (project_id, _key) = create_test_project(&db.pool, "Stale Quota Project").await;
+    let project = ProjectService::get_by_id(&db.pool, project_id)
+        .await
+        .expect("project lookup must succeed");
+    let config = RateLimitConfig {
+        max_events_per_minute: 1000,
+        max_events_per_hour: 10000,
+        max_events_per_project_per_minute: 500,
+        max_events_per_project_per_hour: 5000,
+    };
+
+    // Make the derived state stale so check_quota attempts a refresh...
+    sqlx::query(
+        "UPDATE installation SET next_quota_check = 1, digested_event_count = 5 WHERE id = 1",
+    )
+    .execute(&db.pool)
+    .await
+    .expect("staleness setup must succeed");
+    // ...and make that refresh fail deterministically.
+    sqlx::query(
+        "CREATE TRIGGER fail_quota_refresh BEFORE UPDATE OF next_quota_check ON installation \
+         BEGIN SELECT RAISE(ABORT, 'injected: quota refresh unavailable'); END",
+    )
+    .execute(&db.pool)
+    .await
+    .expect("trigger creation must succeed");
+
+    let verdict = RateLimitService::check_quota(&db.pool, &project, &config)
+        .await
+        .expect("a failed quota refresh must not fail the ingest request");
+    assert!(
+        verdict.is_none(),
+        "stale non-exceeded quota state must admit the event"
+    );
+}

--- a/apps/server/tests/integration/rate_limit_test.rs
+++ b/apps/server/tests/integration/rate_limit_test.rs
@@ -8,7 +8,8 @@ use chrono::{Duration, Utc};
 use rustrak::config::{Config, DatabaseConfig, RateLimitConfig};
 use rustrak::routes;
 use rustrak::services::{
-    DbSourceMapProvider, LocalSourceMapStore, ProjectService, SourceMapProvider, SourceMapStore,
+    DbSourceMapProvider, LocalSourceMapStore, ProjectService, RateLimitService, SourceMapProvider,
+    SourceMapStore,
 };
 use serde_json::json;
 use std::sync::Arc;
@@ -73,21 +74,61 @@ async fn set_project_quota_exceeded(
     project_id: i32,
     until: chrono::DateTime<Utc>,
 ) {
-    sqlx::query("UPDATE projects SET quota_exceeded_until = $1 WHERE id = $2")
-        .bind(until)
-        .bind(project_id)
-        .execute(pool)
-        .await
-        .expect("Failed to set project quota");
+    sqlx::query(
+        "UPDATE projects SET quota_exceeded_until = $1, next_quota_check = 1 WHERE id = $2",
+    )
+    .bind(until)
+    .bind(project_id)
+    .execute(pool)
+    .await
+    .expect("Failed to set project quota");
 }
 
 /// Sets installation quota exceeded until the given time
 async fn set_installation_quota_exceeded(pool: &rustrak::db::DbPool, until: chrono::DateTime<Utc>) {
-    sqlx::query("UPDATE installation SET quota_exceeded_until = $1 WHERE id = 1")
-        .bind(until)
-        .execute(pool)
+    sqlx::query(
+        "UPDATE installation SET quota_exceeded_until = $1, next_quota_check = 1 WHERE id = 1",
+    )
+    .bind(until)
+    .execute(pool)
+    .await
+    .expect("Failed to set installation quota");
+}
+
+#[actix_web::test]
+async fn stale_quota_cache_is_refreshed_before_the_next_ingest() {
+    let db = TestDb::new().await;
+    let (project_id, _) = create_test_project(&db.pool, "Stale Quota Cache").await;
+    let config = default_rate_limit_config();
+    sqlx::query("UPDATE installation SET next_quota_check = 1 WHERE id = 1")
+        .execute(&db.pool)
         .await
-        .expect("Failed to set installation quota");
+        .unwrap();
+    sqlx::query("UPDATE projects SET next_quota_check = 1 WHERE id = $1")
+        .bind(project_id)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    let project = ProjectService::get_by_id(&db.pool, project_id)
+        .await
+        .unwrap();
+    let stale_until = Utc::now() + Duration::minutes(10);
+    set_project_quota_exceeded(&db.pool, project_id, stale_until).await;
+    sqlx::query("UPDATE projects SET next_quota_check = 0 WHERE id = $1")
+        .bind(project_id)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+    assert!(RateLimitService::check_quota(&db.pool, &project, &config)
+        .await
+        .unwrap()
+        .is_none());
+    let refreshed = ProjectService::get_by_id(&db.pool, project_id)
+        .await
+        .unwrap();
+    assert!(refreshed.quota_exceeded_until.is_none());
+    assert!(refreshed.next_quota_check > i64::from(refreshed.digested_event_count));
 }
 
 /// Creates a minimal valid Sentry envelope

--- a/apps/server/tests/integration/sourcemaps_api_test.rs
+++ b/apps/server/tests/integration/sourcemaps_api_test.rs
@@ -941,6 +941,14 @@ async fn test_assemble_poll_returns_ok_after_worker_deleted_chunks() {
     // Simulate the assembly worker completing: job goes ok AND the consumed
     // chunk rows are deleted (assemble_bundle step 8).
     set_assembly_job_state(&db.pool, &bundle_checksum, project.id, "ok").await;
+    sqlx::query(
+        "DELETE FROM assembly_job_chunks WHERE job_id = (SELECT id FROM assembly_jobs WHERE bundle_checksum = $1 AND project_id = $2)",
+    )
+    .bind(&bundle_checksum)
+    .bind(project.id)
+    .execute(&db.pool)
+    .await
+    .expect("job chunk ownership delete must succeed");
     sqlx::query("DELETE FROM chunk WHERE checksum = $1")
         .bind(&chunk_sha1)
         .execute(&db.pool)
@@ -1592,6 +1600,107 @@ async fn test_assemble_bundle_finds_manifest_json() {
         "assemble_bundle must succeed; got: {:?}",
         result.err()
     );
+}
+
+#[actix_web::test]
+async fn test_assemble_bundle_keeps_chunk_owned_by_another_job() {
+    let db = TestDb::new().await;
+    let project_a = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "shared-chunk-a".to_string(),
+            slug: Some("shared-chunk-a".to_string()),
+            platform: None,
+        },
+    )
+    .await
+    .expect("project A creation must succeed");
+    let project_b = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "shared-chunk-b".to_string(),
+            slug: Some("shared-chunk-b".to_string()),
+            platform: None,
+        },
+    )
+    .await
+    .expect("project B creation must succeed");
+
+    let bundle = build_test_artifact_bundle();
+    let checksum = sha1_hex(&bundle);
+    rustrak::services::sourcemap::store_chunks(
+        &db.pool,
+        vec![(checksum.clone(), bundle)],
+        20 * 1024 * 1024,
+    )
+    .await
+    .expect("store_chunks must succeed");
+
+    let chunks = vec![checksum.clone()];
+    let job_a = insert_assembly_job_with_state_and_chunks(
+        &db.pool,
+        &checksum,
+        project_a.id,
+        "assembling",
+        None,
+        &chunks,
+    )
+    .await;
+    let job_b = insert_assembly_job_with_state_and_chunks(
+        &db.pool,
+        &checksum,
+        project_b.id,
+        "assembling",
+        None,
+        &chunks,
+    )
+    .await;
+    insert_assembly_job_chunk(&db.pool, job_a, &checksum).await;
+    insert_assembly_job_chunk(&db.pool, job_b, &checksum).await;
+
+    let config = create_test_config();
+    let store: std::sync::Arc<dyn rustrak::services::SourceMapStore> = std::sync::Arc::new(
+        rustrak::services::LocalSourceMapStore::new(&config.sourcemap_storage_path),
+    );
+    rustrak::services::sourcemap::assemble_bundle_for_job(
+        &db.pool,
+        store.as_ref(),
+        project_a.id,
+        &checksum,
+        &chunks,
+        100 * 1024 * 1024,
+        job_a,
+    )
+    .await
+    .expect("first assembly must succeed");
+
+    let retained: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM chunk WHERE checksum = $1")
+        .bind(&checksum)
+        .fetch_one(&db.pool)
+        .await
+        .expect("chunk count must succeed");
+    assert_eq!(
+        retained, 1,
+        "a shared chunk must survive the first assembly"
+    );
+
+    rustrak::services::sourcemap::assemble_bundle_for_job(
+        &db.pool,
+        store.as_ref(),
+        project_b.id,
+        &checksum,
+        &chunks,
+        100 * 1024 * 1024,
+        job_b,
+    )
+    .await
+    .expect("second assembly must succeed");
+    let deleted: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM chunk WHERE checksum = $1")
+        .bind(&checksum)
+        .fetch_one(&db.pool)
+        .await
+        .expect("chunk count must succeed");
+    assert_eq!(deleted, 0, "the last owner may release the chunk");
 }
 
 // =============================================================================
@@ -2384,37 +2493,50 @@ async fn insert_assembly_job_with_state_and_chunks(
     state: &str,
     detail: Option<&str>,
     chunks: &[String],
-) {
+) -> i64 {
     #[cfg(feature = "postgres")]
-    sqlx::query(
+    let id: i64 = sqlx::query_scalar(
         "INSERT INTO assembly_jobs(bundle_checksum, project_id, chunks, state, detail) \
-         VALUES ($1, $2, $3, $4, $5)",
+         VALUES ($1, $2, $3, $4, $5) RETURNING id",
     )
     .bind(checksum)
     .bind(project_id)
     .bind(chunks)
     .bind(state)
     .bind(detail)
-    .execute(pool)
+    .fetch_one(pool)
     .await
     .expect("insert assembly_jobs must succeed");
 
     #[cfg(not(feature = "postgres"))]
-    {
+    let id: i64 = {
         let chunks_json = serde_json::to_string(chunks).expect("chunks serialization must succeed");
-        sqlx::query(
+        sqlx::query_scalar(
             "INSERT INTO assembly_jobs(bundle_checksum, project_id, chunks, state, detail) \
-             VALUES (?, ?, ?, ?, ?)",
+             VALUES (?, ?, ?, ?, ?) RETURNING id",
         )
         .bind(checksum)
         .bind(project_id)
         .bind(&chunks_json)
         .bind(state)
         .bind(detail)
-        .execute(pool)
+        .fetch_one(pool)
         .await
-        .expect("insert assembly_jobs must succeed");
-    }
+        .expect("insert assembly_jobs must succeed")
+    };
+
+    id
+}
+
+async fn insert_assembly_job_chunk(pool: &rustrak::db::DbPool, job_id: i64, checksum: &str) {
+    sqlx::query(
+        "INSERT INTO assembly_job_chunks(job_id, checksum) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+    )
+    .bind(job_id)
+    .bind(checksum)
+    .execute(pool)
+    .await
+    .expect("insert assembly_job_chunks must succeed");
 }
 
 async fn fetch_assembly_job_chunks(

--- a/apps/server/tests/integration/sourcemaps_api_test.rs
+++ b/apps/server/tests/integration/sourcemaps_api_test.rs
@@ -28,6 +28,7 @@ use serde_json::Value;
 use sha1::{Digest as _, Sha1};
 use std::sync::Arc;
 use std::time::Duration;
+use uuid::Uuid;
 
 // =============================================================================
 // Test helpers
@@ -2215,15 +2216,93 @@ async fn test_worker_restart_recovery_resets_stuck_assembling_jobs() {
 }
 
 #[actix_web::test]
-#[ignore = "requires AssemblyWorker with retry logic to exhaust retries"]
-async fn test_worker_exhausts_retries_sets_error_state() {
-    // GIVEN: an assembly_jobs row with state='created', retry_count = max_retries - 1,
-    //        AND a bundle that will always fail (e.g. invalid ZIP data)
-    // WHEN:  the worker processes the job and it fails
-    // THEN:  assembly_jobs.state = 'error'
-    //        AND assembly_jobs.detail contains the last error message
-    //        AND retry_count == max_retries
-    todo!("enable once AssemblyWorker retry logic is injectable in tests")
+async fn test_worker_terminal_failure_releases_exclusive_chunks_only() {
+    let db = TestDb::new().await;
+    let project = ProjectService::create(
+        &db.pool,
+        CreateProject {
+            name: "terminal-cleanup".to_string(),
+            slug: Some("terminal-cleanup".to_string()),
+            platform: None,
+        },
+    )
+    .await
+    .expect("project creation must succeed");
+
+    let shared = b"not a zip archive".to_vec();
+    let exclusive = b"another invalid archive".to_vec();
+    let shared_checksum = sha1_hex(&shared);
+    let exclusive_checksum = sha1_hex(&exclusive);
+    rustrak::services::sourcemap::store_chunks(
+        &db.pool,
+        vec![
+            (shared_checksum.clone(), shared),
+            (exclusive_checksum.clone(), exclusive),
+        ],
+        20 * 1024 * 1024,
+    )
+    .await
+    .expect("chunk storage must succeed");
+
+    let job = insert_assembly_job_with_state_and_chunks(
+        &db.pool,
+        &shared_checksum,
+        project.id,
+        "created",
+        None,
+        &[shared_checksum.clone(), exclusive_checksum.clone()],
+    )
+    .await;
+    let other_job = insert_assembly_job_with_state_and_chunks(
+        &db.pool,
+        &exclusive_checksum,
+        project.id,
+        "assembling",
+        None,
+        std::slice::from_ref(&shared_checksum),
+    )
+    .await;
+    insert_assembly_job_chunk(&db.pool, job, &shared_checksum).await;
+    insert_assembly_job_chunk(&db.pool, job, &exclusive_checksum).await;
+    insert_assembly_job_chunk(&db.pool, other_job, &shared_checksum).await;
+    sqlx::query("UPDATE assembly_jobs SET retry_count = max_retries - 1 WHERE id = $1")
+        .bind(job)
+        .execute(&db.pool)
+        .await
+        .expect("retry setup must succeed");
+
+    let store = Arc::new(LocalSourceMapStore::new(
+        std::env::temp_dir().join(format!("rustrak-assembly-{}", Uuid::new_v4())),
+    ));
+    let worker = rustrak::workers::sourcemap_assembly::AssemblyWorker::new(
+        db.pool.clone(),
+        store,
+        100 * 1024 * 1024,
+    );
+    worker.run_once().await.expect("worker poll must succeed");
+
+    let state: String = sqlx::query_scalar("SELECT state FROM assembly_jobs WHERE id = $1")
+        .bind(job)
+        .fetch_one(&db.pool)
+        .await
+        .expect("job state lookup must succeed");
+    assert_eq!(state, "error");
+    let owned: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM assembly_job_chunks WHERE job_id = $1")
+            .bind(job)
+            .fetch_one(&db.pool)
+            .await
+            .expect("ownership lookup must succeed");
+    assert_eq!(owned, 0);
+
+    for (checksum, expected) in [(&shared_checksum, 1i64), (&exclusive_checksum, 0i64)] {
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM chunk WHERE checksum = $1")
+            .bind(checksum)
+            .fetch_one(&db.pool)
+            .await
+            .expect("chunk lookup must succeed");
+        assert_eq!(count, expected, "unexpected retention for {checksum}");
+    }
 }
 
 // =============================================================================

--- a/apps/server/tests/unit/log_test.rs
+++ b/apps/server/tests/unit/log_test.rs
@@ -84,6 +84,7 @@ mod level2 {
             remote_addr: None,
         };
 
+        LogsProcessor.process(body.clone(), &ctx).await.unwrap();
         LogsProcessor.process(body, &ctx).await.unwrap();
 
         #[cfg(feature = "postgres")]
@@ -99,7 +100,11 @@ mod level2 {
             .await
             .unwrap();
 
-        assert_eq!(rows.len(), 2, "two-item container → two log rows");
+        assert_eq!(
+            rows.len(),
+            2,
+            "replaying a container must not duplicate rows"
+        );
         let level0: String = rows[0].get("level");
         let body0: String = rows[0].get("body");
         let trace0: String = rows[0].get("trace_id");

--- a/apps/server/tests/unit/span_test.rs
+++ b/apps/server/tests/unit/span_test.rs
@@ -58,6 +58,120 @@ mod level2 {
     }
 
     #[tokio::test]
+    async fn test_span_batch_skips_malformed_and_crosses_chunk_boundary() {
+        // Invalid items are skipped, while valid items survive the 64-item
+        // transaction boundary.
+        let db = TestDb::new().await;
+        let project = ProjectService::create(
+            &db.pool,
+            CreateProject {
+                name: "span-batch".to_string(),
+                slug: None,
+                platform: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let valid = |span_id: String| {
+            serde_json::to_vec(&json!({
+                "op": "http.client",
+                "span_id": span_id,
+                "start_timestamp": 1234567890.0,
+                "timestamp": 1234567890.5,
+                "trace_id": "d3d20f000885466b8c8f947c9b92b8d3",
+            }))
+            .unwrap()
+        };
+        let mut items = vec![valid("0000000000000000".to_string()), b"{}".to_vec()];
+        items.extend((1..65).map(|i| valid(format!("{i:016x}"))));
+
+        SpanProcessor
+            .process_batch(items, &ctx(&db.pool, project.id))
+            .await
+            .unwrap();
+
+        #[cfg(feature = "postgres")]
+        const SPANS_QUERY: &str = "SELECT COUNT(*) FROM spans WHERE project_id = $1";
+        #[cfg(not(feature = "postgres"))]
+        const SPANS_QUERY: &str = "SELECT COUNT(*) FROM spans WHERE project_id = ?";
+        let count: i64 = sqlx::query_scalar(SPANS_QUERY)
+            .bind(project.id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 65);
+    }
+
+    #[tokio::test]
+    async fn test_chunk_failure_commits_earlier_chunks_only() {
+        // Pins the tx granularity of process_batch — the observable contract
+        // of chunking. A duplicate span_id in the SECOND chunk fails only
+        // that chunk, leaving the first chunk (64 spans) committed. A
+        // reverted parse-all/one-tx implementation rolls everything back
+        // (count 0), so this test fails if chunking is ever removed.
+        let db = TestDb::new().await;
+        let project = ProjectService::create(
+            &db.pool,
+            CreateProject {
+                name: "span-chunk-failure".to_string(),
+                slug: None,
+                platform: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // The production schema has no uniqueness on span_id — inject it so
+        // the duplicate below fails the INSERT instead of landing twice.
+        sqlx::query("CREATE UNIQUE INDEX test_spans_uniq_span_id ON spans(project_id, span_id)")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
+        let span_json = |span_id: &str, trace_id: &str| {
+            serde_json::to_vec(&json!({
+                "op": "http.client",
+                "span_id": span_id,
+                "start_timestamp": 1234567890.0,
+                "timestamp": 1234567890.5,
+                "trace_id": trace_id,
+            }))
+            .unwrap()
+        };
+
+        let trace_id = "d3d20f000885466b8c8f947c9b92b8d3";
+        let mut items: Vec<Vec<u8>> = (0..64)
+            .map(|i| span_json(&format!("{i:016x}"), trace_id))
+            .collect();
+        // Same span_id under another trace bypasses the application dedup key
+        // but violates the test-only unique index.
+        items.push(span_json(
+            "0000000000000000",
+            "e4e31f111996577c9f8a58d9c03c9e4",
+        ));
+
+        let result = SpanProcessor
+            .process_batch(items, &ctx(&db.pool, project.id))
+            .await;
+        assert!(result.is_err(), "the duplicate must fail the second chunk");
+
+        #[cfg(feature = "postgres")]
+        const SPANS_QUERY: &str = "SELECT COUNT(*) FROM spans WHERE project_id = $1";
+        #[cfg(not(feature = "postgres"))]
+        const SPANS_QUERY: &str = "SELECT COUNT(*) FROM spans WHERE project_id = ?";
+        let count: i64 = sqlx::query_scalar(SPANS_QUERY)
+            .bind(project.id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            count, 64,
+            "the first chunk committed before the duplicate failed the second"
+        );
+    }
+
+    #[tokio::test]
     async fn test_valid_span_stored_with_null_transaction_id() {
         // A standalone span (real Relay wire-format fixture, see
         // tests/integration/test_spans_standalone.py in the story's Dev Notes)

--- a/apps/server/tests/unit/span_test.rs
+++ b/apps/server/tests/unit/span_test.rs
@@ -91,6 +91,10 @@ mod level2 {
         .unwrap();
 
         SpanProcessor
+            .process(payload.clone(), &ctx(&db.pool, project.id))
+            .await
+            .unwrap();
+        SpanProcessor
             .process(payload, &ctx(&db.pool, project.id))
             .await
             .unwrap();
@@ -100,11 +104,17 @@ mod level2 {
         #[cfg(not(feature = "postgres"))]
         const QUERY: &str = "SELECT span_id, trace_id, parent_span_id, op, description, transaction_id, duration_ms FROM spans WHERE project_id = ?";
 
-        let row = sqlx::query(QUERY)
+        let rows = sqlx::query(QUERY)
             .bind(project.id)
-            .fetch_one(&db.pool)
+            .fetch_all(&db.pool)
             .await
             .unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "replaying a standalone span must not duplicate it"
+        );
+        let row = rows.into_iter().next().unwrap();
 
         let span_id: Option<String> = row.get("span_id");
         let trace_id: Option<String> = row.get("trace_id");

--- a/apps/server/tests/unit/span_v2_test.rs
+++ b/apps/server/tests/unit/span_v2_test.rs
@@ -223,6 +223,13 @@ mod level2 {
             )
             .await
             .unwrap();
+        SpanV2Processor
+            .process(
+                REAL_WIRE_FIXTURE.as_bytes().to_vec(),
+                &ctx(&db.pool, project.id),
+            )
+            .await
+            .unwrap();
 
         #[cfg(feature = "postgres")]
         const COUNT: &str = "SELECT COUNT(*) FROM spans WHERE project_id = $1";

--- a/apps/server/tests/unit/storage_test.rs
+++ b/apps/server/tests/unit/storage_test.rs
@@ -6,6 +6,7 @@
 use crate::common::TestDb;
 use bytes::Bytes;
 use chrono::Utc;
+use rustrak::ingest::{delete_event, read_event_for_project as read_scoped, store_event};
 use rustrak::models::{CleanupFilter, CreateProject};
 use rustrak::services::sourcemap_store::{LocalSourceMapStore, SourceMapStore};
 use rustrak::services::{ProjectService, StorageService};
@@ -16,6 +17,18 @@ use uuid::Uuid;
 /// Monotonic source of `digest_order` so seeded issues never collide on the
 /// `UNIQUE(project_id, digest_order)` constraint within a project.
 static DIGEST_ORDER: AtomicI32 = AtomicI32::new(1);
+
+#[tokio::test]
+async fn ingest_legacy_event_cleanup_removes_the_payload() {
+    let dir = tempdir().unwrap();
+    let event_id = Uuid::new_v4().to_string();
+    let payload = br#"{"legacy":true}"#;
+    store_event(dir.path(), &event_id, payload).await.unwrap();
+    let got = read_scoped(dir.path(), 99999, &event_id).await.unwrap();
+    assert_eq!(got, payload);
+    delete_event(dir.path(), &event_id).await.unwrap();
+    assert!(read_scoped(dir.path(), 99999, &event_id).await.is_err());
+}
 
 /// Inserts a chunk row directly (CAS table: checksum PK, size, data BYTEA).
 async fn insert_chunk(pool: &rustrak::db::DbPool, checksum: &str, size: i64) {

--- a/apps/server/tests/unit/transaction_processor_test.rs
+++ b/apps/server/tests/unit/transaction_processor_test.rs
@@ -152,6 +152,10 @@ mod level2 {
             remote_addr: None,
         };
 
+        TransactionProcessor
+            .process(payload.clone(), &ctx)
+            .await
+            .unwrap();
         TransactionProcessor.process(payload, &ctx).await.unwrap();
 
         #[cfg(feature = "postgres")]
@@ -171,6 +175,16 @@ mod level2 {
         let duration_ms: f64 = row.get("duration_ms");
         assert_eq!(name, "/api/users");
         assert_eq!(duration_ms, 10_000.0, "10s transaction → 10000ms");
+
+        let transaction_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM transactions WHERE project_id = $1 AND event_id = $2",
+        )
+        .bind(project.id)
+        .bind(ctx.event_id)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+        assert_eq!(transaction_count, 1);
     }
 
     #[tokio::test]

--- a/apps/server/tests/unit/transaction_processor_test.rs
+++ b/apps/server/tests/unit/transaction_processor_test.rs
@@ -673,7 +673,7 @@ mod level2 {
             .process(SessionItem::Update(update), &ctx)
             .await
             .unwrap();
-        handle.flush().await;
+        handle.flush().await.unwrap();
 
         #[cfg(feature = "postgres")]
         const QUERY: &str = "SELECT COUNT(*) FROM session_counts WHERE project_id = $1";

--- a/deny.toml
+++ b/deny.toml
@@ -2,15 +2,6 @@
 version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-ignore = [
-    # rsa 0.9.x Marvin timing attack — no fix available upstream;
-    # comes from sqlx-mysql (sqlx-macros-core transitive dep), we don't use MySQL.
-    "RUSTSEC-2023-0071",
-    # rand 0.8.x unsound with custom logger — no fix without sqlx upgrade;
-    # comes from sqlx-postgres (transitive dep), sqlx 0.8.x pins rand 0.8.
-    "RUSTSEC-2026-0097",
-]
-
 [licenses]
 version = 2
 allow = [
@@ -21,7 +12,6 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-3.0",
-    "OpenSSL",
     "Zlib",
     "0BSD",
     "CDLA-Permissive-2.0",


### PR DESCRIPTION
## Summary

Accepted ingest could be acknowledged before durable storage, retries could lose payloads or duplicate derived data, SQLite event sources could be deleted before a WAL checkpoint, recovery scans could hot-loop, quota refreshes could contend with the next digest, and concurrent writers could delete shared data or leave in-memory aggregates changed after a failed flush. This fix makes acceptance, retry, replay, recovery, ownership, and bounded writes explicit.

| Impact | Scenario | Before | After |
|---|---|---|---|
| 🔴 CRITICAL · data loss | Digest recovery after a write, cleanup, or checkpoint failure | pending data could become unrecoverable | 🟢 project event sources remain until processing and SQLite checkpoint complete |
| 🔴 CRITICAL · data loss | Direct transaction, span, log, or session ingest | success returned before durable commit | 🟢 commit completes before acknowledgement; transaction replays are no-ops |
| 🔴 CRITICAL · consistency | Session aggregate flush fails | in-memory state could be lost or partially applied | 🟢 one transaction; failed state is restored |
| 🟠 HIGH · retry durability | Alert delivery retry | payload cleanup or changing identities could lose or duplicate delivery | 🟢 payload persists and identity remains event-stable |
| 🟠 HIGH · replay integrity | Replayed spans and logs | repeated protocol data could create duplicates | 🟢 protocol identities and stable container keys deduplicate replays |
| 🟠 HIGH · shared storage | Sourcemap assembly jobs share chunks | one job could delete another job’s input | 🟢 ownership is tracked; chunks release only when unowned |
| 🟡 MEDIUM · write contention | Standalone span envelope with many items | one transaction per item | 🟢 awaited batches of up to 64 items |
| 🟡 MEDIUM · quota freshness | Post-commit refresh meets the next SQLite writer | refresh can fail after the event commits | 🟢 SQLite serializes refreshes and retries one transient collision |
| 🟡 MEDIUM · recovery load | Pending files remain after a transient failure | scans could retry continuously or wait 30s | 🟢 retry starts at 1s, doubles to 30s, and resets when idle |

- **Durable recovery**: digest records survive quota-refresh failures, SQLite contention, and processor cleanup until recovery succeeds.
- **Acknowledgement ordering**: direct items are committed before the ingest route returns success.
- **Atomic state transitions**: session aggregates either flush together or restore their pre-flush state.
- **Stable retry and replay identity**: alert retries use event-stable identities; standalone spans and logs use protocol- or byte-stable keys.
- **Transaction replay safety**: a duplicate `(project_id, event_id)` stops before child-span extraction.
- **Ownership-aware cleanup**: sourcemap chunks are retained while any assembly job still owns them.
- **Bounded writes**: standalone span items stay inline and awaited, with malformed items remaining individually tolerant.
- **Backend-aware quota refresh**: PostgreSQL refreshes overlap; SQLite serializes its two writes and retries one transient busy collision.
- **Recovery pacing**: pending scans retry in 1s instead of the former fixed 30s, then back off to reduce idle load.

## Durability

SQLite uses WAL with `synchronous=NORMAL`. Project-scoped event sources are deleted only after their digest and alert writes complete and a `wal_checkpoint(FULL)` succeeds; if readers keep the checkpoint busy, the source remains queued for recovery. This closes the application-level cleanup window with bounded cleanup I/O, trading some cleanup latency for safety; `NORMAL` still permits recent uncheckpointed commits to roll back after an OS crash or power loss:

- **Process crash**: committed transactions remain atomic; project event sources survive until processing and the durability checkpoint complete.
- **OS crash or power loss**: recent uncheckpointed commits may roll back, although WAL keeps the database consistent and retained event sources can be replayed.
- **Volume or filesystem loss**: SQLite settings cannot recover the database; use the documented online backup path and verify restores.
- **Hard power-loss durability**: use `synchronous=FULL` (or PostgreSQL) if losing recent committed events is unacceptable, accepting slower commits.

## Release-note follow-up

The related maintainer durability concerns are addressed here: accepted events remain recoverable across post-commit and checkpoint contention, direct items are committed before acknowledgement, transaction retries are idempotent, alert retries retain their payloads and identities, shared sourcemap chunks are not reclaimed prematurely, recovery scans back off, and derived quota refreshes remain backend-safe without widening the accepted-event contract.

Scope: server ingest, digest, alert, session, sourcemap, and standalone-span paths, with matching SQLite and PostgreSQL ownership migrations; no endpoint contract changes.

Validation: SQLite library, black-box unit, and integration tests passed · PostgreSQL `cargo check` passed · formatting and diff checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable recovery and retry processing for pending events and alerts.
  * Added project-scoped event storage and improved ingestion isolation.
  * Added alert payload history and event-specific alert types.
  * Added deterministic deduplication for logs, transactions, and standalone spans.
  * Improved batch span ingestion and session data flushing.
  * Added safer artifact assembly that preserves shared chunks until no longer needed.

* **Bug Fixes**
  * Prevented duplicate records during retries and replayed ingestion.
  * Improved quota handling, malformed data validation, and failure recovery.
  * Preserved recoverable event files after processing failures.
  * Improved alert lookup accuracy across projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->