### PR TITLE
fix: only tell the version to authenticated callers

### DIFF
--- a/apps/server/openapi.json
+++ b/apps/server/openapi.json
@@ -7477,6 +7477,7 @@
           "Health"
         ],
         "summary": "Version check - returns the server version compiled from Cargo.toml.",
+        "description": "Requires a session cookie or a Bearer token, unlike its neighbours in this\nscope. `/health` and `/health/ready` answer \"is this process up\", which a\nprobe has to be able to ask without credentials; this one answers \"which\nbuild is this\", which is the first thing worth knowing about a host you\nintend to attack.",
         "operationId": "version",
         "responses": {
           "200": {
@@ -7488,8 +7489,26 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
-        }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          },
+          {
+            "session_cookie": []
+          }
+        ]
       }
     }
   },

--- a/apps/server/src/routes/health.rs
+++ b/apps/server/src/routes/health.rs
@@ -1,6 +1,7 @@
 use actix_web::{http::StatusCode, web, HttpResponse};
 use serde::Serialize;
 
+use crate::auth::ApiAuth;
 use crate::db::{self, DbPool};
 
 #[cfg(feature = "openapi")]
@@ -51,10 +52,21 @@ pub async fn liveness() -> HttpResponse {
     tag = "Health",
     responses(
         (status = 200, description = "Server version info", body = VersionResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
     ),
+    security(("bearer_auth" = []), ("session_cookie" = [])),
 ))]
 /// Version check - returns the server version compiled from Cargo.toml.
-pub async fn version() -> HttpResponse {
+///
+/// Requires a session cookie or a Bearer token, unlike its neighbours in this
+/// scope. `/health` and `/health/ready` answer "is this process up", which a
+/// probe has to be able to ask without credentials; this one answers "which
+/// build is this", which is the first thing worth knowing about a host you
+/// intend to attack.
+// The gate is the extractor and not the middleware because the whole `/health`
+// prefix is exempt from `RequireAuth` -- see `middleware::auth` -- and the two
+// liveness routes need that exemption to stay.
+pub async fn version(_auth: ApiAuth) -> HttpResponse {
     HttpResponse::Ok().json(VersionResponse {
         version: env!("CARGO_PKG_VERSION"),
     })

--- a/apps/server/tests/integration/health_test.rs
+++ b/apps/server/tests/integration/health_test.rs
@@ -5,6 +5,7 @@
 use crate::common::TestDb;
 use actix_web::{test, web, App};
 use rustrak::routes;
+use rustrak::services::AuthTokenService;
 use serde_json::Value;
 
 // =============================================================================
@@ -212,4 +213,66 @@ async fn test_readiness_post_returns_error() {
     let resp = test::call_service(&app, req).await;
     // Actix-web returns 404 when no route matches the method
     assert!(resp.status().is_client_error());
+}
+
+// =============================================================================
+// Version Endpoint Tests
+// =============================================================================
+
+#[actix_web::test]
+async fn test_version_requires_authentication() {
+    let db = TestDb::new().await;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .service(
+                web::scope("/health").route("/version", web::get().to(routes::health::version)),
+            ),
+    )
+    .await;
+
+    // No session cookie and no Bearer token: an anonymous caller.
+    let req = test::TestRequest::get().uri("/health/version").to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        401,
+        "the running version must not be readable by an anonymous caller"
+    );
+}
+
+#[actix_web::test]
+async fn test_version_returns_version_to_an_authenticated_caller() {
+    let db = TestDb::new().await;
+    let token = AuthTokenService::create(
+        &db.pool,
+        rustrak::models::CreateAuthToken {
+            description: Some("Version test token".to_string()),
+        },
+    )
+    .await
+    .expect("Failed to create test token")
+    .token;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(db.pool.clone()))
+            .service(
+                web::scope("/health").route("/version", web::get().to(routes::health::version)),
+            ),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/health/version")
+        .insert_header(("Authorization", format!("Bearer {}", token)))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
 }

--- a/apps/webview-ui/src/__tests__/architecture/version-behind-auth.test.ts
+++ b/apps/webview-ui/src/__tests__/architecture/version-behind-auth.test.ts
@@ -1,0 +1,88 @@
+import { projectFiles } from 'archunit';
+import { describe, expect, it } from 'vitest';
+import { isTestFile, withoutComments } from './predicates';
+
+/**
+ * The running version is told to signed-in people only.
+ *
+ * A version number is the first thing worth knowing about a host you intend to
+ * attack: it turns "is this instance vulnerable to X" from a probe into a
+ * lookup. The server stopped answering `/health/version` to anonymous callers,
+ * and this rule is the other half of that change -- without it the number goes
+ * straight back onto the login screen the next time someone wants a footer.
+ *
+ * **The boundary is `app/(main)/`, because that is where the gate is.**
+ * `(main)/layout.tsx` redirects an anonymous session to `/auth/login` before it
+ * renders any child, so a page below it has a user by construction. Everything
+ * else in `app/` -- the login, the invitation, `not-found.tsx`, `error.tsx` --
+ * is reachable with no session at all, and so is every component in `shared/`
+ * that those pages render.
+ *
+ * Known limit, stated rather than papered over: `(main)/layout.tsx` also has an
+ * `unavailable` branch that renders `OutageScreen` without a user. A version
+ * printed by a component that only that branch reaches would satisfy this rule
+ * and still be visible to a stranger. `OutageScreen` lives in `shared/`, so it
+ * is caught today; the rule is an approximation of the gate, not a proof of it.
+ *
+ * **Why a content predicate and not `dependOnFiles`.** The leak is a *rendered
+ * string*, and the import is only its most likely shape. Matching the
+ * identifier catches a re-export or a helper that reads `packageJson.version`
+ * under another name being pulled in, which an edge between two named files
+ * would not.
+ */
+
+const APP_VERSION = /\bAPP_VERSION\b/;
+
+const posix = (path: string) => path.split('\\').join('/');
+
+/**
+ * Where the constant is declared. It has to name itself, and a `server only`
+ * module in `shared/config` renders nothing on its own.
+ */
+const isDeclaration = (path: string) =>
+  posix(path).endsWith('src/shared/config/constants.ts');
+
+/** Below the redirect in `(main)/layout.tsx`. */
+const isBehindTheGate = (path: string) => posix(path).includes('/app/(main)/');
+
+describe('the version is only rendered behind the auth gate', () => {
+  /**
+   * The floor. Every assertion below is "no file does X", so if the identifier
+   * is ever renamed the rule would judge an empty set and pass while saying
+   * nothing -- the vacuous-rule failure the suite exists to avoid.
+   */
+  it('reads the population it expects to read', async () => {
+    const users = await projectFiles()
+      .inFolder('src/**')
+      .shouldNot()
+      .adhereTo(
+        (file) =>
+          !isTestFile(file.path) &&
+          !isDeclaration(file.path) &&
+          APP_VERSION.test(withoutComments(file.content)),
+        'counted',
+      )
+      .check();
+
+    // The About page, at minimum.
+    expect(users.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('has no file outside the gate naming APP_VERSION', async () => {
+    const rule = projectFiles()
+      .inFolder('src/**')
+      .shouldNot()
+      .adhereTo(
+        (file) =>
+          !isTestFile(file.path) &&
+          !isDeclaration(file.path) &&
+          !isBehindTheGate(file.path) &&
+          // Comments are blanked first, so the paragraphs above -- which name
+          // the constant while explaining the rule -- do not trip it.
+          APP_VERSION.test(withoutComments(file.content)),
+        'shows the instance version on a surface a signed-out visitor can reach',
+      );
+
+    await expect(rule).toPassAsync();
+  });
+});

--- a/apps/webview-ui/src/app/auth/login/page.tsx
+++ b/apps/webview-ui/src/app/auth/login/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getTranslations } from 'next-intl/server';
-import { APP_VERSION } from '@/shared/config/constants';
 import { RustrakWordmark } from '@/shared/ui/components/rustrak-wordmark';
 import { LoginForm } from './_components/login-form';
 
@@ -62,14 +61,13 @@ export default async function LoginPage() {
           </div>
         </div>
 
-        {/* Footer */}
-        <div className="relative z-20 flex justify-between items-end text-xs text-muted-foreground font-mono">
-          <div>
-            <p className="mt-1">v{APP_VERSION}</p>
-          </div>
-          <div className="flex gap-6">
-            <p>&copy; {new Date().getFullYear()} Rustrak</p>
-          </div>
+        {/* Footer. No version: the instance version is told to signed-in
+            people only, and this page is the one surface every stranger
+            reaches. The server withholds it from anonymous callers for the same
+            reason, so printing it here would give away what the API will not.
+            It lives on `settings/about` instead. */}
+        <div className="relative z-20 flex items-end text-xs text-muted-foreground font-mono">
+          <p>&copy; {new Date().getFullYear()} Rustrak</p>
         </div>
       </div>
 

--- a/apps/webview-ui/src/shared/ui/components/error-screen.tsx
+++ b/apps/webview-ui/src/shared/ui/components/error-screen.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import type { ReactNode } from 'react';
-import { APP_VERSION } from '@/shared/config/constants';
 import { RustrakWordmark } from '@/shared/ui/components/rustrak-wordmark';
 
 /**
@@ -43,7 +42,7 @@ export function ErrorScreen({
   brandDescription?: string;
   /** What the reader can do, when there is anything useful to say. */
   guidance?: string | null;
-  /** Monospace footnote: an error id, a version, anything diagnostic. */
+  /** Monospace footnote: an error id, anything diagnostic. */
   detail?: ReactNode;
   /** Buttons. */
   actions?: ReactNode;
@@ -76,8 +75,11 @@ export function ErrorScreen({
           </p>
         </div>
 
-        <div className="relative z-20 flex justify-between items-end text-xs text-muted-foreground font-mono">
-          <p>v{APP_VERSION}</p>
+        {/* No version here either, and for a sharper reason than on the
+            login: a 404 is the one page an unauthenticated stranger can reach
+            on any path they like, so a number printed here is a number handed
+            to anyone who types a wrong URL. */}
+        <div className="relative z-20 flex items-end text-xs text-muted-foreground font-mono">
           <p>&copy; {new Date().getFullYear()} Rustrak</p>
         </div>
       </div>

--- a/packages/client/src/resources/health.ts
+++ b/packages/client/src/resources/health.ts
@@ -5,6 +5,14 @@ import { serverVersionSchema } from '../schemas/version.js';
 import { BaseResource } from './base.js';
 
 export class HealthResource extends BaseResource {
+  /**
+   * The version the server reports for itself.
+   *
+   * Authenticated: the server answers this one to a session or a Bearer token
+   * only, and returns 401 to anonymous callers. `/health` and `/health/ready`
+   * stay open for probes; a version number is what tells a stranger which
+   * advisories apply to your instance, so it is not probe material.
+   */
   async getVersion(): Promise<Result<ServerVersion, RustrakError>> {
     return this.request(
       () => this.http.get('health/version'),


### PR DESCRIPTION
Closes #274.

@bobbymannino is right that the version is on the login screen, and right that a version number is attacker material. But the UI was the smaller half of it: `GET /health/version` sat behind the `/health` exemption in `RequireAuth` and answered any caller, so `curl https://your-rustrak/health/version` returned the exact number with no credentials. Removing it from the login page alone would have hidden it from the operator while leaving it served on request.

So both halves close together.

## Server

`/health/version` now takes the `ApiAuth` extractor: a session cookie or a Bearer token gets the version, an anonymous caller gets 401. The gate is the extractor rather than the middleware because the whole `/health` prefix is exempt from `RequireAuth`, and the two liveness routes need that exemption to stay:

- `GET /health` and `GET /health/ready` are unchanged and still open. A probe has to be able to ask whether the process is up without credentials, and neither of them reveals a build.
- The OpenAPI spec is regenerated with the 401 and the `security` block.

## Dashboard

`APP_VERSION` is gone from the login page and from `ErrorScreen`, which covers the 404, the global error, the outage screen and the expired invitation in one move. It stays on `settings/about`, behind the auth gate.

## Breaking

External monitoring that polls `/health/version` without credentials now gets a 401. Liveness and readiness are unaffected. Everything in-tree keeps working: the About page and the update banner carry the session cookie, and the MCP `get_server_version` tool carries a Bearer token.

## Tests

Test-first, three cycles:

- `test_version_requires_authentication` — failed with 200 against an expected 401, passes with the extractor.
- `test_version_returns_version_to_an_authenticated_caller` — a guard, not a new-behaviour cycle. It passed the moment the first one went green, and exists to prove the gate did not take the endpoint out entirely.
- `version-behind-auth`, a new architecture rule forbidding `APP_VERSION` outside `app/(main)/` — where the layout's redirect puts the gate. It failed naming exactly `auth/login/page.tsx` and `shared/ui/components/error-screen.tsx`, and is what stops the number returning to a footer later.

The dashboard rule is an archunit rule rather than a render test on purpose: that suite is architecture-only, and a render test would have to reintroduce the whole jsdom harness its config documents as deliberately absent. Its one known limit is written into the file: the `unavailable` branch of `(main)/layout.tsx` renders without a user, so the rule approximates the gate rather than proving it.

`cargo test` (934), the TypeScript suite, clippy, biome and `tsc` are all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * The version health endpoint now requires authentication and returns `401 Unauthorized` for unauthenticated requests.
  * Authenticated access is supported through bearer tokens or session cookies.

* **UI Updates**
  * Removed application version details from the login page and error screen footers.
  * Simplified footer layouts while retaining branding and copyright information.

* **Documentation & Tests**
  * Updated API and client documentation to clarify authentication requirements.
  * Added coverage for authenticated and unauthenticated version endpoint access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->