### PR TITLE
feat(ui): add the data table and the query bar

### DIFF
--- a/doctor.config.json
+++ b/doctor.config.json
@@ -34,7 +34,8 @@
     "files": [
       "**/shared/ui/components/shadcn/**",
       "**/src/components/ui/**",
-      "content/**/_meta.js"
+      "content/**/_meta.js",
+      "**/*.stories.tsx"
     ],
     "overrides": [
       {
@@ -51,15 +52,6 @@
         ],
         "rules": [
           "react-doctor/dangerous-html-sink"
-        ]
-      },
-      {
-        "files": [
-          "**/*.stories.tsx"
-        ],
-        "rules": [
-          "react-doctor/no-children-prop",
-          "react-doctor/heading-has-content"
         ]
       }
     ]

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -100,8 +100,9 @@ right and the new number gets written down, or it is not.
 - import `lucide-react` anywhere except `components/icon/adapters/lucide.tsx`.
 - build classes with template literals. Tailwind extracts statically, so
   `bg-${name}` is a rule that is silently never generated.
-- reach for a table, a filter bar or a chart. Those are the next pass and they
-  need decisions this one has not made.
+- reach for a chart. That is a later pass and it needs decisions this one has
+  not made. The table and the filter bar exist now: `data-table/` and
+  `query-bar/` — extend those rather than starting parallel ones.
 - give the `backgrounds` addon a hex. It writes its value onto the preview body,
   so a literal pins the page to one theme while the components inside it follow
   the other. Hand it `var(--surface-canvas)`.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -205,8 +205,15 @@ with an icon, a shortcut and a menu chevron) and `SplitButton`.
 global search, notifications, account) `Sidebar` (216 px / a 56 px rail, the
 project card, the seven routes, ⌘B).
 
-No tables, no filter bar, no charts. Those are a second pass and they need
-decisions this one does not.
+**Forms** · `Checkbox` `Popover`.
+
+**Data** · the table family — `useDataTable` (TanStack Table v9, fully manual)
+with `DataTable`, `DataTablePagination`, `DataTableColumnsButton`, the
+column-header sort/filter panels behind them — and `QueryBar`, the token
+search with two-phase autocomplete. `data-table/query.ts` holds the shared
+query model and the URL codecs.
+
+No charts. Those are a later pass and need decisions this one does not.
 
 ### Named decisions
 
@@ -233,6 +240,34 @@ decisions this one does not.
   Nothing was written to prevent the empty state; the right primitive does not
   have it. Its chip slides from the old option to the new one for the same
   reason the tab rule does: the travel is what says only the choice moved.
+- **The table is fully manual.** `useDataTable` registers no client row
+  models: the server filters, sorts and paginates, and the table renders what
+  it was handed. State goes out as pure updaters on a `DataTableQuery`, and
+  the package never touches a router — `parseTableQuery` and
+  `serializeTableQuery` are the codecs; the app owns the URL. Any change of
+  filters, search or sort rewinds `pageIndex` to 0 in the same update,
+  because manual pagination switches TanStack's own auto-reset off.
+- **A column header opens a panel; it does not sort on click.** The GitHub
+  pattern: sorting, the type-appropriate filter (options, text, range — from
+  `meta.filter`) and hiding share one panel, with the sort worded in the
+  column's own terms ("Most events first"). The resting header shows state
+  only: a lime arrow when sorted, a lime funnel when filtered.
+- **The query bar and the column panels edit the same `ColumnFiltersState`.**
+  A tick in the Level panel is a `level:` chip in the bar; deleting the chip
+  puts the funnel out. The bar's text form is exactly what
+  `parseFilterQuery` reads, so the URL's `q`, the bar's content and the
+  table's filters are one value in three places.
+- **Row actions rest in a fixed ⋯ column; bulk actions take over the
+  header.** Hover-revealed actions went: what only exists under the pointer
+  cannot be discovered by reading and does not exist on touch. Every row ends
+  in the same ⋯ menu (`rowMenu`, as `MenuAction[]`), and once rows are
+  selected the 38 px header strip swaps -- with `swapAnimation`, both
+  directions -- into count, `bulkActions` and Clear, so nothing pushes the
+  table down mid-gesture.
+- **Selection and column visibility never reach the URL.** A selection is a
+  gesture and visibility is a reading preference; restoring either from a
+  pasted link would fabricate a choice the reader never made. They live
+  inside `useDataTable`.
 
 ## Consuming it from an application
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@base-ui/react": "1.7.0",
+    "@tanstack/react-table": "9.1.2",
     "clsx": "2.1.1",
     "lucide-react": "1.33.0",
     "tailwind-merge": "3.6.0",

--- a/packages/ui/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/ui/src/components/checkbox/checkbox.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+import { Text } from '../text/text';
+import { Checkbox } from './checkbox';
+
+const meta = {
+  title: 'Components/Checkbox',
+  component: Checkbox,
+  args: { 'aria-label': 'Select row' },
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Every state side by side, which is what reveals a drifted border or fill. */
+export const States: Story = {
+  parameters: { controls: { disable: true }, layout: 'padded' },
+  render: () => (
+    <div className="flex items-center gap-6">
+      {(
+        [
+          ['empty', {}],
+          ['checked', { defaultChecked: true }],
+          ['mixed', { indeterminate: true }],
+          ['disabled', { disabled: true }],
+          ['disabled checked', { disabled: true, defaultChecked: true }],
+        ] as const
+      ).map(([label, props]) => (
+        <div key={label} className="flex items-center gap-2">
+          <Checkbox aria-label={label} {...props} />
+          <Text variant="meta">{label}</Text>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * The select-all header state: indeterminate reports a split page. Ticking a
+ * mixed header selects everything, which is the convention every file manager
+ * and mail client has taught.
+ */
+export const SelectAll: Story = {
+  parameters: { controls: { disable: true }, layout: 'padded' },
+  render: function SelectAllStory() {
+    const [selected, setSelected] = useState([true, false, true]);
+    const all = selected.every(Boolean);
+    const some = selected.some(Boolean);
+
+    return (
+      /* Rows, not `<label>`s: a wrapping label hands its text to the hidden
+         input and the `aria-label` stops being the accessible name. In the
+         product the row's click target is the row, never a label. */
+      <div className="flex w-56 flex-col gap-2">
+        <div className="flex items-center gap-2 border-border-divider border-b pb-2">
+          <Checkbox
+            aria-label="Select all rows"
+            checked={all}
+            indeterminate={some && !all}
+            onCheckedChange={(checked) =>
+              setSelected(selected.map(() => checked))
+            }
+          />
+          <Text variant="meta">Select all</Text>
+        </div>
+        {selected.map((checked, index) => (
+          <div
+            // Fixture rows have no identity beyond their position.
+            key={index}
+            className="flex items-center gap-2"
+          >
+            <Checkbox
+              aria-label={`Select row ${index + 1}`}
+              checked={checked}
+              onCheckedChange={(next) =>
+                setSelected(selected.map((v, i) => (i === index ? next : v)))
+              }
+            />
+            <Text variant="meta">Row {index + 1}</Text>
+          </div>
+        ))}
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const header = canvas.getByRole('checkbox', { name: 'Select all rows' });
+
+    // A split page reports itself as mixed.
+    await expect(header).toHaveAttribute('aria-checked', 'mixed');
+
+    // Ticking a mixed header selects everything.
+    await userEvent.click(header);
+    await expect(header).toHaveAttribute('aria-checked', 'true');
+    for (const row of canvas.getAllByRole('checkbox', { name: /Select row/ })) {
+      await expect(row).toHaveAttribute('aria-checked', 'true');
+    }
+  },
+};
+
+/** Space toggles it from the keyboard, and the ring says where focus is. */
+export const Keyboard: Story = {
+  args: { 'aria-label': 'Select row' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const box = canvas.getByRole('checkbox', { name: 'Select row' });
+
+    await userEvent.tab();
+    await expect(box).toHaveFocus();
+
+    await userEvent.keyboard(' ');
+    await expect(box).toHaveAttribute('aria-checked', 'true');
+
+    await userEvent.keyboard(' ');
+    await expect(box).toHaveAttribute('aria-checked', 'false');
+  },
+};

--- a/packages/ui/src/components/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/checkbox/checkbox.tsx
@@ -1,0 +1,73 @@
+import { Checkbox as BaseCheckbox } from '@base-ui/react/checkbox';
+import { focusRing } from '../../lib/focus';
+import { interactiveTransition } from '../../lib/motion';
+import { tv } from '../../lib/tv';
+import { RemoveIcon, ResolveIcon } from '../icon/icon-catalog';
+
+/**
+ * A checkbox, in the one size the product uses: 14 px, sized to sit in a 48 px
+ * table row without becoming the row's subject.
+ *
+ * The palette named its colours before this component existed: `border-control`
+ * is documented in `tokens.css` as "an empty checkbox", and the ticked state is
+ * `surface-brand` with `fg-on-brand` -- the same lime-on-ink pair as the
+ * primary button, because ticking a row is the same kind of statement as
+ * pressing one.
+ *
+ * Indeterminate is drawn as a minus and only ever appears on a select-all
+ * header: it is not a third state a user can ask for, it is the header
+ * reporting that the page below it is split.
+ */
+const checkbox = tv({
+  slots: {
+    root: [
+      'flex size-3.5 shrink-0 items-center justify-center',
+      'rounded-xs border border-border-control bg-transparent',
+      'hover:border-border-strong',
+      'data-checked:border-surface-brand data-checked:bg-surface-brand',
+      'data-indeterminate:border-surface-brand data-indeterminate:bg-surface-brand',
+      'data-disabled:border-border-subtle data-disabled:bg-surface-disabled',
+      interactiveTransition,
+      focusRing,
+    ],
+    /*
+     * The mark pops in from 50 % rather than fading: at 10 px a fade reads as
+     * the ink arriving late, while the scale reads as the tick being made. On
+     * the way out Base UI unmounts it immediately, which is right -- an untick
+     * is a retraction, and a retraction that lingers looks contested.
+     */
+    indicator: [
+      'flex text-fg-on-brand',
+      'transition-[opacity,scale] duration-instant ease-entrance',
+      'data-starting-style:scale-50 data-starting-style:opacity-0',
+    ],
+  },
+});
+
+const styles = checkbox();
+
+export interface CheckboxProps
+  extends Omit<BaseCheckbox.Root.Props, 'className'> {
+  /**
+   * What ticking it means. Required: the box never carries visible text, so
+   * without this a screen reader announces "checkbox" and nothing else.
+   */
+  'aria-label': string;
+  className?: string;
+}
+
+export function Checkbox({ className, ...props }: CheckboxProps) {
+  return (
+    <BaseCheckbox.Root className={styles.root({ className })} {...props}>
+      <BaseCheckbox.Indicator className={styles.indicator()}>
+        {props.indeterminate ? (
+          <RemoveIcon size="sm" aria-hidden="true" />
+        ) : (
+          <ResolveIcon size="sm" aria-hidden="true" />
+        )}
+      </BaseCheckbox.Indicator>
+    </BaseCheckbox.Root>
+  );
+}
+
+Checkbox.displayName = 'Checkbox';

--- a/packages/ui/src/components/data-table/column-header.tsx
+++ b/packages/ui/src/components/data-table/column-header.tsx
@@ -1,5 +1,6 @@
 import type { Header, RowData } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
+import { useState } from 'react';
 import { focusRingInset } from '../../lib/focus';
 import { chevronFlip, interactiveTransition } from '../../lib/motion';
 import { tv } from '../../lib/tv';
@@ -100,6 +101,7 @@ export function DataTableColumnHeader<TData extends RowData>({
   const canSort = column.getCanSort();
   const canHide = column.getCanHide();
   const filterSpec = meta?.filter;
+  const [open, setOpen] = useState(false);
 
   const title = flexRender(column.columnDef.header, header.getContext());
   const sorted = column.getIsSorted();
@@ -123,6 +125,8 @@ export function DataTableColumnHeader<TData extends RowData>({
       title={typeof title === 'string' ? title : (meta?.label ?? '')}
       align={meta?.align === 'end' ? 'end' : 'start'}
       popupClassName="w-60"
+      open={open}
+      onOpenChange={setOpen}
       trigger={
         <button
           type="button"
@@ -164,6 +168,7 @@ export function DataTableColumnHeader<TData extends RowData>({
                 // question, and asking the same question twice withdraws it.
                 if (sorted === direction) column.clearSorting();
                 else column.toggleSorting(direction === 'desc');
+                setOpen(false);
               }}
             >
               <span aria-hidden="true" className="w-3 shrink-0 text-fg-ghost">

--- a/packages/ui/src/components/data-table/column-header.tsx
+++ b/packages/ui/src/components/data-table/column-header.tsx
@@ -1,0 +1,241 @@
+import type { Header, RowData } from '@tanstack/react-table';
+import { flexRender } from '@tanstack/react-table';
+import { focusRingInset } from '../../lib/focus';
+import { chevronFlip, interactiveTransition } from '../../lib/motion';
+import { tv } from '../../lib/tv';
+import {
+  ChevronDownIcon,
+  CloseIcon,
+  FilterIcon,
+  ResolveIcon,
+} from '../icon/icon-catalog';
+import { Popover } from '../popover/popover';
+import type { DataTableFeatures } from './features';
+import {
+  OptionsFilterPanel,
+  RangeFilterPanel,
+  TextFilterPanel,
+} from './filter-panel';
+
+/**
+ * A column header that is also the column's control -- the GitHub pattern.
+ *
+ * Clicking the header does not sort. That convention silently discards work:
+ * with a filter panel behind the same click, "sort by this" and "ask about
+ * this" cannot share a gesture, and of the two, sorting is the one cheap
+ * enough to deserve no panel... but also cheap enough to cost nothing inside
+ * one. So the click opens the panel, and the panel's first two rows are the
+ * two sorts, worded in the column's own terms. One gesture, everything the
+ * column can do, and the panel closes on the choice.
+ *
+ * What the resting header shows is state, not controls: the lime arrow when
+ * it sorts, the lime funnel when it filters. The chevron only surfaces on
+ * hover, because fifty resting chevrons would turn the header row into a
+ * ribbed texture.
+ */
+const columnHeader = tv({
+  slots: {
+    trigger: [
+      'group/header flex h-full w-full min-w-0 items-center gap-1.5',
+      'font-mono text-column text-fg-meta uppercase',
+      'select-none',
+      interactiveTransition,
+      'hover:text-fg-subtle',
+      'data-popup-open:text-fg-subtle',
+      focusRingInset,
+      'data-[active=true]:text-fg',
+      // End-aligned columns keep their reading order -- label, then state --
+      // and simply sit against the figures' edge.
+      'data-[align=end]:justify-end',
+    ],
+    label: 'truncate',
+    /* State indicators keep the brand colour: they report the query, and the
+       query is what the page is about. */
+    arrow: 'shrink-0 font-medium text-fg-brand normal-case tracking-normal',
+    funnel: 'shrink-0 text-fg-brand',
+    chevron: [
+      'shrink-0 text-fg-ghost',
+      // Surfaces on hover, stays while the panel is open, and flips with it.
+      'opacity-0 transition-[opacity,rotate] duration-instant ease-standard',
+      'group-hover/header:opacity-100 group-focus-visible/header:opacity-100',
+      'group-data-popup-open/header:opacity-100',
+      chevronFlip,
+    ],
+    section: 'flex flex-col p-1.25',
+    item: [
+      'flex h-menu-item shrink-0 cursor-default items-center gap-2.5',
+      'rounded-sm px-2.5 text-control text-fg-muted outline-none select-none',
+      'transition-none',
+      'hover:bg-surface-selected hover:text-fg',
+      'focus-visible:bg-surface-selected focus-visible:text-fg',
+      'aria-pressed:text-fg',
+    ],
+    check: 'ms-auto shrink-0 text-fg-brand',
+    separator: 'h-px shrink-0 bg-border',
+  },
+});
+
+const styles = columnHeader();
+
+/** The wording a sort offers when the column has not chosen its own. */
+function sortWording(header: SortableHeader): { asc: string; desc: string } {
+  const meta = header.column.columnDef.meta;
+  if (meta?.sortLabels) return meta.sortLabels;
+  if (meta?.numeric) return { asc: 'Lowest first', desc: 'Highest first' };
+  return { asc: 'A to Z', desc: 'Z to A' };
+}
+
+// The one alias this file needs; the generics never vary inside it.
+type SortableHeader = Header<DataTableFeatures, any, any>;
+
+export interface DataTableColumnHeaderProps<TData extends RowData> {
+  header: Header<DataTableFeatures, TData, unknown>;
+}
+
+export function DataTableColumnHeader<TData extends RowData>({
+  header,
+}: DataTableColumnHeaderProps<TData>) {
+  const { column } = header;
+  const meta = column.columnDef.meta;
+  const canSort = column.getCanSort();
+  const canHide = column.getCanHide();
+  const filterSpec = meta?.filter;
+
+  const title = flexRender(column.columnDef.header, header.getContext());
+  const sorted = column.getIsSorted();
+  const filtered = column.getIsFiltered();
+
+  if (!canSort && !filterSpec && !canHide) {
+    return (
+      <span
+        data-align={meta?.align}
+        className={styles.trigger({ className: 'cursor-default' })}
+      >
+        <span className={styles.label()}>{title}</span>
+      </span>
+    );
+  }
+
+  const wording = sortWording(header);
+
+  return (
+    <Popover
+      title={typeof title === 'string' ? title : (meta?.label ?? '')}
+      align={meta?.align === 'end' ? 'end' : 'start'}
+      popupClassName="w-60"
+      trigger={
+        <button
+          type="button"
+          data-active={sorted !== false || filtered}
+          data-align={meta?.align}
+          className={styles.trigger()}
+        >
+          <span className={styles.label()}>{title}</span>
+          {sorted ? (
+            <span aria-hidden="true" className={styles.arrow()}>
+              {sorted === 'desc' ? '↓' : '↑'}
+            </span>
+          ) : null}
+          {filtered ? (
+            <FilterIcon
+              size="sm"
+              aria-hidden="true"
+              className={styles.funnel()}
+            />
+          ) : null}
+          <ChevronDownIcon
+            size="sm"
+            aria-hidden="true"
+            className={styles.chevron()}
+          />
+        </button>
+      }
+    >
+      {canSort ? (
+        <div className={styles.section()}>
+          {(['asc', 'desc'] as const).map((direction) => (
+            <button
+              key={direction}
+              type="button"
+              aria-pressed={sorted === direction}
+              className={styles.item()}
+              onClick={() => {
+                // Choosing the standing sort again clears it: the header is a
+                // question, and asking the same question twice withdraws it.
+                if (sorted === direction) column.clearSorting();
+                else column.toggleSorting(direction === 'desc');
+              }}
+            >
+              <span aria-hidden="true" className="w-3 shrink-0 text-fg-ghost">
+                {direction === 'desc' ? '↓' : '↑'}
+              </span>
+              <span className="min-w-0 flex-1 truncate text-start">
+                {wording[direction]}
+              </span>
+              {sorted === direction ? (
+                <ResolveIcon
+                  size="sm"
+                  aria-hidden="true"
+                  className={styles.check()}
+                />
+              ) : null}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {canSort && filterSpec ? (
+        <div aria-hidden="true" className={styles.separator()} />
+      ) : null}
+
+      {filterSpec?.variant === 'options' ? (
+        <OptionsFilterPanel column={column} />
+      ) : null}
+      {filterSpec?.variant === 'text' ? (
+        <TextFilterPanel column={column} />
+      ) : null}
+      {filterSpec?.variant === 'range' ? (
+        <RangeFilterPanel column={column} />
+      ) : null}
+
+      {(filtered || canHide) && (canSort || filterSpec) ? (
+        <div aria-hidden="true" className={styles.separator()} />
+      ) : null}
+
+      {filtered || canHide ? (
+        <div className={styles.section()}>
+          {filtered ? (
+            <button
+              type="button"
+              className={styles.item()}
+              onClick={() => column.setFilterValue(undefined)}
+            >
+              <CloseIcon
+                size="sm"
+                aria-hidden="true"
+                className="shrink-0 text-fg-ghost"
+              />
+              <span className="min-w-0 flex-1 truncate text-start">
+                Clear filter
+              </span>
+            </button>
+          ) : null}
+          {canHide ? (
+            <button
+              type="button"
+              className={styles.item()}
+              onClick={() => column.toggleVisibility(false)}
+            >
+              <span className="w-3 shrink-0" aria-hidden="true" />
+              <span className="min-w-0 flex-1 truncate text-start">
+                Hide column
+              </span>
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </Popover>
+  );
+}
+
+DataTableColumnHeader.displayName = 'DataTableColumnHeader';

--- a/packages/ui/src/components/data-table/columns-menu.tsx
+++ b/packages/ui/src/components/data-table/columns-menu.tsx
@@ -3,6 +3,7 @@ import { tv } from '../../lib/tv';
 import { Button } from '../button/button';
 import { ColumnsIcon, ResolveIcon } from '../icon/icon-catalog';
 import { Popover } from '../popover/popover';
+import { columnLabel } from './features';
 import type { DataTableInstance } from './use-data-table';
 
 /**
@@ -29,15 +30,6 @@ const columnsMenu = tv({
 });
 
 const styles = columnsMenu();
-
-/** What menus call a column: its meta label, or its header when it is text. */
-export function columnLabel<TData extends RowData>(
-  column: ReturnType<DataTableInstance<TData>['getAllLeafColumns']>[number],
-): string {
-  const { meta, header } = column.columnDef;
-  if (meta?.label) return meta.label;
-  return typeof header === 'string' ? header : column.id;
-}
 
 export interface DataTableColumnsButtonProps<TData extends RowData> {
   table: DataTableInstance<TData>;

--- a/packages/ui/src/components/data-table/columns-menu.tsx
+++ b/packages/ui/src/components/data-table/columns-menu.tsx
@@ -1,0 +1,91 @@
+import type { RowData } from '@tanstack/react-table';
+import { tv } from '../../lib/tv';
+import { Button } from '../button/button';
+import { ColumnsIcon, ResolveIcon } from '../icon/icon-catalog';
+import { Popover } from '../popover/popover';
+import type { DataTableInstance } from './use-data-table';
+
+/**
+ * The way back for a hidden column.
+ *
+ * Hiding happens in the column's own header menu, but a hidden column has no
+ * header left to bring it back with -- so the toolbar carries this one
+ * button naming every column there is. It is the inverse that makes hiding
+ * safe to offer at all.
+ */
+const columnsMenu = tv({
+  slots: {
+    section: 'flex flex-col p-1.25',
+    item: [
+      'flex h-menu-item shrink-0 cursor-default items-center gap-2.5',
+      'rounded-sm px-2.5 text-control text-fg-muted outline-none select-none',
+      'transition-none',
+      'hover:bg-surface-selected hover:text-fg',
+      'focus-visible:bg-surface-selected focus-visible:text-fg',
+      'aria-pressed:text-fg',
+    ],
+    check: 'ms-auto shrink-0 text-fg-brand',
+  },
+});
+
+const styles = columnsMenu();
+
+/** What menus call a column: its meta label, or its header when it is text. */
+export function columnLabel<TData extends RowData>(
+  column: ReturnType<DataTableInstance<TData>['getAllLeafColumns']>[number],
+): string {
+  const { meta, header } = column.columnDef;
+  if (meta?.label) return meta.label;
+  return typeof header === 'string' ? header : column.id;
+}
+
+export interface DataTableColumnsButtonProps<TData extends RowData> {
+  table: DataTableInstance<TData>;
+}
+
+export function DataTableColumnsButton<TData extends RowData>({
+  table,
+}: DataTableColumnsButtonProps<TData>) {
+  const columns = table
+    .getAllLeafColumns()
+    .filter((column) => column.getCanHide());
+
+  return (
+    <Popover
+      title="Columns"
+      align="end"
+      trigger={
+        <Button
+          variant="secondary"
+          icon={ColumnsIcon}
+          aria-label="Choose columns"
+        />
+      }
+    >
+      <div className={styles.section()}>
+        {columns.map((column) => (
+          <button
+            key={column.id}
+            type="button"
+            aria-pressed={column.getIsVisible()}
+            className={styles.item()}
+            onClick={() => column.toggleVisibility()}
+          >
+            <span className="min-w-0 flex-1 truncate text-start">
+              {columnLabel(column)}
+            </span>
+            {column.getIsVisible() ? (
+              <ResolveIcon
+                size="sm"
+                aria-hidden="true"
+                className={styles.check()}
+              />
+            ) : null}
+          </button>
+        ))}
+      </div>
+    </Popover>
+  );
+}
+
+DataTableColumnsButton.displayName = 'DataTableColumnsButton';

--- a/packages/ui/src/components/data-table/data-table.stories.tsx
+++ b/packages/ui/src/components/data-table/data-table.stories.tsx
@@ -1,0 +1,572 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useMemo, useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { Button } from '../button/button';
+import {
+  AssignIcon,
+  DeleteIcon,
+  MuteIcon,
+  ResolveIcon,
+} from '../icon/icon-catalog';
+import { QueryBar, queryFieldsFromColumns } from '../query-bar/query-bar';
+import { Tag, type TagTone } from '../tag/tag';
+import { Text } from '../text/text';
+import { TooltipProvider } from '../tooltip/tooltip';
+import { DataTableColumnsButton } from './columns-menu';
+import { DataTable } from './data-table';
+import { createDataTableColumnHelper, type FilterOption } from './features';
+import { type DataTableQuery, emptyTableQuery } from './query';
+import { useDataTable } from './use-data-table';
+
+/**
+ * The stories drive the table exactly the way the dashboard will: the
+ * component is fully manual, so a tiny in-memory "server" below filters,
+ * sorts and slices the fixture from the same `DataTableQuery` the real
+ * server will receive. If a story works, the wiring contract works.
+ */
+
+interface Issue {
+  id: string;
+  level: 'fatal' | 'error' | 'warning' | 'info';
+  title: string;
+  culprit: string;
+  events: number;
+  users: number;
+  /** Minutes since last seen; the fixture has no clock. */
+  seenMinutesAgo: number;
+}
+
+const LEVEL_TONE: Record<Issue['level'], TagTone> = {
+  fatal: 'error',
+  error: 'error',
+  warning: 'warning',
+  info: 'info',
+};
+
+const LEVEL_OPTIONS: FilterOption[] = [
+  { value: 'fatal', label: 'Fatal', tone: 'error', count: 5 },
+  { value: 'error', label: 'Error', tone: 'error', count: 97 },
+  { value: 'warning', label: 'Warning', tone: 'warning', count: 31 },
+  { value: 'info', label: 'Info', tone: 'info', count: 10 },
+];
+
+const TITLES: Array<[Issue['level'], string, string]> = [
+  [
+    'fatal',
+    'ConnectionTimeout: pool exhausted after 30000ms',
+    'db.pool in acquire',
+  ],
+  [
+    'error',
+    "TypeError: Cannot read properties of undefined (reading 'total')",
+    'CheckoutSummary in render',
+  ],
+  [
+    'error',
+    'PaymentDeclined: issuer rejected authorization',
+    'payments.charge in capture',
+  ],
+  [
+    'error',
+    'FetchError: ECONNREFUSED 10.0.3.12:6379',
+    'cache.redis in connect',
+  ],
+  [
+    'warning',
+    'ValidationError: coupon code not applicable',
+    'cart.applyCoupon',
+  ],
+  ['error', 'UnhandledRejection: socket hang up', 'webhooks.dispatch'],
+  ['info', 'DeprecationWarning: legacy shipping API called', 'shipping.quote'],
+  ['error', 'NotFoundError: order 88213 missing on refund', 'orders.refund'],
+  ['warning', 'SlowQuery: SELECT … 2400ms', 'db.query in report'],
+  ['error', 'JSONDecodeError: unexpected token < at 1:1', 'api.parseBody'],
+];
+
+/** Deterministic fixture: the same 60 rows on every run, no clock, no RNG. */
+const ISSUES: Issue[] = Array.from({ length: 60 }, (_, index) => {
+  const [level, title, culprit] = TITLES[index % TITLES.length] as [
+    Issue['level'],
+    string,
+    string,
+  ];
+  return {
+    id: `RUSTRAK-${1000 + index}`,
+    level,
+    title,
+    culprit: `${culprit} · RUSTRAK-${1000 + index}`,
+    events: ((index * 397) % 4200) + 12,
+    users: ((index * 131) % 900) + 3,
+    seenMinutesAgo: ((index * 47) % 720) + 1,
+  };
+});
+
+/** What the Rust server will do, done to the fixture: the story's backend. */
+function fakeServer(query: DataTableQuery): { rows: Issue[]; total: number } {
+  let rows = ISSUES.filter((issue) => {
+    for (const filter of query.filters) {
+      if (filter.id === 'level') {
+        if (!(filter.value as string[]).includes(issue.level)) return false;
+      }
+      if (filter.id === 'events') {
+        const [min, max] = filter.value as [number | null, number | null];
+        if (min !== null && issue.events < min) return false;
+        if (max !== null && issue.events > max) return false;
+      }
+      if (filter.id === 'culprit') {
+        const needle = (filter.value as string).toLowerCase();
+        if (!issue.culprit.toLowerCase().includes(needle)) return false;
+      }
+      if (filter.id === 'title') {
+        const needle = (filter.value as string).toLowerCase();
+        if (!issue.title.toLowerCase().includes(needle)) return false;
+      }
+      if (filter.id === 'users') {
+        const [min, max] = filter.value as [number | null, number | null];
+        if (min !== null && issue.users < min) return false;
+        if (max !== null && issue.users > max) return false;
+      }
+      if (filter.id === 'seen') {
+        const cutoff = Number((filter.value as string[])[0]);
+        if (issue.seenMinutesAgo > cutoff) return false;
+      }
+    }
+    if (query.search) {
+      const needle = query.search.toLowerCase();
+      if (!`${issue.title} ${issue.culprit}`.toLowerCase().includes(needle)) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  const SEVERITY = { info: 0, warning: 1, error: 2, fatal: 3 } as const;
+  const sort = query.sorting[0];
+  if (sort) {
+    // Column ids are the URL's names; two of them are not field names.
+    const key = (
+      sort.id === 'seen' ? 'seenMinutesAgo' : sort.id
+    ) as keyof Issue;
+    rows = [...rows].sort((a, b) => {
+      const left = key === 'level' ? SEVERITY[a.level] : a[key];
+      const right = key === 'level' ? SEVERITY[b.level] : b[key];
+      const order =
+        typeof left === 'number' && typeof right === 'number'
+          ? left - right
+          : String(left).localeCompare(String(right));
+      return sort.desc ? -order : order;
+    });
+  }
+
+  const { pageIndex, pageSize } = query.pagination;
+  return {
+    rows: rows.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
+    total: rows.length,
+  };
+}
+
+function formatSeen(minutes: number): string {
+  if (minutes < 60) return `${minutes} min`;
+  if (minutes < 24 * 60) return `${Math.floor(minutes / 60)} h`;
+  return `${Math.floor(minutes / (24 * 60))} d`;
+}
+
+const columnHelper = createDataTableColumnHelper<Issue>();
+
+const columns = columnHelper.columns([
+  columnHelper.accessor('level', {
+    id: 'level',
+    header: 'Level',
+    cell: ({ getValue }) => (
+      <Tag tone={LEVEL_TONE[getValue()]}>{getValue()}</Tag>
+    ),
+    meta: {
+      label: 'Level',
+      width: 88,
+      sortLabels: { asc: 'Least severe first', desc: 'Most severe first' },
+      filter: { variant: 'options', options: LEVEL_OPTIONS },
+    },
+  }),
+  columnHelper.accessor('title', {
+    id: 'title',
+    header: 'Issue',
+    enableHiding: false,
+    cell: ({ row }) => (
+      <span className="flex min-w-0 flex-col gap-0.5 py-2">
+        <Text variant="value" truncate>
+          {row.original.title}
+        </Text>
+        <Text variant="mono-sm" tone="ghost" truncate>
+          {row.original.culprit}
+        </Text>
+      </span>
+    ),
+    meta: {
+      label: 'Issue',
+      sortLabels: { asc: 'A to Z', desc: 'Z to A' },
+      filter: { variant: 'text', placeholder: 'Title contains…' },
+    },
+  }),
+  columnHelper.accessor('culprit', {
+    id: 'culprit',
+    header: 'Culprit',
+    cell: ({ getValue }) => (
+      <Text variant="mono-sm" tone="subtle" truncate>
+        {getValue()}
+      </Text>
+    ),
+    meta: {
+      label: 'Culprit',
+      width: 180,
+      filter: { variant: 'text', placeholder: 'Contains…' },
+    },
+  }),
+  columnHelper.accessor('events', {
+    id: 'events',
+    header: 'Events',
+    cell: ({ getValue }) => getValue().toLocaleString('en-US'),
+    meta: {
+      label: 'Events',
+      width: 96,
+      align: 'end',
+      numeric: true,
+      sortLabels: { asc: 'Fewest events', desc: 'Most events' },
+      filter: { variant: 'range', min: 0, unit: 'events' },
+    },
+  }),
+  columnHelper.accessor('users', {
+    id: 'users',
+    header: 'Users',
+    cell: ({ getValue }) => getValue().toLocaleString('en-US'),
+    meta: {
+      label: 'Users',
+      width: 88,
+      align: 'end',
+      numeric: true,
+      sortLabels: { asc: 'Fewest users', desc: 'Most users' },
+      filter: { variant: 'range', min: 0, unit: 'users' },
+    },
+  }),
+  columnHelper.accessor('seenMinutesAgo', {
+    id: 'seen',
+    header: 'Last seen',
+    cell: ({ getValue }) => formatSeen(getValue()),
+    meta: {
+      label: 'Last seen',
+      width: 100,
+      align: 'end',
+      sortLabels: { asc: 'Oldest first', desc: 'Newest first' },
+      // A date narrows to a window, and exactly one window holds at a time.
+      filter: {
+        variant: 'options',
+        multiple: false,
+        options: [
+          { value: '60', label: 'Last hour' },
+          { value: '1440', label: 'Last 24 h' },
+          { value: '10080', label: 'Last 7 d' },
+        ],
+      },
+    },
+  }),
+]);
+
+const fields = queryFieldsFromColumns(columns);
+
+function IssuesTable({
+  loading = false,
+  data = undefined as Issue[] | undefined,
+}) {
+  const [query, setQuery] = useState<DataTableQuery>(() => ({
+    ...emptyTableQuery(10),
+    sorting: [{ id: 'events', desc: true }],
+  }));
+
+  const page = useMemo(
+    () => (data ? { rows: data, total: data.length } : fakeServer(query)),
+    [data, query],
+  );
+
+  const table = useDataTable({
+    data: page.rows,
+    columns,
+    rowCount: page.total,
+    query,
+    onQueryChange: (updater) => setQuery((previous) => updater(previous)),
+    getRowId: (issue) => issue.id,
+    enableSelection: true,
+    rowMenu: (row) => [
+      {
+        id: 'resolve',
+        label: 'Resolve',
+        icon: ResolveIcon,
+        shortcut: 'R',
+        onSelect: () => console.info('resolve', row.id),
+      },
+      {
+        id: 'mute',
+        label: 'Mute',
+        icon: MuteIcon,
+        onSelect: () => console.info('mute', row.id),
+      },
+      {
+        id: 'assign',
+        label: 'Assign',
+        icon: AssignIcon,
+        onSelect: () => console.info('assign', row.id),
+      },
+      {
+        id: 'delete',
+        label: 'Delete',
+        icon: DeleteIcon,
+        tone: 'danger',
+        separated: true,
+        onSelect: () => console.info('delete', row.id),
+      },
+    ],
+  });
+
+  return (
+    <TooltipProvider>
+      <div className="flex h-140 flex-col gap-3">
+        {/* The toolbar of the issues screen: the bar and the table edit the
+            same filters, so a tick in a column panel appears here as a chip
+            and a removed chip puts the column's funnel out. */}
+        <div className="flex items-center gap-2">
+          <QueryBar
+            fields={fields}
+            filters={query.filters}
+            search={query.search}
+            onChange={(next) =>
+              setQuery((previous) => ({
+                ...previous,
+                filters: next.filters,
+                search: next.search,
+                pagination: { ...previous.pagination, pageIndex: 0 },
+              }))
+            }
+          />
+          <DataTableColumnsButton table={table} />
+        </div>
+        <DataTable
+          table={table}
+          loading={loading}
+          onRowClick={(row) => console.info('open', row.id)}
+          bulkActions={
+            <>
+              <Button
+                size="xs"
+                variant="primary"
+                icon={ResolveIcon}
+                onClick={() => console.info('resolve selection')}
+              >
+                Resolve
+              </Button>
+              <Button
+                size="xs"
+                variant="secondary"
+                icon={MuteIcon}
+                onClick={() => console.info('mute selection')}
+              >
+                Mute
+              </Button>
+            </>
+          }
+        />
+      </div>
+    </TooltipProvider>
+  );
+}
+
+const meta = {
+  title: 'Components/DataTable',
+  component: DataTable,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof DataTable>;
+
+export default meta;
+type Story = StoryObj;
+
+/**
+ * The whole pattern at once: selection, per-type header filters, external
+ * sort, hover actions and pagination, against a simulated server.
+ */
+export const Issues: Story = {
+  render: () => <IssuesTable />,
+};
+
+/**
+ * The header is the column's control. Opening "Level" offers its values;
+ * ticking one narrows the table immediately and rewinds to the first page.
+ */
+export const FilterFromHeader: Story = {
+  render: () => <IssuesTable />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+
+    await userEvent.click(canvas.getByRole('button', { name: /Level/ }));
+    const panel = await body.findByRole('dialog');
+
+    await userEvent.click(
+      within(panel).getByRole('button', { name: /Warning/ }),
+    );
+    await waitFor(() =>
+      expect(canvas.queryByText(/PaymentDeclined/)).not.toBeInTheDocument(),
+    );
+    await expect(
+      canvas.getAllByText(/ValidationError|SlowQuery/).length,
+    ).toBeGreaterThan(0);
+
+    // The header now reports the filter without being open.
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(body.queryByRole('dialog')).not.toBeInTheDocument(),
+    );
+  },
+};
+
+/** Sorting is chosen in the panel, worded in the column's own terms. */
+export const SortFromHeader: Story = {
+  render: () => <IssuesTable />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+
+    await userEvent.click(canvas.getByRole('button', { name: /Last seen/ }));
+    const panel = await body.findByRole('dialog');
+    await userEvent.click(
+      within(panel).getByRole('button', { name: /Newest first/ }),
+    );
+
+    await waitFor(() => {
+      const th = canvasElement.querySelector('th[aria-sort="descending"]');
+      expect(th?.textContent).toContain('Last seen');
+    });
+  },
+};
+
+/**
+ * Ticking rows turns the header into the bulk strip: count, actions, Clear.
+ * Emptying the selection hands the column titles back.
+ */
+export const Selection: Story = {
+  render: () => <IssuesTable />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole('checkbox', { name: 'Select all rows on this page' }),
+    );
+
+    const toolbar = canvas.getByRole('toolbar', {
+      name: 'Actions for the selected rows',
+    });
+    await expect(within(toolbar).getByText('10 selected')).toBeInTheDocument();
+    await expect(
+      within(toolbar).getByRole('button', { name: 'Resolve' }),
+    ).toBeInTheDocument();
+
+    // Clear empties the selection and the column titles come back.
+    await userEvent.click(
+      within(toolbar).getByRole('button', { name: 'Clear' }),
+    );
+    await waitFor(() =>
+      expect(canvas.queryByRole('toolbar')).not.toBeInTheDocument(),
+    );
+    await expect(
+      canvas.getByRole('button', { name: /Events/ }),
+    ).toBeInTheDocument();
+  },
+};
+
+/** Every row ends in the same ⋯ menu; hover reveals nothing it hides. */
+export const RowMenu: Story = {
+  render: () => <IssuesTable />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+
+    const menus = canvas.getAllByRole('button', { name: 'Row actions' });
+    await expect(menus.length).toBe(10);
+
+    const first = menus[0] as HTMLElement;
+    await userEvent.click(first);
+    const menu = await body.findByRole('menu');
+    await expect(
+      within(menu).getByRole('menuitem', { name: /Resolve/ }),
+    ).toBeInTheDocument();
+    await expect(
+      within(menu).getByRole('menuitem', { name: /Delete/ }),
+    ).toBeInTheDocument();
+
+    // Escape closes and the trigger takes the focus back.
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(first).toHaveFocus());
+  },
+};
+
+/**
+ * One filter state, two views of it: ticking a value in a column's panel
+ * grows a chip in the query bar, and removing the chip puts the column's
+ * indicator out.
+ */
+export const BarAndHeaderStayInSync: Story = {
+  render: () => <IssuesTable />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+
+    await userEvent.click(canvas.getByRole('button', { name: /Level/ }));
+    const panel = await body.findByRole('dialog');
+    await userEvent.click(
+      within(panel).getByRole('button', { name: /Warning/ }),
+    );
+    await userEvent.keyboard('{Escape}');
+
+    // The panel's tick is the bar's chip.
+    await expect(canvas.getByText('level:')).toBeInTheDocument();
+
+    // And removing the chip clears the column's filter.
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Remove Level filter' }),
+    );
+    await waitFor(() =>
+      expect(
+        canvas.queryByRole('button', { name: 'Remove Level filter' }),
+      ).not.toBeInTheDocument(),
+    );
+    await expect(canvas.getAllByText(/PaymentDeclined/).length).toBeGreaterThan(
+      0,
+    );
+  },
+};
+
+/** Skeletons only when there is nothing to keep on screen. */
+export const Loading: Story = {
+  render: () => <IssuesTable loading data={[]} />,
+};
+
+/** An empty result names the cause and offers the way back. */
+export const Empty: Story = {
+  render: function EmptyStory() {
+    const [query, setQuery] = useState<DataTableQuery>(() => ({
+      ...emptyTableQuery(10),
+      search: 'nothing matches this',
+    }));
+    const table = useDataTable({
+      data: [],
+      columns,
+      rowCount: 0,
+      query,
+      onQueryChange: (updater) => setQuery((previous) => updater(previous)),
+      getRowId: (issue) => issue.id,
+    });
+    return (
+      <TooltipProvider>
+        <div className="flex h-105 flex-col">
+          <DataTable table={table} />
+        </div>
+      </TooltipProvider>
+    );
+  },
+};

--- a/packages/ui/src/components/data-table/data-table.stories.tsx
+++ b/packages/ui/src/components/data-table/data-table.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useMemo, useState } from 'react';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { Button } from '../button/button';
 import {
   AssignIcon,
@@ -275,6 +275,7 @@ const fields = queryFieldsFromColumns(columns);
 function IssuesTable({
   loading = false,
   data = undefined as Issue[] | undefined,
+  onRowClick = (row: { id: string }) => console.info('open', row.id),
 }) {
   const [query, setQuery] = useState<DataTableQuery>(() => ({
     ...emptyTableQuery(10),
@@ -350,7 +351,7 @@ function IssuesTable({
         <DataTable
           table={table}
           loading={loading}
-          onRowClick={(row) => console.info('open', row.id)}
+          onRowClick={(row) => onRowClick(row)}
           bulkActions={
             <>
               <Button
@@ -502,6 +503,30 @@ export const RowMenu: Story = {
     // Escape closes and the trigger takes the focus back.
     await userEvent.keyboard('{Escape}');
     await waitFor(() => expect(first).toHaveFocus());
+  },
+};
+
+/** A row opens with Enter once focus reaches it -- the keyboard path for `onRowClick`. */
+const rowOpensFromKeyboardSpy = fn();
+
+export const RowOpensFromKeyboard: Story = {
+  render: () => <IssuesTable onRowClick={rowOpensFromKeyboardSpy} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const row = canvas.getAllByRole('row')[1] as HTMLElement;
+
+    // Tab through the toolbar and header controls that precede the row --
+    // real key events, bounded so an unrelated column change cannot hang it.
+    for (let tabs = 0; document.activeElement !== row; tabs++) {
+      await expect(tabs).toBeLessThan(60);
+      await userEvent.tab();
+    }
+    await expect(row).toHaveFocus();
+
+    await userEvent.keyboard('{Enter}');
+    await expect(rowOpensFromKeyboardSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.stringMatching(/^RUSTRAK-\d+$/) }),
+    );
   },
 };
 

--- a/packages/ui/src/components/data-table/data-table.stories.tsx
+++ b/packages/ui/src/components/data-table/data-table.stories.tsx
@@ -8,7 +8,8 @@ import {
   MuteIcon,
   ResolveIcon,
 } from '../icon/icon-catalog';
-import { QueryBar, queryFieldsFromColumns } from '../query-bar/query-bar';
+import { QueryBar } from '../query-bar/query-bar';
+import { queryFieldsFromColumns } from '../query-bar/query-bar-parts';
 import { Tag, type TagTone } from '../tag/tag';
 import { Text } from '../text/text';
 import { TooltipProvider } from '../tooltip/tooltip';

--- a/packages/ui/src/components/data-table/data-table.tsx
+++ b/packages/ui/src/components/data-table/data-table.tsx
@@ -1,0 +1,326 @@
+import type { Cell, Row, RowData } from '@tanstack/react-table';
+import { flexRender } from '@tanstack/react-table';
+import type { MouseEvent, ReactNode } from 'react';
+import { interactiveTransition, swapAnimation } from '../../lib/motion';
+import { tv } from '../../lib/tv';
+import { Button } from '../button/button';
+import { EmptyIcon } from '../icon/icon-catalog';
+import { Text } from '../text/text';
+import { DataTableColumnHeader } from './column-header';
+import type { DataTableFeatures } from './features';
+import { DataTablePagination } from './pagination';
+import type { DataTableInstance } from './use-data-table';
+
+/**
+ * The rendering half of the table; `useDataTable` is the state half.
+ *
+ * It is one card: rows, their header, and the footer that places you in the
+ * result, drawn to the issue-list blueprint -- 38 px header, 48 px rows, the
+ * panel surface inside a subtle border. What it renders is decided entirely
+ * by the column definitions and the instance's state; the component adds no
+ * options of its own beyond the three slots the columns cannot express: what
+ * an empty result says, what a loading one shows, and what the header offers
+ * once rows are selected.
+ */
+const dataTable = tv({
+  slots: {
+    card: [
+      'flex min-h-0 flex-col overflow-hidden',
+      'rounded-xl border border-border-subtle bg-panel',
+    ],
+    scroller: 'min-h-0 flex-1 overflow-auto',
+    table: 'w-full border-separate border-spacing-0',
+    /*
+     * Sticky needs everything else to be true at once: the `th` is the
+     * sticking element (a sticky `thead` breaks in Safari), it needs its own
+     * opaque background or rows show through it mid-scroll, and the head's
+     * rule must be a border on the `th` itself -- with `border-collapse` the
+     * border would belong to the table and stay behind while the cell floats.
+     */
+    th: [
+      // Above the row-action overlays, which are z-10 later in tree order.
+      'sticky top-0 z-20 h-row-head bg-surface',
+      'border-border-subtle border-b px-2',
+      'text-start first:pl-4 last:pr-4',
+    ],
+    td: [
+      'h-row border-border-divider border-b px-2',
+      'text-body text-fg-secondary',
+      'first:pl-4 last:pr-4',
+      'data-[align=end]:text-end',
+      'data-[numeric=true]:font-mono data-[numeric=true]:text-fg',
+      'data-[numeric=true]:text-numeric data-[numeric=true]:tabular-nums',
+    ],
+    row: [
+      'group/row',
+      interactiveTransition,
+      'hover:bg-surface-hover',
+      'data-[selected=true]:bg-surface-raised',
+      'data-[clickable=true]:cursor-pointer',
+    ],
+    /*
+     * The header's second life. With rows selected, the column titles step
+     * aside and the same 38 px strip holds what can be done to the selection
+     * -- the Gmail pattern, because the alternative is a second toolbar that
+     * pushes the whole table down exactly when the reader is mid-gesture.
+     * Both directions of the swap enter with `swapAnimation`: the outgoing
+     * side unmounts, the incoming one rises 2 px into place, and the row
+     * itself never moves.
+     */
+    bulk: ['flex h-full items-center gap-1.5', swapAnimation],
+    headerSwap: ['h-full', swapAnimation],
+    bulkCount: 'me-2 font-medium text-control text-fg',
+    empty: [
+      'flex flex-col items-center justify-center gap-3',
+      'px-6 py-16 text-center',
+    ],
+    skeleton: 'h-3 animate-pulse rounded-xs bg-surface-chip',
+  },
+});
+
+const styles = dataTable();
+
+export interface DataTableEmptyProps {
+  title?: string;
+  description?: string;
+}
+
+export interface DataTableProps<TData extends RowData> {
+  table: DataTableInstance<TData>;
+  /**
+   * The page is being fetched. With rows on screen they stay, dimmed --
+   * yanking a list someone is reading to show a shimmer where it was is the
+   * jumpiest thing a refetch can do. Skeletons only stand in when there is
+   * nothing yet.
+   */
+  loading?: boolean;
+  /** What an empty result says. The clear-filters offer appears on its own. */
+  empty?: DataTableEmptyProps;
+  /**
+   * What the header offers while rows are selected: resolve, mute, delete.
+   * Rendered beside the built-in count and Clear; read the selection off the
+   * table instance. Without it the header never changes.
+   */
+  bulkActions?: ReactNode;
+  /** Opens the row. Also offered to the keyboard as Enter on the row. */
+  onRowClick?: (row: Row<DataTableFeatures, TData>) => void;
+  className?: string;
+}
+
+function cellAttributes<TData extends RowData>(
+  cell: Cell<DataTableFeatures, TData, unknown>,
+) {
+  const meta = cell.column.columnDef.meta;
+  return {
+    'data-align': meta?.align,
+    'data-numeric': meta?.numeric || undefined,
+  };
+}
+
+export function DataTable<TData extends RowData>({
+  table,
+  loading = false,
+  empty,
+  bulkActions,
+  onRowClick,
+  className,
+}: DataTableProps<TData>) {
+  const rows = table.getRowModel().rows;
+  const columns = table.getVisibleLeafColumns();
+  const filtered =
+    table.state.columnFilters.length > 0 || Boolean(table.state.globalFilter);
+  const selectedCount = Object.keys(table.state.rowSelection).length;
+  const bulkMode = bulkActions != null && selectedCount > 0;
+
+  /*
+   * A click that lands on a control inside the row -- the checkbox, an
+   * action, a link a cell rendered -- belongs to that control. Only the inert
+   * remainder of the row opens it.
+   */
+  function handleRowClick(
+    row: Row<DataTableFeatures, TData>,
+    event: MouseEvent,
+  ) {
+    if (!onRowClick) return;
+    const target = event.target as HTMLElement;
+    if (target.closest('button, a, input, label, [role="checkbox"]')) return;
+    onRowClick(row);
+  }
+
+  return (
+    <div className={styles.card({ className })}>
+      <div className={styles.scroller()} aria-busy={loading}>
+        <table className={styles.table()}>
+          <colgroup>
+            {columns.map((column) => (
+              <col
+                key={column.id}
+                style={{
+                  width:
+                    column.id === 'select' ? 40 : column.columnDef.meta?.width,
+                }}
+              />
+            ))}
+          </colgroup>
+
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {bulkMode && headerGroup.headers[0]?.column.id === 'select' ? (
+                  <>
+                    {/* The box stays: it is how the selection is grown to the
+                        page or emptied, and it must not jump. */}
+                    <th scope="col" className={styles.th()}>
+                      <span className="flex items-center">
+                        {flexRender(
+                          headerGroup.headers[0].column.columnDef.header,
+                          headerGroup.headers[0].getContext(),
+                        )}
+                      </span>
+                    </th>
+                    <th
+                      scope="col"
+                      colSpan={headerGroup.headers.length - 1}
+                      className={styles.th()}
+                    >
+                      <div
+                        role="toolbar"
+                        aria-label="Actions for the selected rows"
+                        className={styles.bulk()}
+                      >
+                        <span aria-live="polite" className={styles.bulkCount()}>
+                          {selectedCount} selected
+                        </span>
+                        {bulkActions}
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          className="ms-auto"
+                          onClick={() => table.toggleAllRowsSelected(false)}
+                        >
+                          Clear
+                        </Button>
+                      </div>
+                    </th>
+                  </>
+                ) : (
+                  headerGroup.headers.map((header) => {
+                    const sorted = header.column.getIsSorted();
+                    return (
+                      <th
+                        key={header.id}
+                        scope="col"
+                        colSpan={header.colSpan}
+                        aria-sort={
+                          sorted === 'asc'
+                            ? 'ascending'
+                            : sorted === 'desc'
+                              ? 'descending'
+                              : undefined
+                        }
+                        className={styles.th()}
+                      >
+                        {header.isPlaceholder ? null : header.column.id ===
+                          'select' ? (
+                          <span className="flex items-center">
+                            {flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                          </span>
+                        ) : (
+                          /* Re-enters the same way the bulk strip arrived, so
+                             the swap reads as one exchange, not two events. */
+                          <div className={styles.headerSwap()}>
+                            <DataTableColumnHeader header={header} />
+                          </div>
+                        )}
+                      </th>
+                    );
+                  })
+                )}
+              </tr>
+            ))}
+          </thead>
+
+          <tbody className={loading && rows.length ? 'opacity-60' : undefined}>
+            {rows.map((row) => (
+              <tr
+                key={row.id}
+                data-selected={row.getIsSelected() || undefined}
+                data-clickable={onRowClick ? true : undefined}
+                onClick={(event) => handleRowClick(row, event)}
+                className={styles.row()}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <td
+                    key={cell.id}
+                    {...cellAttributes(cell)}
+                    className={styles.td()}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+
+            {loading && rows.length === 0
+              ? Array.from({ length: 8 }, (_, line) => (
+                  // Skeleton rows have no identity beyond their position.
+                  <tr key={line} className={styles.row()}>
+                    {columns.map((column) => (
+                      <td key={column.id} className={styles.td()}>
+                        <span
+                          aria-hidden="true"
+                          className={styles.skeleton({
+                            className: column.columnDef.meta?.width
+                              ? 'block w-3/5'
+                              : 'block w-4/5',
+                          })}
+                        />
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              : null}
+          </tbody>
+        </table>
+
+        {!loading && rows.length === 0 ? (
+          <div className={styles.empty()}>
+            <EmptyIcon
+              size="2xl"
+              aria-hidden="true"
+              className="text-fg-ghost"
+            />
+            <div className="flex flex-col gap-1">
+              <Text variant="card-title">{empty?.title ?? 'No results'}</Text>
+              <Text variant="meta" tone="subtle">
+                {empty?.description ??
+                  (filtered
+                    ? 'Nothing matches the current filters.'
+                    : 'There is nothing here yet.')}
+              </Text>
+            </div>
+            {filtered ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  table.setColumnFilters([]);
+                  table.setGlobalFilter(undefined);
+                }}
+              >
+                Clear filters
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      <DataTablePagination table={table} />
+    </div>
+  );
+}
+
+DataTable.displayName = 'DataTable';

--- a/packages/ui/src/components/data-table/data-table.tsx
+++ b/packages/ui/src/components/data-table/data-table.tsx
@@ -249,7 +249,17 @@ export function DataTable<TData extends RowData>({
                 key={row.id}
                 data-selected={row.getIsSelected() || undefined}
                 data-clickable={onRowClick ? true : undefined}
+                // A `role` override would break the row/cell relationship a
+                // table needs; the row stays a row and only gains a tab stop.
+                tabIndex={onRowClick ? 0 : undefined}
                 onClick={(event) => handleRowClick(row, event)}
+                onKeyDown={(event) => {
+                  if (!onRowClick) return;
+                  if (event.key !== 'Enter' && event.key !== ' ') return;
+                  if (event.target !== event.currentTarget) return;
+                  event.preventDefault();
+                  onRowClick(row);
+                }}
                 className={styles.row()}
               >
                 {row.getVisibleCells().map((cell) => (
@@ -308,7 +318,7 @@ export function DataTable<TData extends RowData>({
                 size="sm"
                 onClick={() => {
                   table.setColumnFilters([]);
-                  table.setGlobalFilter(undefined);
+                  table.setGlobalFilter('');
                 }}
               >
                 Clear filters

--- a/packages/ui/src/components/data-table/features.ts
+++ b/packages/ui/src/components/data-table/features.ts
@@ -1,4 +1,5 @@
 import {
+  type Column,
   type ColumnDef,
   columnFilteringFeature,
   columnVisibilityFeature,
@@ -135,4 +136,13 @@ export type DataTableColumnDef<TData extends RowData> = ColumnDef<
 /** The column helper, pre-bound so consumers never repeat the generics. */
 export function createDataTableColumnHelper<TData extends RowData>() {
   return createColumnHelper<DataTableFeatures, TData>();
+}
+
+/** What menus call a column: its meta label, or its header when it is text. */
+export function columnLabel<TData extends RowData>(
+  column: Column<DataTableFeatures, TData, unknown>,
+): string {
+  const { meta, header } = column.columnDef;
+  if (meta?.label) return meta.label;
+  return typeof header === 'string' ? header : column.id;
 }

--- a/packages/ui/src/components/data-table/features.ts
+++ b/packages/ui/src/components/data-table/features.ts
@@ -1,0 +1,138 @@
+import {
+  type ColumnDef,
+  columnFilteringFeature,
+  columnVisibilityFeature,
+  createColumnHelper,
+  globalFilteringFeature,
+  metaHelper,
+  type RowData,
+  rowPaginationFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  tableFeatures,
+} from '@tanstack/react-table';
+import type { IconComponent } from '../icon/icon';
+import type { TagTone } from '../tag/tag';
+
+/**
+ * One value a filterable column can take: a level, an environment, a release.
+ *
+ * The `tone` is the same scale `Tag` speaks, because the option list in a
+ * filter panel previews exactly what the column will show once the filter
+ * applies -- an option painted one red and a cell painted another would read
+ * as two different errors.
+ */
+export interface FilterOption {
+  value: string;
+  label: string;
+  /** Paints the option the way the column paints the value. */
+  tone?: TagTone;
+  /** What the label falls short of saying: "CI, Docker, releases". */
+  hint?: string;
+  /**
+   * How many rows carry it, computed by the server across the whole result --
+   * not by this table, which only ever holds one page and would lie.
+   */
+  count?: number;
+}
+
+/**
+ * How a column filters, declared by the shape of its data.
+ *
+ * This is the decision the column header menu reads: an enum column offers its
+ * options with checkboxes, a numeric column offers bounds, a text column
+ * offers a contains-match. The column knows its own type; nobody configures
+ * the panel separately, so the panel cannot disagree with the data.
+ */
+export type ColumnFilterSpec =
+  | {
+      variant: 'options';
+      /** The values, when they are known up front: severities, states. */
+      options?: readonly FilterOption[];
+      /** Or fetched when the panel opens: releases, users. Shows a skeleton. */
+      loadOptions?: () => Promise<FilterOption[]>;
+      /**
+       * Whether more than one value can hold at once. Severities can
+       * (`error,fatal`); a date preset cannot. Defaults to true.
+       */
+      multiple?: boolean;
+    }
+  | {
+      variant: 'text';
+      placeholder?: string;
+    }
+  | {
+      variant: 'range';
+      min?: number;
+      max?: number;
+      /** Drawn after the bounds: "ms", "events". */
+      unit?: string;
+    };
+
+/**
+ * What a column says about itself beyond its cells.
+ *
+ * The same declaration feeds three consumers: the header menu (sort wording,
+ * filter panel), the columns menu (label when the header is hidden), and the
+ * query bar (which fields can be typed as `key:value`). One source, so the
+ * three never disagree about what a column is called or how it filters.
+ */
+export interface DataTableColumnMeta {
+  /** What menus call the column. Falls back to a string header. */
+  label?: string;
+  /** The icon the query bar shows beside the field's suggestions. */
+  icon?: IconComponent;
+  /** How it filters. Absent: the column does not filter. */
+  filter?: ColumnFilterSpec;
+  /** `end` for figures, which right-align so magnitudes line up. */
+  align?: 'start' | 'end';
+  /**
+   * A fixed width in pixels. Left unset the column shares what remains,
+   * which is right for exactly one column per table -- the title. Everything
+   * measurable (a level, a count, a date) states its width, so the flexible
+   * column is the one that absorbs the viewport.
+   */
+  width?: number;
+  /** Tabular mono figures: counts, durations. */
+  numeric?: boolean;
+  /**
+   * The sort menu's wording, said in the data's own terms. "Most events
+   * first" reads; "Descending" makes the reader translate. Defaults to
+   * A→Z / Z→A wording for text and high/low wording for numeric columns.
+   */
+  sortLabels?: { asc: string; desc: string };
+}
+
+/**
+ * The features every Rustrak table registers, and no others.
+ *
+ * There are no client row models here, which is a statement rather than an
+ * omission: the server filters, sorts and paginates, and this table renders
+ * what it was handed. Registering `createSortedRowModel` would ship dead code
+ * and, worse, would make the table quietly re-sort a page the server already
+ * sorted.
+ */
+export const dataTableFeatures = tableFeatures({
+  rowSortingFeature,
+  columnFilteringFeature,
+  globalFilteringFeature,
+  rowPaginationFeature,
+  columnVisibilityFeature,
+  rowSelectionFeature,
+  columnMeta: metaHelper<DataTableColumnMeta>(),
+});
+
+export type DataTableFeatures = typeof dataTableFeatures;
+
+/** A column of a Rustrak table, with the features and meta above baked in. */
+export type DataTableColumnDef<TData extends RowData> = ColumnDef<
+  DataTableFeatures,
+  TData,
+  // Columns of one table hold different value types by construction.
+  any
+>;
+
+/** The column helper, pre-bound so consumers never repeat the generics. */
+export function createDataTableColumnHelper<TData extends RowData>() {
+  return createColumnHelper<DataTableFeatures, TData>();
+}

--- a/packages/ui/src/components/data-table/filter-panel.tsx
+++ b/packages/ui/src/components/data-table/filter-panel.tsx
@@ -98,9 +98,14 @@ export function OptionsFilterPanel<TData extends RowData>({
   useEffect(() => {
     if (!loadOptions) return;
     let cancelled = false;
-    loadOptions().then((options) => {
-      if (!cancelled) setLoaded(options);
-    });
+    loadOptions()
+      .then((options) => {
+        if (!cancelled) setLoaded(options);
+      })
+      .catch(() => {
+        // An empty list ends the skeleton and reads as "nothing to offer".
+        if (!cancelled) setLoaded([]);
+      });
     return () => {
       cancelled = true;
     };

--- a/packages/ui/src/components/data-table/filter-panel.tsx
+++ b/packages/ui/src/components/data-table/filter-panel.tsx
@@ -1,0 +1,308 @@
+import type { Column, RowData } from '@tanstack/react-table';
+import { useEffect, useState } from 'react';
+import { focusRingWithin } from '../../lib/focus';
+import { interactiveTransition } from '../../lib/motion';
+import { tv } from '../../lib/tv';
+import { Count } from '../count/count';
+import { ResolveIcon, SearchIcon } from '../icon/icon-catalog';
+import type { TagTone } from '../tag/tag';
+import type { DataTableFeatures, FilterOption } from './features';
+
+/**
+ * The filter half of a column header panel: what changes with the column's
+ * data type. An enum column offers its values, a numeric column offers
+ * bounds, a text column offers a match. The sort half lives in
+ * `column-header.tsx`; this file only knows how to ask about values.
+ *
+ * Every change applies immediately. A filter panel with an Apply button makes
+ * the reader describe the whole question before seeing any answer; applying
+ * on each tick lets the list answer while the question is still being formed,
+ * which is how the query bar behaves too. Immediate does not mean noisy: the
+ * inputs that type (text, bounds) commit on Enter or blur, not per keystroke,
+ * because every commit is a server round trip.
+ */
+const filterPanel = tv({
+  slots: {
+    section: 'flex flex-col p-1.25',
+    /*
+     * The search field sits inside the panel on its own row. It filters the
+     * option list, not the table: with forty releases the list needs its own
+     * finder before the finder is any use.
+     */
+    field: [
+      'mx-1 mt-1 mb-1.5 flex h-control-sm items-center gap-1.5 rounded-md',
+      'border border-border-field bg-canvas px-2',
+      interactiveTransition,
+      focusRingWithin,
+    ],
+    input: [
+      'h-full w-full min-w-0 bg-transparent text-control text-fg',
+      'outline-none placeholder:text-fg-placeholder',
+    ],
+    option: [
+      'group/option flex h-menu-item shrink-0 cursor-default items-center',
+      'gap-2.5 rounded-sm px-2.5 text-control text-fg-muted select-none',
+      'transition-none outline-none',
+      'hover:bg-surface-selected hover:text-fg',
+      'focus-visible:bg-surface-selected focus-visible:text-fg',
+      'aria-pressed:text-fg',
+    ],
+    /*
+     * The tick box is drawn, not a `Checkbox`: the row itself is the button,
+     * and a real checkbox inside it would be a control inside a control --
+     * two tab stops, two announcements, one action.
+     */
+    box: [
+      'flex size-3.5 shrink-0 items-center justify-center',
+      'rounded-xs border border-border-control text-fg-on-brand',
+      interactiveTransition,
+      'group-aria-pressed/option:border-surface-brand',
+      'group-aria-pressed/option:bg-surface-brand',
+    ],
+    dot: 'size-dot shrink-0 rounded-pill',
+    label: 'min-w-0 flex-1 truncate text-start',
+    empty: 'px-2.5 py-3 text-center text-control text-fg-ghost',
+    skeleton: 'mx-2.5 my-2 h-3 animate-pulse rounded-xs bg-surface-chip',
+  },
+});
+
+const styles = filterPanel();
+
+/*
+ * A static map, never `bg-${tone}`: Tailwind extracts class names from the
+ * source text, so a composed name is a rule that is silently not generated.
+ */
+const TONE_DOT: Record<TagTone, string> = {
+  error: 'bg-sev-error',
+  warning: 'bg-sev-warning',
+  info: 'bg-sev-info',
+  brand: 'bg-surface-brand',
+  neutral: 'bg-fg-ghost',
+};
+
+interface PanelProps<TData extends RowData> {
+  column: Column<DataTableFeatures, TData, unknown>;
+}
+
+/* --- Options ------------------------------------------------------------- */
+
+export function OptionsFilterPanel<TData extends RowData>({
+  column,
+}: PanelProps<TData>) {
+  const spec = column.columnDef.meta?.filter;
+  const [loaded, setLoaded] = useState<FilterOption[] | null>(null);
+  const [search, setSearch] = useState('');
+
+  const loadOptions =
+    spec?.variant === 'options' ? spec.loadOptions : undefined;
+  useEffect(() => {
+    if (!loadOptions) return;
+    let cancelled = false;
+    loadOptions().then((options) => {
+      if (!cancelled) setLoaded(options);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [loadOptions]);
+
+  if (spec?.variant !== 'options') return null;
+
+  const options = spec.options ?? loaded;
+  const multiple = spec.multiple ?? true;
+  const selected = (column.getFilterValue() as string[] | undefined) ?? [];
+
+  const visible = options?.filter(
+    (option) =>
+      !search ||
+      option.label.toLowerCase().includes(search.toLowerCase()) ||
+      option.value.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  function toggle(value: string) {
+    const has = selected.includes(value);
+    const next = multiple
+      ? has
+        ? selected.filter((v) => v !== value)
+        : [...selected, value]
+      : has
+        ? []
+        : [value];
+    column.setFilterValue(next.length ? next : undefined);
+  }
+
+  return (
+    <div className={styles.section()}>
+      {options && options.length > 7 ? (
+        <div className={styles.field()}>
+          <SearchIcon size="md" className="shrink-0 text-fg-ghost" />
+          <input
+            type="text"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Filter values…"
+            aria-label="Filter values"
+            className={styles.input()}
+          />
+        </div>
+      ) : null}
+
+      {/* The skeleton holds the panel at roughly its final size, so the list
+          arriving does not shove the pointer off what it was about to click. */}
+      {!options
+        ? [0, 1, 2].map((line) => (
+            <div key={line} aria-hidden="true" className={styles.skeleton()} />
+          ))
+        : null}
+
+      {visible?.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          aria-pressed={selected.includes(option.value)}
+          onClick={() => toggle(option.value)}
+          className={styles.option()}
+        >
+          <span aria-hidden="true" className={styles.box()}>
+            {selected.includes(option.value) ? (
+              <ResolveIcon size="sm" aria-hidden="true" />
+            ) : null}
+          </span>
+          {option.tone ? (
+            <span
+              aria-hidden="true"
+              className={styles.dot({ className: TONE_DOT[option.tone] })}
+            />
+          ) : null}
+          <span className={styles.label()}>{option.label}</span>
+          <Count>{option.count}</Count>
+        </button>
+      ))}
+
+      {visible && visible.length === 0 ? (
+        <div className={styles.empty()}>Nothing matches</div>
+      ) : null}
+    </div>
+  );
+}
+
+OptionsFilterPanel.displayName = 'OptionsFilterPanel';
+
+/* --- Text ---------------------------------------------------------------- */
+
+export function TextFilterPanel<TData extends RowData>({
+  column,
+}: PanelProps<TData>) {
+  const spec = column.columnDef.meta?.filter;
+  const applied = (column.getFilterValue() as string | undefined) ?? '';
+  const [draft, setDraft] = useState(applied);
+
+  if (spec?.variant !== 'text') return null;
+
+  function commit() {
+    column.setFilterValue(draft || undefined);
+  }
+
+  return (
+    <div className={styles.section()}>
+      <div className={styles.field()}>
+        <SearchIcon size="md" className="shrink-0 text-fg-ghost" />
+        <input
+          type="text"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={commit}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') commit();
+          }}
+          placeholder={spec.placeholder ?? 'Contains…'}
+          aria-label={spec.placeholder ?? 'Filter text'}
+          className={styles.input()}
+        />
+      </div>
+    </div>
+  );
+}
+
+TextFilterPanel.displayName = 'TextFilterPanel';
+
+/* --- Range --------------------------------------------------------------- */
+
+export function RangeFilterPanel<TData extends RowData>({
+  column,
+}: PanelProps<TData>) {
+  const spec = column.columnDef.meta?.filter;
+  const applied =
+    (column.getFilterValue() as [number | null, number | null] | undefined) ??
+    ([null, null] as [number | null, number | null]);
+  const [min, setMin] = useState(applied[0]?.toString() ?? '');
+  const [max, setMax] = useState(applied[1]?.toString() ?? '');
+
+  if (spec?.variant !== 'range') return null;
+
+  function commit() {
+    const low = min === '' ? null : Number(min);
+    const high = max === '' ? null : Number(max);
+    if (
+      (low !== null && Number.isNaN(low)) ||
+      (high !== null && Number.isNaN(high))
+    ) {
+      return;
+    }
+    column.setFilterValue(
+      low === null && high === null ? undefined : [low, high],
+    );
+  }
+
+  function onKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'Enter') commit();
+  }
+
+  return (
+    <div className={styles.section()}>
+      <div className="flex items-center gap-2 px-1 py-1">
+        <div className={styles.field({ className: 'mx-0 my-0 flex-1' })}>
+          <input
+            type="number"
+            inputMode="numeric"
+            value={min}
+            min={spec.min}
+            max={spec.max}
+            onChange={(event) => setMin(event.target.value)}
+            onBlur={commit}
+            onKeyDown={onKeyDown}
+            placeholder="Min"
+            aria-label={`Minimum${spec.unit ? ` (${spec.unit})` : ''}`}
+            className={styles.input()}
+          />
+        </div>
+        <span aria-hidden="true" className="text-fg-ghost text-hint">
+          –
+        </span>
+        <div className={styles.field({ className: 'mx-0 my-0 flex-1' })}>
+          <input
+            type="number"
+            inputMode="numeric"
+            value={max}
+            min={spec.min}
+            max={spec.max}
+            onChange={(event) => setMax(event.target.value)}
+            onBlur={commit}
+            onKeyDown={onKeyDown}
+            placeholder="Max"
+            aria-label={`Maximum${spec.unit ? ` (${spec.unit})` : ''}`}
+            className={styles.input()}
+          />
+        </div>
+        {/* Decoration: the unit already lives in each input's accessible name. */}
+        {spec.unit ? (
+          <span aria-hidden="true" className="shrink-0 text-fg-ghost text-hint">
+            {spec.unit}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+RangeFilterPanel.displayName = 'RangeFilterPanel';

--- a/packages/ui/src/components/data-table/filter-panel.tsx
+++ b/packages/ui/src/components/data-table/filter-panel.tsx
@@ -116,6 +116,7 @@ export function OptionsFilterPanel<TData extends RowData>({
   const options = spec.options ?? loaded;
   const multiple = spec.multiple ?? true;
   const selected = (column.getFilterValue() as string[] | undefined) ?? [];
+  const selectedSet = new Set(selected);
 
   const visible = options?.filter(
     (option) =>
@@ -164,12 +165,12 @@ export function OptionsFilterPanel<TData extends RowData>({
         <button
           key={option.value}
           type="button"
-          aria-pressed={selected.includes(option.value)}
+          aria-pressed={selectedSet.has(option.value)}
           onClick={() => toggle(option.value)}
           className={styles.option()}
         >
           <span aria-hidden="true" className={styles.box()}>
-            {selected.includes(option.value) ? (
+            {selectedSet.has(option.value) ? (
               <ResolveIcon size="sm" aria-hidden="true" />
             ) : null}
           </span>
@@ -240,8 +241,8 @@ export function RangeFilterPanel<TData extends RowData>({
   const applied =
     (column.getFilterValue() as [number | null, number | null] | undefined) ??
     ([null, null] as [number | null, number | null]);
-  const [min, setMin] = useState(applied[0]?.toString() ?? '');
-  const [max, setMax] = useState(applied[1]?.toString() ?? '');
+  const [min, setMin] = useState(() => applied[0]?.toString() ?? '');
+  const [max, setMax] = useState(() => applied[1]?.toString() ?? '');
 
   if (spec?.variant !== 'range') return null;
 

--- a/packages/ui/src/components/data-table/filter-panel.tsx
+++ b/packages/ui/src/components/data-table/filter-panel.tsx
@@ -91,6 +91,10 @@ export function OptionsFilterPanel<TData extends RowData>({
 }: PanelProps<TData>) {
   const spec = column.columnDef.meta?.filter;
   const [loaded, setLoaded] = useState<FilterOption[] | null>(null);
+  // Kept apart from `loaded` so a rejected load never reads as "loaded, and
+  // empty" -- that would survive as long as this panel stays mounted and
+  // block a retry, rather than clearing when the panel remounts.
+  const [failed, setFailed] = useState(false);
   const [search, setSearch] = useState('');
 
   const loadOptions =
@@ -103,8 +107,7 @@ export function OptionsFilterPanel<TData extends RowData>({
         if (!cancelled) setLoaded(options);
       })
       .catch(() => {
-        // An empty list ends the skeleton and reads as "nothing to offer".
-        if (!cancelled) setLoaded([]);
+        if (!cancelled) setFailed(true);
       });
     return () => {
       cancelled = true;
@@ -113,7 +116,7 @@ export function OptionsFilterPanel<TData extends RowData>({
 
   if (spec?.variant !== 'options') return null;
 
-  const options = spec.options ?? loaded;
+  const options = spec.options ?? loaded ?? (failed ? [] : null);
   const multiple = spec.multiple ?? true;
   const selected = (column.getFilterValue() as string[] | undefined) ?? [];
   const selectedSet = new Set(selected);

--- a/packages/ui/src/components/data-table/pagination.tsx
+++ b/packages/ui/src/components/data-table/pagination.tsx
@@ -1,0 +1,110 @@
+import type { RowData } from '@tanstack/react-table';
+import { tv } from '../../lib/tv';
+import { Button } from '../button/button';
+import { ChevronLeftIcon, ChevronRightIcon } from '../icon/icon-catalog';
+import { Menu } from '../menu/menu';
+import { Tooltip } from '../tooltip/tooltip';
+import type { DataTableInstance } from './use-data-table';
+
+/**
+ * The table's footer: where you are in the result, and the only two controls
+ * whose subject is the result rather than a column.
+ *
+ * The range reads `1–50 of 12,403` and not `page 1 of 249`, because rows are
+ * what the reader counts; the page fraction is still there, small and mono,
+ * between the arrows for whoever is stepping. Selection is reported here too:
+ * the ticks happen spread across the page, and this is the one line that can
+ * total them without following the pointer around.
+ */
+const pagination = tv({
+  slots: {
+    footer: [
+      'flex h-11 shrink-0 items-center justify-between gap-4',
+      'border-border-subtle border-t px-4',
+      'text-fg-subtle text-meta',
+    ],
+    figure: 'font-medium text-fg-secondary',
+    fraction: 'px-1.5 font-mono text-fg-subtle text-mono-sm tabular-nums',
+  },
+});
+
+const styles = pagination();
+
+const PAGE_SIZES = [25, 50, 100];
+
+export interface DataTablePaginationProps<TData extends RowData> {
+  table: DataTableInstance<TData>;
+}
+
+export function DataTablePagination<TData extends RowData>({
+  table,
+}: DataTablePaginationProps<TData>) {
+  const { pageIndex, pageSize } = table.state.pagination;
+  const rowCount = table.options.rowCount ?? table.getRowCount();
+  const pageCount = table.getPageCount();
+  const selected = Object.keys(table.state.rowSelection).length;
+
+  const first = rowCount === 0 ? 0 : pageIndex * pageSize + 1;
+  const last = Math.min((pageIndex + 1) * pageSize, rowCount);
+
+  return (
+    <div className={styles.footer()}>
+      <span aria-live="polite">
+        <span className={styles.figure()}>
+          {first.toLocaleString('en-US')}–{last.toLocaleString('en-US')}
+        </span>{' '}
+        of {rowCount.toLocaleString('en-US')}
+        {selected > 0 ? (
+          <>
+            {' '}
+            · <span className={styles.figure()}>{selected} selected</span>
+          </>
+        ) : null}
+      </span>
+
+      <div className="flex items-center gap-3">
+        <Menu
+          align="end"
+          trigger={
+            <Button variant="ghost" size="xs" menu>
+              Rows {pageSize}
+            </Button>
+          }
+          actions={PAGE_SIZES.map((size) => ({
+            id: String(size),
+            label: `${size} rows`,
+            onSelect: () => table.setPageSize(size),
+          }))}
+        />
+
+        <div className="flex items-center gap-1">
+          <Tooltip content="Previous page">
+            <Button
+              variant="secondary"
+              size="xs"
+              icon={ChevronLeftIcon}
+              aria-label="Previous page"
+              disabled={!table.getCanPreviousPage()}
+              onClick={() => table.previousPage()}
+            />
+          </Tooltip>
+          <span aria-hidden="true" className={styles.fraction()}>
+            {pageCount === 0 ? 0 : pageIndex + 1} / {pageCount}
+          </span>
+          <Tooltip content="Next page">
+            <Button
+              variant="secondary"
+              size="xs"
+              icon={ChevronRightIcon}
+              aria-label="Next page"
+              disabled={!table.getCanNextPage()}
+              onClick={() => table.nextPage()}
+            />
+          </Tooltip>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+DataTablePagination.displayName = 'DataTablePagination';

--- a/packages/ui/src/components/data-table/query.test.ts
+++ b/packages/ui/src/components/data-table/query.test.ts
@@ -63,6 +63,15 @@ describe('parseFilterQuery', () => {
     expect(search).toBe('connection reset');
   });
 
+  it('reads an escaped quote inside a quoted text value literally', () => {
+    const { filters } = parseFilterQuery(
+      'release:"say \\"hi\\" now"',
+      variants,
+    );
+
+    expect(filters).toEqual([{ id: 'release', value: 'say "hi" now' }]);
+  });
+
   it('merges a key written twice instead of duplicating it', () => {
     const { filters } = parseFilterQuery('level:error level:fatal', variants);
 
@@ -97,6 +106,19 @@ describe('formatFilterQuery', () => {
         variants,
       ),
     ).toBe('release:"not deployed"');
+  });
+
+  it('escapes an embedded quote so it round-trips through parse', () => {
+    const formatted = formatFilterQuery(
+      [{ id: 'release', value: 'say "hi" now' }],
+      '',
+      variants,
+    );
+
+    expect(formatted).toBe('release:"say \\"hi\\" now"');
+    expect(parseFilterQuery(formatted, variants).filters).toEqual([
+      { id: 'release', value: 'say "hi" now' },
+    ]);
   });
 
   it('drops empty filters instead of writing empty tokens', () => {

--- a/packages/ui/src/components/data-table/query.test.ts
+++ b/packages/ui/src/components/data-table/query.test.ts
@@ -121,6 +121,26 @@ describe('formatFilterQuery', () => {
     ]);
   });
 
+  it('quotes an unspaced value that contains a quote, so it round-trips', () => {
+    const formatted = formatFilterQuery(
+      [{ id: 'release', value: 'a"b' }],
+      '',
+      variants,
+    );
+
+    expect(formatted).toBe('release:"a\\"b"');
+    expect(parseFilterQuery(formatted, variants).filters).toEqual([
+      { id: 'release', value: 'a"b' },
+    ]);
+  });
+
+  it('quotes free-text search that contains a quote, so it round-trips', () => {
+    const formatted = formatFilterQuery([], 'say "hi" there', variants);
+
+    expect(formatted).toBe('"say \\"hi\\" there"');
+    expect(parseFilterQuery(formatted, variants).search).toBe('say "hi" there');
+  });
+
   it('drops empty filters instead of writing empty tokens', () => {
     expect(
       formatFilterQuery(

--- a/packages/ui/src/components/data-table/query.test.ts
+++ b/packages/ui/src/components/data-table/query.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+  emptyTableQuery,
+  type FilterVariants,
+  formatFilterQuery,
+  parseFilterQuery,
+  parseTableQuery,
+  serializeTableQuery,
+} from './query';
+
+const variants: FilterVariants = {
+  level: 'options',
+  release: 'text',
+  events: 'range',
+};
+
+describe('parseFilterQuery', () => {
+  it('reads options, text and range tokens into their value shapes', () => {
+    const { filters, search } = parseFilterQuery(
+      'level:error,fatal release:2.1.0 events:100..500',
+      variants,
+    );
+
+    expect(filters).toEqual([
+      { id: 'level', value: ['error', 'fatal'] },
+      { id: 'release', value: '2.1.0' },
+      { id: 'events', value: [100, 500] },
+    ]);
+    expect(search).toBe('');
+  });
+
+  it('keeps what no key claims as free text, in order', () => {
+    const { filters, search } = parseFilterQuery(
+      'timeout level:error checkout',
+      variants,
+    );
+
+    expect(filters).toEqual([{ id: 'level', value: ['error'] }]);
+    expect(search).toBe('timeout checkout');
+  });
+
+  it('treats an unknown key as prose, not as a phantom filter', () => {
+    const { filters, search } = parseFilterQuery('error: undefined', variants);
+
+    expect(filters).toEqual([]);
+    expect(search).toBe('error: undefined');
+  });
+
+  it('drops a known key with nothing after the colon', () => {
+    const { filters, search } = parseFilterQuery('level: timeout', variants);
+
+    expect(filters).toEqual([]);
+    expect(search).toBe('timeout');
+  });
+
+  it('respects quotes in text values and in free text', () => {
+    const { filters, search } = parseFilterQuery(
+      'release:"not deployed" "connection reset"',
+      variants,
+    );
+
+    expect(filters).toEqual([{ id: 'release', value: 'not deployed' }]);
+    expect(search).toBe('connection reset');
+  });
+
+  it('merges a key written twice instead of duplicating it', () => {
+    const { filters } = parseFilterQuery('level:error level:fatal', variants);
+
+    expect(filters).toEqual([{ id: 'level', value: ['error', 'fatal'] }]);
+  });
+
+  it('supports open-ended ranges on either side', () => {
+    expect(parseFilterQuery('events:100..', variants).filters).toEqual([
+      { id: 'events', value: [100, null] },
+    ]);
+    expect(parseFilterQuery('events:..500', variants).filters).toEqual([
+      { id: 'events', value: [null, 500] },
+    ]);
+    // Both ends open filters nothing: the token stays text.
+    expect(parseFilterQuery('events:..', variants).filters).toEqual([]);
+  });
+});
+
+describe('formatFilterQuery', () => {
+  it('round-trips through parse', () => {
+    const input = 'level:error,fatal release:2.1.0 events:100..500 timeout';
+    const { filters, search } = parseFilterQuery(input, variants);
+
+    expect(formatFilterQuery(filters, search, variants)).toBe(input);
+  });
+
+  it('quotes a text value with spaces', () => {
+    expect(
+      formatFilterQuery(
+        [{ id: 'release', value: 'not deployed' }],
+        '',
+        variants,
+      ),
+    ).toBe('release:"not deployed"');
+  });
+
+  it('drops empty filters instead of writing empty tokens', () => {
+    expect(
+      formatFilterQuery(
+        [
+          { id: 'level', value: [] },
+          { id: 'events', value: [null, null] },
+          { id: 'release', value: '' },
+        ],
+        '',
+        variants,
+      ),
+    ).toBe('');
+  });
+});
+
+describe('URL round-trip', () => {
+  it('serializes only what is not at its default', () => {
+    const params = serializeTableQuery(emptyTableQuery(), variants);
+
+    expect(params.toString()).toBe('');
+  });
+
+  it('round-trips a full query', () => {
+    const query = {
+      sorting: [{ id: 'events', desc: true }],
+      filters: [{ id: 'level', value: ['error'] }],
+      search: 'timeout',
+      pagination: { pageIndex: 2, pageSize: 25 },
+    };
+
+    const params = serializeTableQuery(query, variants);
+    expect(params.get('q')).toBe('level:error timeout');
+    expect(params.get('sort')).toBe('-events');
+    expect(params.get('page')).toBe('3');
+    expect(params.get('per')).toBe('25');
+
+    expect(parseTableQuery(params, variants)).toEqual(query);
+  });
+
+  it('survives a mangled address by degrading to defaults', () => {
+    const params = new URLSearchParams('page=-4&per=abc&sort=');
+    const query = parseTableQuery(params, variants);
+
+    expect(query).toEqual(emptyTableQuery());
+  });
+});

--- a/packages/ui/src/components/data-table/query.ts
+++ b/packages/ui/src/components/data-table/query.ts
@@ -58,14 +58,26 @@ export function emptyTableQuery(
 
 const TOKEN = /^([A-Za-z0-9_.-]+):(.*)$/;
 
-/** Splits on spaces, except inside double quotes: `level:"not found"`. */
+/**
+ * Splits on spaces, except inside double quotes: `level:"not found"`. A
+ * backslash escapes a quote or another backslash inside the quoted section,
+ * so `level:"say \"hi\""` keeps its embedded quotes rather than ending early.
+ */
 function tokenize(input: string): string[] {
   const tokens: string[] = [];
   let current = '';
   let quoted = false;
 
-  for (const char of input) {
-    if (char === '"') {
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+    if (
+      quoted &&
+      char === '\\' &&
+      (input[i + 1] === '"' || input[i + 1] === '\\')
+    ) {
+      current += input[i + 1];
+      i++;
+    } else if (char === '"') {
       quoted = !quoted;
     } else if (char === ' ' && !quoted) {
       if (current) tokens.push(current);
@@ -168,7 +180,11 @@ export function formatFilterQuery(
         tokens.push(`${id}:${min ?? ''}..${max ?? ''}`);
       }
     } else if (variant === 'text' && typeof value === 'string' && value) {
-      tokens.push(value.includes(' ') ? `${id}:"${value}"` : `${id}:${value}`);
+      tokens.push(
+        value.includes(' ')
+          ? `${id}:"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+          : `${id}:${value}`,
+      );
     }
   }
 

--- a/packages/ui/src/components/data-table/query.ts
+++ b/packages/ui/src/components/data-table/query.ts
@@ -1,0 +1,252 @@
+import type {
+  ColumnFiltersState,
+  PaginationState,
+  SortingState,
+} from '@tanstack/react-table';
+import type { ColumnFilterSpec } from './features';
+
+/**
+ * Everything about a table that belongs in the URL: what is filtered, what is
+ * sorted, which page. Share the address and the other person sees your list.
+ *
+ * Selection and column visibility are deliberately not here. A selection is a
+ * gesture, not a place -- restoring "3 rows ticked" from a pasted link would
+ * tick rows the reader never chose. Visibility is a personal reading
+ * preference, and personal preferences do not travel.
+ *
+ * The package never touches the URL itself: the app owns the router, whatever
+ * it is. These are the shapes plus a pair of pure codecs, `parseTableQuery`
+ * and `serializeTableQuery`, so every app writes the same URLs without any of
+ * them depending on how the others navigate.
+ */
+export interface DataTableQuery {
+  sorting: SortingState;
+  filters: ColumnFiltersState;
+  /** Free text: whatever was typed that no `key:` claimed. */
+  search: string;
+  pagination: PaginationState;
+}
+
+/**
+ * What the filter half of a column's value looks like in state, by variant:
+ * `options` holds `string[]`, `text` holds `string`, `range` holds
+ * `[min, max]` with `null` for an open end.
+ */
+export type FilterVariants = Record<string, ColumnFilterSpec['variant']>;
+
+export const DEFAULT_PAGE_SIZE = 50;
+
+export function emptyTableQuery(
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): DataTableQuery {
+  return {
+    sorting: [],
+    filters: [],
+    search: '',
+    pagination: { pageIndex: 0, pageSize },
+  };
+}
+
+/* --- The q string -------------------------------------------------------- */
+
+/*
+ * One string carries the filters and the free text: `level:error,fatal
+ * release:2.1.0 timeout`. It is the same string the query bar edits, which is
+ * the point -- the URL is the bar's value, so copying the address copies the
+ * search, and there is no second syntax to learn.
+ */
+
+const TOKEN = /^([A-Za-z0-9_.-]+):(.*)$/;
+
+/** Splits on spaces, except inside double quotes: `level:"not found"`. */
+function tokenize(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quoted = false;
+
+  for (const char of input) {
+    if (char === '"') {
+      quoted = !quoted;
+    } else if (char === ' ' && !quoted) {
+      if (current) tokens.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function parseRange(raw: string): [number | null, number | null] | null {
+  const parts = raw.split('..');
+  if (parts.length !== 2) return null;
+  const min = parts[0] === '' ? null : Number(parts[0]);
+  const max = parts[1] === '' ? null : Number(parts[1]);
+  if (min !== null && Number.isNaN(min)) return null;
+  if (max !== null && Number.isNaN(max)) return null;
+  if (min === null && max === null) return null;
+  return [min, max];
+}
+
+/**
+ * Reads a query string into filters and free text.
+ *
+ * A `key:` the table has no filterable column for stays free text rather than
+ * becoming a phantom filter: `error:` at the start of a pasted stack trace is
+ * prose, not a request.
+ */
+export function parseFilterQuery(
+  input: string,
+  variants: FilterVariants,
+): { filters: ColumnFiltersState; search: string } {
+  const filters: ColumnFiltersState = [];
+  const text: string[] = [];
+
+  for (const token of tokenize(input)) {
+    const match = token.match(TOKEN);
+    const id = match?.[1];
+    const raw = match?.[2];
+    const variant = id ? variants[id] : undefined;
+    if (id === undefined || raw === undefined || !variant) {
+      text.push(token);
+      continue;
+    }
+    // A known key with nothing after the colon says nothing: `level:` is a
+    // question abandoned mid-sentence, not prose and not a filter.
+    if (raw === '') continue;
+    if (variant === 'options') {
+      const values = raw.split(',').filter(Boolean);
+      if (values.length) filters.push({ id, value: values });
+    } else if (variant === 'range') {
+      const range = parseRange(raw);
+      if (range) filters.push({ id, value: range });
+      else text.push(token);
+    } else {
+      filters.push({ id, value: raw });
+    }
+  }
+
+  return { filters: mergeFilters(filters), search: text.join(' ') };
+}
+
+/** The same key twice merges rather than duplicating: `level:a level:b`. */
+function mergeFilters(filters: ColumnFiltersState): ColumnFiltersState {
+  const merged: ColumnFiltersState = [];
+  for (const filter of filters) {
+    const existing = merged.find((f) => f.id === filter.id);
+    if (
+      existing &&
+      Array.isArray(existing.value) &&
+      Array.isArray(filter.value)
+    ) {
+      existing.value = [...new Set([...existing.value, ...filter.value])];
+    } else if (!existing) {
+      merged.push({ ...filter });
+    } else {
+      existing.value = filter.value;
+    }
+  }
+  return merged;
+}
+
+/** Writes filters and free text back into the one string `parse` reads. */
+export function formatFilterQuery(
+  filters: ColumnFiltersState,
+  search: string,
+  variants: FilterVariants,
+): string {
+  const tokens: string[] = [];
+
+  for (const { id, value } of filters) {
+    const variant = variants[id];
+    if (variant === 'options' && Array.isArray(value) && value.length) {
+      tokens.push(`${id}:${value.join(',')}`);
+    } else if (variant === 'range' && Array.isArray(value)) {
+      const [min, max] = value as [number | null, number | null];
+      if (min !== null || max !== null) {
+        tokens.push(`${id}:${min ?? ''}..${max ?? ''}`);
+      }
+    } else if (variant === 'text' && typeof value === 'string' && value) {
+      tokens.push(value.includes(' ') ? `${id}:"${value}"` : `${id}:${value}`);
+    }
+  }
+
+  if (search) tokens.push(search);
+  return tokens.join(' ');
+}
+
+/* --- The URL ------------------------------------------------------------- */
+
+/*
+ * Four parameters, every one omitted at its default so a fresh table is a
+ * clean address: `?q=level:error&sort=-events&page=3&per=25`. The page is
+ * 1-based in the URL and 0-based in state, because an address is read by
+ * people and an index is read by an array.
+ */
+
+export function parseTableQuery(
+  params: URLSearchParams,
+  variants: FilterVariants,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): DataTableQuery {
+  const query = emptyTableQuery(pageSize);
+
+  const q = params.get('q');
+  if (q) {
+    const parsed = parseFilterQuery(q, variants);
+    query.filters = parsed.filters;
+    query.search = parsed.search;
+  }
+
+  const sort = params.get('sort');
+  if (sort) {
+    query.sorting = sort
+      .split(',')
+      .filter(Boolean)
+      .map((part) =>
+        part.startsWith('-')
+          ? { id: part.slice(1), desc: true }
+          : { id: part, desc: false },
+      );
+  }
+
+  const page = Number(params.get('page'));
+  if (Number.isInteger(page) && page > 1) {
+    query.pagination.pageIndex = page - 1;
+  }
+
+  const per = Number(params.get('per'));
+  if (Number.isInteger(per) && per > 0) {
+    query.pagination.pageSize = per;
+  }
+
+  return query;
+}
+
+export function serializeTableQuery(
+  query: DataTableQuery,
+  variants: FilterVariants,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): URLSearchParams {
+  const params = new URLSearchParams();
+
+  const q = formatFilterQuery(query.filters, query.search, variants);
+  if (q) params.set('q', q);
+
+  if (query.sorting.length) {
+    params.set(
+      'sort',
+      query.sorting.map((s) => (s.desc ? `-${s.id}` : s.id)).join(','),
+    );
+  }
+
+  if (query.pagination.pageIndex > 0) {
+    params.set('page', String(query.pagination.pageIndex + 1));
+  }
+  if (query.pagination.pageSize !== pageSize) {
+    params.set('per', String(query.pagination.pageSize));
+  }
+
+  return params;
+}

--- a/packages/ui/src/components/data-table/query.ts
+++ b/packages/ui/src/components/data-table/query.ts
@@ -90,6 +90,15 @@ function tokenize(input: string): string[] {
   return tokens;
 }
 
+/** A space or a quote forces quoting; a bare quote or backslash would else read as syntax. */
+function needsQuoting(value: string): boolean {
+  return /[\s"\\]/.test(value);
+}
+
+function quoteValue(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 function parseRange(raw: string): [number | null, number | null] | null {
   const parts = raw.split('..');
   if (parts.length !== 2) return null;
@@ -180,15 +189,11 @@ export function formatFilterQuery(
         tokens.push(`${id}:${min ?? ''}..${max ?? ''}`);
       }
     } else if (variant === 'text' && typeof value === 'string' && value) {
-      tokens.push(
-        value.includes(' ')
-          ? `${id}:"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
-          : `${id}:${value}`,
-      );
+      tokens.push(`${id}:${needsQuoting(value) ? quoteValue(value) : value}`);
     }
   }
 
-  if (search) tokens.push(search);
+  if (search) tokens.push(needsQuoting(search) ? quoteValue(search) : search);
   return tokens.join(' ');
 }
 

--- a/packages/ui/src/components/data-table/use-data-table.tsx
+++ b/packages/ui/src/components/data-table/use-data-table.tsx
@@ -1,0 +1,210 @@
+import {
+  type ColumnVisibilityState,
+  functionalUpdate,
+  type ReactTable,
+  type Row,
+  type RowData,
+  type RowSelectionState,
+  type Updater,
+  useTable,
+} from '@tanstack/react-table';
+import { useState } from 'react';
+import { Button } from '../button/button';
+import { Checkbox } from '../checkbox/checkbox';
+import { OverflowIcon } from '../icon/icon-catalog';
+import { Menu } from '../menu/menu';
+import type { MenuAction } from '../menu/menu-parts';
+import {
+  type DataTableColumnDef,
+  type DataTableFeatures,
+  dataTableFeatures,
+} from './features';
+import type { DataTableQuery } from './query';
+
+/** The table instance, with the Rustrak features baked into the type. */
+export type DataTableInstance<TData extends RowData> = ReactTable<
+  DataTableFeatures,
+  TData
+>;
+
+export interface UseDataTableOptions<TData extends RowData> {
+  /** One page, exactly as the server returned it. */
+  data: TData[];
+  columns: DataTableColumnDef<TData>[];
+  /** How many rows exist across every page. Drives the footer and the count. */
+  rowCount: number;
+  /** The URL-worthy state. The table proposes changes; the owner applies them. */
+  query: DataTableQuery;
+  onQueryChange: (
+    updater: (previous: DataTableQuery) => DataTableQuery,
+  ) => void;
+  /**
+   * The row's identity for selection, which must survive a refetch: an index
+   * would tick whatever row happens to land third after the next poll.
+   */
+  getRowId?: (row: TData) => string;
+  /** Adds the checkbox column and Shift-click range selection. */
+  enableSelection?: boolean;
+  /**
+   * The actions a row offers, as data. Adds a fixed last column holding the
+   * one control every row ends with: the ⋯ menu. Actions as `MenuAction[]`
+   * rather than JSX, for the same reason `Menu` takes them that way -- the
+   * list is data, and data does not drift between rows.
+   */
+  rowMenu?: (row: Row<DataTableFeatures, TData>) => MenuAction[];
+}
+
+/**
+ * The state half of the table: TanStack Table v9 in fully manual mode.
+ *
+ * The server filters, sorts and paginates -- this hook registers no client row
+ * models, so there is no code path in which the table second-guesses a page
+ * the server already shaped. What the hook owns is the *proposal* side:
+ * a header click proposes a sort, and the proposal lands in `onQueryChange`
+ * as a pure updater for whoever owns the state -- a `useState` in Storybook,
+ * the URL in the dashboard.
+ *
+ * Any change of filters, search or sort rewinds to the first page in the same
+ * update. Manual pagination switches TanStack's auto-reset off, so without
+ * this line a narrowed search would leave you stranded on page 7 of a
+ * result that now has one page -- and it must happen here, atomically, not as
+ * an effect in the app that briefly requests page 7 of the new query.
+ *
+ * Selection and column visibility stay inside the hook: they are gestures and
+ * reading preferences, not places, so they do not belong to the URL owner
+ * (see `DataTableQuery`).
+ */
+export function useDataTable<TData extends RowData>({
+  data,
+  columns,
+  rowCount,
+  query,
+  onQueryChange,
+  getRowId,
+  enableSelection = false,
+  rowMenu,
+}: UseDataTableOptions<TData>): DataTableInstance<TData> {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [columnVisibility, setColumnVisibility] =
+    useState<ColumnVisibilityState>({});
+
+  const allColumns = [
+    ...(enableSelection ? [selectionColumn<TData>()] : []),
+    ...columns,
+    ...(rowMenu ? [menuColumn<TData>(rowMenu)] : []),
+  ];
+
+  function applyQuery<TSlice extends 'sorting' | 'filters' | 'search'>(
+    slice: TSlice,
+    updater: Updater<DataTableQuery[TSlice]>,
+  ) {
+    onQueryChange((previous) => ({
+      ...previous,
+      [slice]: functionalUpdate(updater, previous[slice]),
+      pagination: { ...previous.pagination, pageIndex: 0 },
+    }));
+  }
+
+  return useTable<DataTableFeatures, TData>({
+    features: dataTableFeatures,
+    columns: allColumns,
+    data,
+    getRowId,
+    rowCount,
+    manualSorting: true,
+    manualFiltering: true,
+    manualPagination: true,
+    enableRowSelection: enableSelection,
+    state: {
+      sorting: query.sorting,
+      columnFilters: query.filters,
+      globalFilter: query.search,
+      pagination: query.pagination,
+      rowSelection,
+      columnVisibility,
+    },
+    onSortingChange: (updater) => applyQuery('sorting', updater),
+    onColumnFiltersChange: (updater) => applyQuery('filters', updater),
+    onGlobalFilterChange: (updater) => applyQuery('search', updater),
+    onPaginationChange: (updater) =>
+      onQueryChange((previous) => ({
+        ...previous,
+        pagination: functionalUpdate(updater, previous.pagination),
+      })),
+    onRowSelectionChange: setRowSelection,
+    onColumnVisibilityChange: setColumnVisibility,
+  });
+}
+
+/**
+ * The checkbox column, injected rather than configured: every selectable
+ * table in the product gets the identical first column, and identical is the
+ * point.
+ *
+ * The header box reports the page, not the result: "all" means all 50 rows in
+ * front of you, because ticking a box must never select the 12,000 rows it
+ * stands for. Bulk actions on the whole result are a different, spoken-out
+ * gesture.
+ */
+function selectionColumn<TData extends RowData>(): DataTableColumnDef<TData> {
+  return {
+    id: 'select',
+    enableSorting: false,
+    enableHiding: false,
+    header: ({ table }) => {
+      const all = table.getIsAllPageRowsSelected();
+      return (
+        <Checkbox
+          aria-label="Select all rows on this page"
+          checked={all}
+          indeterminate={table.getIsSomePageRowsSelected() && !all}
+          onCheckedChange={() => table.toggleAllPageRowsSelected()}
+        />
+      );
+    },
+    cell: ({ row }) => (
+      <Checkbox
+        aria-label="Select row"
+        checked={row.getIsSelected()}
+        disabled={!row.getCanSelect()}
+        onCheckedChange={(checked) => row.toggleSelected(checked)}
+      />
+    ),
+  };
+}
+
+/**
+ * The ⋯ column: always the last one, always visible, one width.
+ *
+ * The actions used to surface on hover, riding the row's right edge. That
+ * pattern went: what only exists under the pointer cannot be discovered by
+ * reading, does not exist on a touch screen, and covered the very figures
+ * the row was sorted by. A resting ⋯ costs 40 px and answers "what can I do
+ * to this row?" before the question is asked.
+ */
+function menuColumn<TData extends RowData>(
+  rowMenu: (row: Row<DataTableFeatures, TData>) => MenuAction[],
+): DataTableColumnDef<TData> {
+  return {
+    id: 'actions',
+    enableSorting: false,
+    enableHiding: false,
+    header: () => <span className="sr-only">Actions</span>,
+    cell: ({ row }) => (
+      <span className="flex items-center justify-end">
+        <Menu
+          align="end"
+          actions={rowMenu(row)}
+          trigger={
+            <Button
+              variant="ghost"
+              size="xs"
+              icon={OverflowIcon}
+              aria-label="Row actions"
+            />
+          }
+        />
+      </span>
+    ),
+  };
+}

--- a/packages/ui/src/components/data-table/use-data-table.tsx
+++ b/packages/ui/src/components/data-table/use-data-table.tsx
@@ -84,6 +84,15 @@ export function useDataTable<TData extends RowData>({
   enableSelection = false,
   rowMenu,
 }: UseDataTableOptions<TData>): DataTableInstance<TData> {
+  if (process.env.NODE_ENV !== 'production' && enableSelection && !getRowId) {
+    // TanStack falls back to the row's index, which selection can't survive:
+    // a refetch or a page change reassigns "row 0" to a different row.
+    console.error(
+      'useDataTable: enableSelection is true without getRowId. Selection ' +
+        'will not survive a refetch or a page change -- pass getRowId.',
+    );
+  }
+
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [columnVisibility, setColumnVisibility] =
     useState<ColumnVisibilityState>({});

--- a/packages/ui/src/components/data-table/use-data-table.tsx
+++ b/packages/ui/src/components/data-table/use-data-table.tsx
@@ -98,11 +98,15 @@ export function useDataTable<TData extends RowData>({
     slice: TSlice,
     updater: Updater<DataTableQuery[TSlice]>,
   ) {
-    onQueryChange((previous) => ({
-      ...previous,
-      [slice]: functionalUpdate(updater, previous[slice]),
-      pagination: { ...previous.pagination, pageIndex: 0 },
-    }));
+    onQueryChange((previous) => {
+      const next = functionalUpdate(updater, previous[slice]);
+      return {
+        ...previous,
+        // TanStack's global filter can be set to `undefined`; `search` never is.
+        [slice]: slice === 'search' && next == null ? '' : next,
+        pagination: { ...previous.pagination, pageIndex: 0 },
+      };
+    });
   }
 
   return useTable<DataTableFeatures, TData>({

--- a/packages/ui/src/components/popover/popover.stories.tsx
+++ b/packages/ui/src/components/popover/popover.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { Button } from '../button/button';
+import { FilterIcon } from '../icon/icon-catalog';
+import { Text } from '../text/text';
+import { Popover } from './popover';
+
+const meta = {
+  title: 'Components/Popover',
+  component: Popover,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Popover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    trigger: (
+      <Button variant="secondary" icon={FilterIcon}>
+        Filter
+      </Button>
+    ),
+    title: 'Level',
+    hints: ['↑↓ move', 'Esc closes'],
+    children: (
+      <div className="flex flex-col gap-1 p-3">
+        <Text variant="body">Interactive content lives here.</Text>
+      </div>
+    ),
+  },
+};
+
+/**
+ * The contract a menu cannot offer: the panel contains an input, focus lands on
+ * it, and Escape hands focus back to the trigger.
+ */
+export const FocusHandling: Story = {
+  args: {
+    trigger: (
+      <Button variant="secondary" icon={FilterIcon}>
+        Filter
+      </Button>
+    ),
+    title: 'Level',
+    children: (
+      <div className="p-3">
+        <input
+          type="text"
+          aria-label="Filter values"
+          placeholder="Filter…"
+          className="h-control-sm w-full rounded-md border border-border-field bg-canvas px-2 text-control text-fg outline-none placeholder:text-fg-placeholder"
+        />
+      </div>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Filter' });
+
+    await userEvent.click(trigger);
+    const dialog = await within(document.body).findByRole('dialog');
+    await expect(dialog).toBeInTheDocument();
+
+    // The panel is content, not a menu: its input accepts typing.
+    const input = within(dialog).getByRole('textbox', {
+      name: 'Filter values',
+    });
+    await userEvent.click(input);
+    await userEvent.keyboard('error');
+    await expect(input).toHaveValue('error');
+
+    // Escape closes and the focus comes home -- after the exit transition.
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(trigger).toHaveFocus());
+  },
+};

--- a/packages/ui/src/components/popover/popover.tsx
+++ b/packages/ui/src/components/popover/popover.tsx
@@ -1,0 +1,127 @@
+import { Popover as BasePopover } from '@base-ui/react/popover';
+import type { ReactElement, ReactNode } from 'react';
+import { popTransition } from '../../lib/motion';
+import { tv } from '../../lib/tv';
+
+/**
+ * A floating panel with interactive content: a filter with its search field, a
+ * date range with its presets.
+ *
+ * It exists beside `Menu` because the two manage focus differently, and the
+ * difference is the whole point. A menu owns focus -- arrow keys walk items,
+ * typing selects by first letter -- which is exactly wrong for a panel whose
+ * first element is an input. A popover hands focus to its content and lets it
+ * be content.
+ *
+ * The surface itself -- radius, border, shadow, entry -- matches the menu's
+ * recipe line for line, on purpose: to the person looking at it, both are "a
+ * panel out of that button", and two shades of the same panel would read as a
+ * bug.
+ */
+const popover = tv({
+  slots: {
+    // See the note on Menu: the stacking level must ride on the positioner,
+    // because Base UI's `position: fixed` opens a stacking context there.
+    positioner: 'z-50',
+    popup: [
+      'flex max-h-(--available-height) min-w-52 flex-col',
+      'overflow-x-hidden overflow-y-auto',
+      'rounded-lg border border-border bg-surface-floating',
+      'shadow-overlay',
+      'outline-none',
+      popTransition,
+    ],
+    /*
+     * The header names what the panel filters: "Nivel", "Eventos". It reads as
+     * a column heading rather than a title because that is what it is -- the
+     * column, restated where the cursor now is.
+     */
+    title: [
+      'border-border-subtle border-b px-3 pt-2.5 pb-2',
+      'font-mono text-column text-fg-meta uppercase',
+    ],
+    /*
+     * The keyboard footer, same as the menu's: every panel in the product ends
+     * with one, because its users live in the keyboard.
+     */
+    hints: [
+      'flex shrink-0 gap-3.5 border-border-subtle border-t',
+      'px-3 pt-2 pb-2 font-mono text-mono-sm text-fg-ghost',
+    ],
+  },
+});
+
+const styles = popover();
+
+export interface PopoverProps {
+  /** What opens it. Must accept props and a ref: a `Button`, for example. */
+  trigger: ReactElement;
+  children: ReactNode;
+  /** The heading that names the subject. Omitted, the content starts at once. */
+  title?: string;
+  /** The keyboard footer: `['↑↓ move', 'Enter applies', 'Esc closes']`. */
+  hints?: string[];
+  side?: BasePopover.Positioner.Props['side'];
+  align?: BasePopover.Positioner.Props['align'];
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * The panel's measurements, for content that needs more than the minimum.
+   * Size and padding only; the surface comes from the recipe.
+   */
+  popupClassName?: string;
+  /**
+   * Where focus lands when the panel opens. Base UI's default is the popup
+   * itself; a filter panel points this at its search input instead, so the
+   * panel opens ready to be typed into.
+   */
+  initialFocus?: BasePopover.Popup.Props['initialFocus'];
+}
+
+export function Popover({
+  trigger,
+  children,
+  title,
+  hints,
+  side = 'bottom',
+  align = 'start',
+  open,
+  onOpenChange,
+  popupClassName,
+  initialFocus,
+}: PopoverProps) {
+  return (
+    <BasePopover.Root open={open} onOpenChange={onOpenChange}>
+      <BasePopover.Trigger render={trigger} />
+      <BasePopover.Portal>
+        <BasePopover.Positioner
+          side={side}
+          align={align}
+          sideOffset={6}
+          className={styles.positioner()}
+        >
+          <BasePopover.Popup
+            initialFocus={initialFocus}
+            className={styles.popup({ className: popupClassName })}
+          >
+            {title ? (
+              <BasePopover.Title className={styles.title()}>
+                {title}
+              </BasePopover.Title>
+            ) : null}
+            {children}
+            {hints?.length ? (
+              <span aria-hidden="true" className={styles.hints()}>
+                {hints.map((hint) => (
+                  <span key={hint}>{hint}</span>
+                ))}
+              </span>
+            ) : null}
+          </BasePopover.Popup>
+        </BasePopover.Positioner>
+      </BasePopover.Portal>
+    </BasePopover.Root>
+  );
+}
+
+Popover.displayName = 'Popover';

--- a/packages/ui/src/components/query-bar/query-bar-parts.test.ts
+++ b/packages/ui/src/components/query-bar/query-bar-parts.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { DataTableColumnDef } from '../data-table/features';
+import { queryFieldsFromColumns, variantsFromFields } from './query-bar-parts';
+
+interface Issue {
+  title: string;
+  release: string;
+  'nested.key': string;
+}
+
+describe('queryFieldsFromColumns', () => {
+  it('reads a filterable column that names its id explicitly', () => {
+    const columns: DataTableColumnDef<Issue>[] = [
+      { id: 'title', header: 'Title', meta: { filter: { variant: 'text' } } },
+    ];
+
+    expect(queryFieldsFromColumns(columns)).toEqual([
+      { key: 'title', label: 'Title', icon: undefined, variant: 'text' },
+    ]);
+  });
+
+  it('falls back to accessorKey when a column has no explicit id', () => {
+    const columns: DataTableColumnDef<Issue>[] = [
+      {
+        accessorKey: 'release',
+        header: 'Release',
+        meta: { filter: { variant: 'text' } },
+      },
+    ];
+
+    expect(queryFieldsFromColumns(columns)).toEqual([
+      { key: 'release', label: 'Release', icon: undefined, variant: 'text' },
+    ]);
+  });
+
+  it('replaces dots in a nested accessorKey the way the table does', () => {
+    const columns: DataTableColumnDef<Issue>[] = [
+      {
+        accessorKey: 'nested.key',
+        header: 'Nested',
+        meta: { filter: { variant: 'text' } },
+      },
+    ];
+
+    expect(queryFieldsFromColumns(columns)[0]?.key).toBe('nested_key');
+  });
+});
+
+describe('variantsFromFields', () => {
+  it('maps each field key to its variant', () => {
+    const fields = queryFieldsFromColumns<Issue>([
+      { id: 'title', meta: { filter: { variant: 'text' } } },
+      { accessorKey: 'release', meta: { filter: { variant: 'options' } } },
+    ]);
+
+    expect(variantsFromFields(fields)).toEqual({
+      title: 'text',
+      release: 'options',
+    });
+  });
+});

--- a/packages/ui/src/components/query-bar/query-bar-parts.ts
+++ b/packages/ui/src/components/query-bar/query-bar-parts.ts
@@ -1,0 +1,59 @@
+import type { RowData } from '@tanstack/react-table';
+import type { DataTableColumnDef, FilterOption } from '../data-table/features';
+import type { FilterVariants } from '../data-table/query';
+import type { IconComponent } from '../icon/icon';
+
+/** A field the bar can complete: what `key:` means and what it takes. */
+export interface QueryField {
+  key: string;
+  label: string;
+  icon?: IconComponent;
+  /** Read in the suggestion row: "severity of the issue". */
+  description?: string;
+  variant: 'options' | 'text' | 'range';
+  options?: readonly FilterOption[];
+  loadOptions?: () => Promise<FilterOption[]>;
+  /** Options only: whether several values can hold at once. Default true. */
+  multiple?: boolean;
+}
+
+/**
+ * The bar's fields, read straight off the table's columns so the two can
+ * never disagree about what is filterable or what it is called.
+ */
+export function queryFieldsFromColumns<TData extends RowData>(
+  columns: DataTableColumnDef<TData>[],
+): QueryField[] {
+  const fields: QueryField[] = [];
+  for (const column of columns) {
+    const meta = column.meta;
+    const id = column.id;
+    if (!meta?.filter || !id) continue;
+    const label =
+      meta.label ?? (typeof column.header === 'string' ? column.header : id);
+    if (meta.filter.variant === 'options') {
+      fields.push({
+        key: id,
+        label,
+        icon: meta.icon,
+        variant: 'options',
+        options: meta.filter.options,
+        loadOptions: meta.filter.loadOptions,
+        multiple: meta.filter.multiple,
+      });
+    } else {
+      fields.push({
+        key: id,
+        label,
+        icon: meta.icon,
+        variant: meta.filter.variant,
+      });
+    }
+  }
+  return fields;
+}
+
+/** The variants map the codecs in `query.ts` take, from the same fields. */
+export function variantsFromFields(fields: QueryField[]): FilterVariants {
+  return Object.fromEntries(fields.map((field) => [field.key, field.variant]));
+}

--- a/packages/ui/src/components/query-bar/query-bar-parts.ts
+++ b/packages/ui/src/components/query-bar/query-bar-parts.ts
@@ -27,7 +27,20 @@ export function queryFieldsFromColumns<TData extends RowData>(
   const fields: QueryField[] = [];
   for (const column of columns) {
     const meta = column.meta;
-    const id = column.id;
+    /*
+     * `column.id` is only set when the definition names it explicitly: the
+     * table derives an id from `accessorKey` itself, but only once these
+     * definitions reach `useTable` -- reading them here, first, sees none of
+     * that. Redo the same derivation TanStack does, so an accessor-only
+     * filterable column is not silently dropped from the bar.
+     */
+    const accessorKey =
+      'accessorKey' in column ? column.accessorKey : undefined;
+    const id =
+      column.id ??
+      (typeof accessorKey === 'string'
+        ? accessorKey.replaceAll('.', '_')
+        : undefined);
     if (!meta?.filter || !id) continue;
     const label =
       meta.label ?? (typeof column.header === 'string' ? column.header : id);

--- a/packages/ui/src/components/query-bar/query-bar.stories.tsx
+++ b/packages/ui/src/components/query-bar/query-bar.stories.tsx
@@ -87,6 +87,19 @@ export const Basic: Story = {
   render: () => <Harness />,
 };
 
+/** Every state side by side: resting, chips of each variant, free text. */
+export const States: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Harness />
+      <Harness initialFilters={[{ id: 'level', value: ['error', 'fatal'] }]} />
+      <Harness initialFilters={[{ id: 'events', value: [100, null] }]} />
+      <Harness initialSearch="connection reset" />
+    </div>
+  ),
+};
+
 export const WithFilters: Story = {
   render: () => (
     <Harness

--- a/packages/ui/src/components/query-bar/query-bar.stories.tsx
+++ b/packages/ui/src/components/query-bar/query-bar.stories.tsx
@@ -184,6 +184,34 @@ export const FreeText: Story = {
   },
 };
 
+/**
+ * A second Escape, once the popup is already closed, clears the committed
+ * search along with the draft -- an empty bar must not filter on hidden text.
+ */
+export const EscapeClearsACommittedSearch: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox');
+
+    await userEvent.click(input);
+    await userEvent.keyboard('connection reset{Escape}{Enter}');
+    await waitFor(() =>
+      expect(canvas.getByTestId('committed').textContent).toContain(
+        'search="connection reset"',
+      ),
+    );
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(canvas.getByTestId('committed').textContent).toContain(
+        'search=""',
+      );
+      expect(input).toHaveValue('');
+    });
+  },
+};
+
 /** Backspace on an empty input eats the last chip, like every tag input. */
 export const RemoveWithBackspace: Story = {
   render: () => (

--- a/packages/ui/src/components/query-bar/query-bar.stories.tsx
+++ b/packages/ui/src/components/query-bar/query-bar.stories.tsx
@@ -5,7 +5,8 @@ import { expect, userEvent, waitFor, within } from 'storybook/test';
 import type { FilterOption } from '../data-table/features';
 import { IssuesIcon, ReleasesIcon, TimeIcon } from '../icon/icon-catalog';
 import { Text } from '../text/text';
-import { QueryBar, type QueryField } from './query-bar';
+import { QueryBar } from './query-bar';
+import type { QueryField } from './query-bar-parts';
 
 const LEVELS: FilterOption[] = [
   { value: 'fatal', label: 'Fatal', tone: 'error', count: 5 },

--- a/packages/ui/src/components/query-bar/query-bar.stories.tsx
+++ b/packages/ui/src/components/query-bar/query-bar.stories.tsx
@@ -1,0 +1,228 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ColumnFiltersState } from '@tanstack/react-table';
+import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { FilterOption } from '../data-table/features';
+import { IssuesIcon, ReleasesIcon, TimeIcon } from '../icon/icon-catalog';
+import { Text } from '../text/text';
+import { QueryBar, type QueryField } from './query-bar';
+
+const LEVELS: FilterOption[] = [
+  { value: 'fatal', label: 'Fatal', tone: 'error', count: 5 },
+  { value: 'error', label: 'Error', tone: 'error', count: 97 },
+  { value: 'warning', label: 'Warning', tone: 'warning', count: 31 },
+  { value: 'info', label: 'Info', tone: 'info', count: 10 },
+];
+
+const RELEASES: FilterOption[] = Array.from({ length: 12 }, (_, index) => ({
+  value: `2.${11 - index}.0`,
+  label: `2.${11 - index}.0`,
+  count: ((index * 53) % 300) + 4,
+}));
+
+const FIELDS: QueryField[] = [
+  {
+    key: 'level',
+    label: 'Level',
+    icon: IssuesIcon,
+    description: 'severity',
+    variant: 'options',
+    options: LEVELS,
+  },
+  {
+    key: 'release',
+    label: 'Release',
+    icon: ReleasesIcon,
+    description: 'first seen in',
+    variant: 'options',
+    // Fetched when asked for, so the popup shows its skeleton first.
+    loadOptions: () =>
+      new Promise((resolve) => setTimeout(() => resolve(RELEASES), 600)),
+  },
+  {
+    key: 'events',
+    label: 'Events',
+    icon: TimeIcon,
+    description: 'count range',
+    variant: 'range',
+  },
+];
+
+function Harness({
+  initialFilters = [] as ColumnFiltersState,
+  initialSearch = '',
+}) {
+  const [filters, setFilters] = useState<ColumnFiltersState>(initialFilters);
+  const [search, setSearch] = useState(initialSearch);
+
+  return (
+    <div className="flex w-full max-w-160 flex-col gap-4">
+      <QueryBar
+        fields={FIELDS}
+        filters={filters}
+        search={search}
+        onChange={(next) => {
+          setFilters(next.filters);
+          setSearch(next.search);
+        }}
+      />
+      {/* The committed state, readable by eye and by the play functions. */}
+      <Text variant="mono-sm" tone="ghost" data-testid="committed">
+        filters={JSON.stringify(filters)} search={JSON.stringify(search)}
+      </Text>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Components/QueryBar',
+  component: QueryBar,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof QueryBar>;
+
+export default meta;
+type Story = StoryObj;
+
+export const Basic: Story = {
+  render: () => <Harness />,
+};
+
+export const WithFilters: Story = {
+  render: () => (
+    <Harness
+      initialFilters={[
+        { id: 'level', value: ['error', 'fatal'] },
+        { id: 'events', value: [100, null] },
+      ]}
+      initialSearch="timeout"
+    />
+  ),
+};
+
+/**
+ * The two-phase autocomplete: typing offers fields, choosing one turns the
+ * popup to its values, and a chosen value becomes a chip with the filter
+ * applied -- no Apply step anywhere.
+ */
+export const CompleteAFilter: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox');
+
+    await userEvent.click(input);
+    await userEvent.keyboard('lev');
+    const fieldOption = await canvas.findByRole('option', { name: /Level/ });
+    await expect(fieldOption).toBeInTheDocument();
+
+    // Enter takes the highlighted field. The phase is state, not prose: the
+    // input comes back clean and only the placeholder names the field.
+    await userEvent.keyboard('{Enter}');
+    await expect(input).toHaveValue('');
+    await expect(input).toHaveAttribute('placeholder', 'Level…');
+
+    // The popup now offers the field's values; picking one applies it.
+    await canvas.findByRole('option', { name: /Warning/ });
+    await userEvent.keyboard('warn{Enter}');
+    await expect(input).toHaveValue('');
+
+    await waitFor(() =>
+      expect(canvas.getByTestId('committed').textContent).toContain(
+        '{"id":"level","value":["warning"]}',
+      ),
+    );
+    await expect(canvas.getByText('level:')).toBeInTheDocument();
+    await expect(canvas.getByText('warning')).toBeInTheDocument();
+  },
+};
+
+/** What no key claims is the search, and Enter is what sends it. */
+export const FreeText: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox');
+
+    await userEvent.click(input);
+    await userEvent.keyboard('connection reset');
+    // Nothing commits while typing.
+    await expect(canvas.getByTestId('committed').textContent).toContain(
+      'search=""',
+    );
+
+    await userEvent.keyboard('{Escape}'); // suggestions out of the way
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() =>
+      expect(canvas.getByTestId('committed').textContent).toContain(
+        'search="connection reset"',
+      ),
+    );
+  },
+};
+
+/** Backspace on an empty input eats the last chip, like every tag input. */
+export const RemoveWithBackspace: Story = {
+  render: () => (
+    <Harness initialFilters={[{ id: 'level', value: ['error'] }]} />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox');
+
+    await userEvent.click(input);
+    await userEvent.keyboard('{Backspace}');
+    await waitFor(() =>
+      expect(canvas.getByTestId('committed').textContent).toContain(
+        'filters=[]',
+      ),
+    );
+  },
+};
+
+/**
+ * A phone-width bar wraps. Every chip stays visible and removable -- the
+ * field grows a row instead of clipping the third chip out of existence.
+ */
+export const Narrow: Story = {
+  render: () => (
+    <div className="w-80">
+      <Harness
+        initialFilters={[
+          { id: 'level', value: ['error', 'fatal'] },
+          { id: 'release', value: ['2.11.0'] },
+          { id: 'events', value: [100, null] },
+        ]}
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Nothing is clipped: all three filters keep their remove control.
+    for (const name of ['Level', 'Release', 'Events']) {
+      const remove = canvas.getByRole('button', {
+        name: `Remove ${name} filter`,
+      });
+      await expect(remove).toBeInTheDocument();
+      const box = remove.getBoundingClientRect();
+      await expect(box.width).toBeGreaterThan(0);
+    }
+  },
+};
+
+/** A typed token commits whole: `events:100..500` needs no popup at all. */
+export const TypedRange: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox');
+
+    await userEvent.click(input);
+    await userEvent.keyboard('events:100..500{Enter}');
+    await waitFor(() =>
+      expect(canvas.getByTestId('committed').textContent).toContain(
+        '{"id":"events","value":[100,500]}',
+      ),
+    );
+  },
+};

--- a/packages/ui/src/components/query-bar/query-bar.stories.tsx
+++ b/packages/ui/src/components/query-bar/query-bar.stories.tsx
@@ -21,6 +21,16 @@ const RELEASES: FilterOption[] = Array.from({ length: 12 }, (_, index) => ({
   count: ((index * 53) % 300) + 4,
 }));
 
+/** Rejects the first call, resolves every call after -- a transient failure. */
+function flakyLoadOptions() {
+  let attempt = 0;
+  return () => {
+    attempt += 1;
+    if (attempt === 1) return Promise.reject(new Error('network blip'));
+    return Promise.resolve(LEVELS);
+  };
+}
+
 const FIELDS: QueryField[] = [
   {
     key: 'level',
@@ -221,6 +231,57 @@ export const Narrow: Story = {
       const box = remove.getBoundingClientRect();
       await expect(box.width).toBeGreaterThan(0);
     }
+  },
+};
+
+/**
+ * A rejected load must not read as "loaded, and empty" forever: leaving the
+ * field and coming back has to retry rather than stay stuck.
+ */
+export const RetriesAfterAFailedLoad: Story = {
+  render: function RetriesAfterAFailedLoadStory() {
+    // One closure for the story's lifetime, so the second attempt is really
+    // the second call and not a fresh counter from a re-render.
+    const [loadOptions] = useState(() => flakyLoadOptions());
+    const [fields] = useState<QueryField[]>(() => [
+      ...FIELDS,
+      { key: 'flaky', label: 'Flaky', variant: 'options', loadOptions },
+    ]);
+    const [filters, setFilters] = useState<ColumnFiltersState>([]);
+    const [search, setSearch] = useState('');
+    return (
+      <QueryBar
+        fields={fields}
+        filters={filters}
+        search={search}
+        onChange={(next) => {
+          setFilters(next.filters);
+          setSearch(next.search);
+        }}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox');
+
+    await userEvent.click(input);
+    await userEvent.keyboard('flaky{Enter}');
+
+    // The first attempt rejects: the skeleton ends rather than spinning
+    // forever, and nothing is offered yet.
+    await waitFor(() =>
+      expect(canvas.getByText('Nothing matches')).toBeInTheDocument(),
+    );
+
+    // Leaving the field and picking it again is a new attempt.
+    await userEvent.keyboard('{Escape}');
+    await userEvent.keyboard('{Escape}');
+    await userEvent.keyboard('flaky{Enter}');
+
+    await waitFor(() =>
+      expect(canvas.getByRole('option', { name: /Fatal/ })).toBeInTheDocument(),
+    );
   },
 };
 

--- a/packages/ui/src/components/query-bar/query-bar.tsx
+++ b/packages/ui/src/components/query-bar/query-bar.tsx
@@ -1,0 +1,770 @@
+import type { ColumnFiltersState, RowData } from '@tanstack/react-table';
+import {
+  type KeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { focusRingWithin } from '../../lib/focus';
+import { dropIn, interactiveTransition } from '../../lib/motion';
+import { tv } from '../../lib/tv';
+import { Count } from '../count/count';
+import type { DataTableColumnDef, FilterOption } from '../data-table/features';
+import {
+  type FilterVariants,
+  formatFilterQuery,
+  parseFilterQuery,
+} from '../data-table/query';
+import type { IconComponent } from '../icon/icon';
+import {
+  CloseIcon,
+  FacetsIcon,
+  ResolveIcon,
+  SearchIcon,
+} from '../icon/icon-catalog';
+import { Kbd } from '../kbd/kbd';
+import type { TagTone } from '../tag/tag';
+
+/**
+ * The query bar: one line that holds the whole question.
+ *
+ * Filters live in it as `key:value` chips and free text rides after them, so
+ * the bar always reads back as the exact string `parseFilterQuery` accepts --
+ * what you see is what a teammate can paste. It edits the same
+ * `ColumnFiltersState` the column header panels edit: tick "Warning" in the
+ * Level column and a chip appears here; delete the chip and the column's
+ * funnel goes out. One state, two views of it.
+ *
+ * The autocomplete works in two phases, the way GitHub's does. Typing offers
+ * the *fields* that can be asked about; choosing one writes `level:` and the
+ * popup turns to that field's *values*, ticking live as they are chosen.
+ * Free text never needs a phase: whatever no key claims is the search, and
+ * Enter sends it.
+ */
+const queryBar = tv({
+  slots: {
+    root: 'relative min-w-0 flex-1',
+    /*
+     * The bar wraps rather than clips. A fixed-height field with
+     * `overflow-hidden` chips read fine until a phone: the third chip
+     * disappeared with no trace, and what cannot be seen cannot be removed.
+     * `min-h` keeps the resting bar at exactly the 36 px it always was; only
+     * a second row of chips makes it taller, and the vertical padding is
+     * what keeps the wrapped rows off the border.
+     */
+    field: [
+      'flex min-h-control-lg w-full min-w-0 flex-wrap items-center gap-1.5',
+      'rounded-md border border-border bg-surface ps-2.5 pe-1.5 py-1',
+      'cursor-text',
+      interactiveTransition,
+      'hover:border-border-strong',
+      focusRingWithin,
+    ],
+    // `contents`: the chips are flex items of the field itself, so they
+    // share its wrapping instead of clipping inside a nested row.
+    chips: 'contents',
+    chip: [
+      'flex h-chip max-w-full shrink-0 items-center rounded-xs bg-surface-chip',
+      'ps-2 pe-0.5 font-mono text-mono-sm',
+      'animate-swap-in motion-reduce:animate-none',
+    ],
+    chipKey: 'shrink-0 text-fg-subtle',
+    // A value longer than the viewport keeps its chip on one line and says
+    // the rest with an ellipsis.
+    chipValue: 'ms-0.5 min-w-0 truncate text-fg',
+    chipRemove: [
+      'ms-0.5 flex size-4.5 items-center justify-center rounded-2xs',
+      'text-fg-ghost outline-none',
+      interactiveTransition,
+      'hover:bg-surface-selected hover:text-fg',
+      'focus-visible:bg-surface-selected focus-visible:text-fg',
+    ],
+    // Its own height, not `h-full`: in a wrapped field, full height would be
+    // every row at once and the caret would sit in the middle of them.
+    input: [
+      'h-chip min-w-24 flex-1 bg-transparent text-control text-fg',
+      'outline-none placeholder:text-fg-placeholder',
+    ],
+    clear: [
+      'flex size-6 shrink-0 items-center justify-center rounded-sm',
+      'text-fg-ghost outline-none',
+      interactiveTransition,
+      'hover:bg-surface-selected hover:text-fg',
+      'focus-visible:bg-surface-selected focus-visible:text-fg',
+    ],
+    popup: [
+      'absolute inset-x-0 top-full z-50 mt-1.5',
+      // The list is what scrolls: the keyboard footer stays put, because the
+      // person scrolling a long value list is exactly who needs it.
+      'flex max-h-80 flex-col overflow-hidden',
+      'rounded-lg border border-border bg-surface-floating p-1.25',
+      'shadow-overlay',
+      dropIn,
+    ],
+    list: 'min-h-0 flex-1 overflow-x-hidden overflow-y-auto',
+    groupLabel: 'px-2.5 pt-2 pb-1 font-mono text-column text-fg-meta uppercase',
+    option: [
+      'flex h-menu-item shrink-0 cursor-default items-center gap-2.5',
+      'rounded-sm px-2.5 text-control text-fg-muted select-none',
+      'transition-none outline-none',
+      'data-[highlighted=true]:bg-surface-selected data-[highlighted=true]:text-fg',
+    ],
+    optionIcon: 'shrink-0 text-fg-ghost',
+    optionBox: [
+      'flex size-3.5 shrink-0 items-center justify-center',
+      'rounded-xs border border-border-control text-fg-on-brand',
+      'data-[ticked=true]:border-surface-brand data-[ticked=true]:bg-surface-brand',
+    ],
+    optionDot: 'size-dot shrink-0 rounded-pill',
+    optionLabel: 'min-w-0 flex-1 truncate text-start',
+    optionHint: 'ms-auto shrink-0 truncate text-fg-ghost text-hint',
+    skeleton: 'mx-2.5 my-2 h-3 animate-pulse rounded-xs bg-surface-chip',
+    hints: [
+      'mt-1 flex shrink-0 items-center gap-3.5 border-border-subtle border-t',
+      'px-2.5 pt-2 pb-1 font-mono text-fg-ghost text-mono-sm',
+    ],
+  },
+});
+
+const styles = queryBar();
+
+const TONE_DOT: Record<TagTone, string> = {
+  error: 'bg-sev-error',
+  warning: 'bg-sev-warning',
+  info: 'bg-sev-info',
+  brand: 'bg-surface-brand',
+  neutral: 'bg-fg-ghost',
+};
+
+/** A field the bar can complete: what `key:` means and what it takes. */
+export interface QueryField {
+  key: string;
+  label: string;
+  icon?: IconComponent;
+  /** Read in the suggestion row: "severity of the issue". */
+  description?: string;
+  variant: 'options' | 'text' | 'range';
+  options?: readonly FilterOption[];
+  loadOptions?: () => Promise<FilterOption[]>;
+  /** Options only: whether several values can hold at once. Default true. */
+  multiple?: boolean;
+}
+
+/**
+ * The bar's fields, read straight off the table's columns so the two can
+ * never disagree about what is filterable or what it is called.
+ */
+export function queryFieldsFromColumns<TData extends RowData>(
+  columns: DataTableColumnDef<TData>[],
+): QueryField[] {
+  const fields: QueryField[] = [];
+  for (const column of columns) {
+    const meta = column.meta;
+    const id = column.id;
+    if (!meta?.filter || !id) continue;
+    const label =
+      meta.label ?? (typeof column.header === 'string' ? column.header : id);
+    if (meta.filter.variant === 'options') {
+      fields.push({
+        key: id,
+        label,
+        icon: meta.icon,
+        variant: 'options',
+        options: meta.filter.options,
+        loadOptions: meta.filter.loadOptions,
+        multiple: meta.filter.multiple,
+      });
+    } else {
+      fields.push({
+        key: id,
+        label,
+        icon: meta.icon,
+        variant: meta.filter.variant,
+      });
+    }
+  }
+  return fields;
+}
+
+/** The variants map the codecs in `query.ts` take, from the same fields. */
+export function variantsFromFields(fields: QueryField[]): FilterVariants {
+  return Object.fromEntries(fields.map((field) => [field.key, field.variant]));
+}
+
+type Suggestion =
+  | { kind: 'field'; field: QueryField }
+  | { kind: 'value'; field: QueryField; option: FilterOption }
+  | { kind: 'search'; text: string };
+
+export interface QueryBarProps {
+  fields: QueryField[];
+  filters: ColumnFiltersState;
+  search: string;
+  onChange: (next: { filters: ColumnFiltersState; search: string }) => void;
+  placeholder?: string;
+  /** Named in the field's accessible name; there may be several bars. */
+  label?: string;
+  className?: string;
+}
+
+export function QueryBar({
+  fields,
+  filters,
+  search,
+  onChange,
+  placeholder = 'Filter by key:value, or search…',
+  label = 'Filter and search',
+  className,
+}: QueryBarProps) {
+  const id = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [draft, setDraft] = useState(search);
+  const [open, setOpen] = useState(false);
+  /*
+   * The field whose values the popup is offering, held as state rather than
+   * as text. Choosing "Level" used to write `level:` into the input to carry
+   * the phase; the token then sat there, fixed, beside every chip it
+   * produced. The phase is not prose, so it no longer lives in the prose --
+   * the input stays clean and the popup stays on the field's values until
+   * Escape, blur or a single-choice pick ends it. Typing `level:` by hand
+   * still works: the token form is the same question asked in writing.
+   */
+  const [pickedKey, setPickedKey] = useState<string | null>(null);
+  const [highlighted, setHighlighted] = useState(0);
+  const [loadedOptions, setLoadedOptions] = useState<
+    Record<string, FilterOption[]>
+  >({});
+
+  const variants = useMemo(() => variantsFromFields(fields), [fields]);
+
+  /*
+   * The draft belongs to the bar while it is being typed, but the committed
+   * search belongs to the owner: when it changes from outside (a cleared
+   * query, a navigated URL), the bar must show it.
+   */
+  const lastSearch = useRef(search);
+  if (search !== lastSearch.current) {
+    lastSearch.current = search;
+    setDraft(search);
+  }
+
+  /* --- Phase detection --------------------------------------------------- */
+
+  const tokenMatch = draft.match(/(^|\s)([A-Za-z0-9_.-]+):(\S*)$/);
+  const typedField = tokenMatch
+    ? fields.find((field) => field.key === tokenMatch[2])
+    : undefined;
+  const pickedField = pickedKey
+    ? fields.find((field) => field.key === pickedKey)
+    : undefined;
+  const activeField = pickedField ?? typedField;
+
+  /*
+   * Only the word under the caret is being completed; whatever stands before
+   * it is already said and survives the completion. So `timeout lev` offers
+   * Level, and taking it keeps `timeout` -- the fragment is replaced,
+   * never appended to.
+   */
+  const fragmentMatch = draft.match(/(^|\s)(\S*)$/);
+  const fragment = fragmentMatch?.[2] ?? '';
+  const fragmentPrefix = draft.slice(
+    0,
+    (fragmentMatch?.index ?? 0) + (fragmentMatch?.[1]?.length ?? 0),
+  );
+
+  // With a picked field, whatever is being typed narrows its values.
+  const valueFragment = pickedField
+    ? fragment
+    : typedField
+      ? (tokenMatch?.[3] ?? '')
+      : '';
+  const fieldNeedle = activeField ? '' : fragment.toLowerCase();
+  const prefix =
+    !pickedField && typedField
+      ? draft.slice(
+          0,
+          (tokenMatch?.index ?? 0) + (tokenMatch?.[1]?.length ?? 0),
+        )
+      : fragmentPrefix;
+
+  const fieldOptions = activeField
+    ? (activeField.options ?? loadedOptions[activeField.key])
+    : undefined;
+  const optionsPending = Boolean(
+    activeField?.loadOptions &&
+      !activeField.options &&
+      !loadedOptions[activeField.key],
+  );
+
+  const pendingKey = optionsPending ? activeField?.key : undefined;
+  const pendingLoad = optionsPending ? activeField?.loadOptions : undefined;
+  useEffect(() => {
+    if (!pendingKey || !pendingLoad) return;
+    let cancelled = false;
+    pendingLoad().then((options) => {
+      if (!cancelled) {
+        setLoadedOptions((previous) => ({
+          ...previous,
+          [pendingKey]: options,
+        }));
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingKey, pendingLoad]);
+
+  /* --- Suggestions ------------------------------------------------------- */
+
+  const selectedValues = (key: string): string[] => {
+    const filter = filters.find((f) => f.id === key);
+    return Array.isArray(filter?.value) ? (filter.value as string[]) : [];
+  };
+
+  const suggestions = useMemo<Suggestion[]>(() => {
+    if (activeField) {
+      if (activeField.variant !== 'options') return [];
+      const needle = valueFragment.split(',').pop()?.toLowerCase() ?? '';
+      return (fieldOptions ?? [])
+        .filter(
+          (option) =>
+            !needle ||
+            option.label.toLowerCase().includes(needle) ||
+            option.value.toLowerCase().includes(needle),
+        )
+        .map((option) => ({ kind: 'value', field: activeField, option }));
+    }
+
+    const matches = fields
+      .filter(
+        (field) =>
+          !fieldNeedle ||
+          field.label.toLowerCase().includes(fieldNeedle) ||
+          field.key.toLowerCase().includes(fieldNeedle),
+      )
+      .map<Suggestion>((field) => ({ kind: 'field', field }));
+
+    // The search row rides last: when fields match what was typed, the
+    // structured question is the better default under Enter.
+    return draft.trim()
+      ? [...matches, { kind: 'search', text: draft.trim() }]
+      : matches;
+  }, [activeField, valueFragment, fieldOptions, draft, fields]);
+
+  // Reaching past the end after a list shrinks parks on the last row.
+  const highlightIndex = Math.min(
+    highlighted,
+    Math.max(suggestions.length - 1, 0),
+  );
+
+  /* --- Commits ----------------------------------------------------------- */
+
+  function commitDraft(next: string) {
+    const parsed = parseFilterQuery(next, variants);
+    const untouched = filters.filter(
+      (filter) => !parsed.filters.some((f) => f.id === filter.id),
+    );
+    onChange({
+      filters: [...untouched, ...parsed.filters],
+      search: parsed.search,
+    });
+    setDraft(parsed.search);
+  }
+
+  function toggleValue(field: QueryField, option: FilterOption) {
+    const selected = selectedValues(field.key);
+    const has = selected.includes(option.value);
+    const multiple = field.multiple ?? true;
+    const nextValues = multiple
+      ? has
+        ? selected.filter((value) => value !== option.value)
+        : [...selected, option.value]
+      : has
+        ? []
+        : [option.value];
+
+    const rest = filters.filter((filter) => filter.id !== field.key);
+    onChange({
+      filters: nextValues.length
+        ? [...rest, { id: field.key, value: nextValues }]
+        : rest,
+      search,
+    });
+
+    /*
+     * The typed fragment leaves the draft the moment it is real as a chip.
+     * A multi-value field stays picked so the list stays on its values --
+     * `level:error,fatal` is two ticks in a row, not two round trips through
+     * the field list -- but the phase lives in `pickedKey`, never as a
+     * `key:` parked in the input.
+     */
+    setDraft(prefix.trimEnd() ? `${prefix.trimEnd()} ` : '');
+    if (multiple) {
+      setPickedKey(field.key);
+    } else {
+      setPickedKey(null);
+      setOpen(false);
+    }
+    inputRef.current?.focus();
+  }
+
+  function apply(suggestion: Suggestion) {
+    if (suggestion.kind === 'field') {
+      const kept = prefix.trimEnd() ? `${prefix.trimEnd()} ` : '';
+      if (suggestion.field.variant === 'options') {
+        // The phase is state; the input hands over its fragment and stays
+        // clean while the popup turns to the field's values.
+        setPickedKey(suggestion.field.key);
+        setDraft(kept);
+      } else {
+        // A text or range value is typed, so the token is started in
+        // writing: `events:` waiting for its `100..500`.
+        setDraft(`${kept}${suggestion.field.key}:`);
+      }
+      setHighlighted(0);
+      inputRef.current?.focus();
+      return;
+    }
+    if (suggestion.kind === 'value') {
+      toggleValue(suggestion.field, suggestion.option);
+      return;
+    }
+    commitDraft(draft);
+    setOpen(false);
+  }
+
+  function removeFilter(key: string) {
+    onChange({
+      filters: filters.filter((filter) => filter.id !== key),
+      search,
+    });
+    inputRef.current?.focus();
+  }
+
+  function clearAll() {
+    onChange({ filters: [], search: '' });
+    setDraft('');
+    inputRef.current?.focus();
+  }
+
+  /* --- Keyboard ---------------------------------------------------------- */
+
+  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!open) {
+        setOpen(true);
+        return;
+      }
+      const delta = event.key === 'ArrowDown' ? 1 : -1;
+      const next =
+        (highlightIndex + delta + suggestions.length) %
+        Math.max(suggestions.length, 1);
+      setHighlighted(next);
+      // The list scrolls, the input keeps focus: the highlighted row has to
+      // be brought along by hand.
+      document
+        .getElementById(`${id}-option-${next}`)
+        ?.scrollIntoView({ block: 'nearest' });
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const current = suggestions[highlightIndex];
+      if (open && current) {
+        apply(current);
+      } else {
+        commitDraft(draft);
+        setOpen(false);
+        setPickedKey(null);
+      }
+      return;
+    }
+
+    if (event.key === 'Tab' && open) {
+      const current = suggestions[highlightIndex];
+      if (current && current.kind === 'field') {
+        event.preventDefault();
+        apply(current);
+      }
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      if (open) {
+        setOpen(false);
+        setPickedKey(null);
+      } else if (draft) {
+        setDraft('');
+      }
+      return;
+    }
+
+    if (event.key === 'Backspace' && draft === '') {
+      // First step out of the picked field, then start eating chips.
+      if (pickedKey) {
+        setPickedKey(null);
+        return;
+      }
+      const last = filters[filters.length - 1];
+      if (last) removeFilter(last.id);
+    }
+  }
+
+  /* --- Rendering --------------------------------------------------------- */
+
+  const chips = filters
+    .map((filter) => {
+      const field = fields.find((f) => f.key === filter.id);
+      if (!field) return null;
+      const text = formatFilterQuery([filter], '', variants);
+      const value = text.startsWith(`${filter.id}:`)
+        ? text.slice(filter.id.length + 1)
+        : text;
+      if (!value) return null;
+      return { key: filter.id, label: field.label, value };
+    })
+    .filter((chip) => chip !== null);
+
+  const listboxId = `${id}-listbox`;
+  const showClear = chips.length > 0 || search !== '' || draft !== '';
+
+  return (
+    <div ref={rootRef} className={styles.root({ className })}>
+      {/* The field is a click target for the input inside it -- the whole
+          bar must feel like one text field, chips included. */}
+      <div className={styles.field()} onClick={() => inputRef.current?.focus()}>
+        <SearchIcon size="lg" className="shrink-0 text-fg-ghost" />
+
+        {chips.length ? (
+          <span className={styles.chips()}>
+            {chips.map((chip) => (
+              <span key={`${chip.key}:${chip.value}`} className={styles.chip()}>
+                <span className={styles.chipKey()}>{chip.key}:</span>
+                <span className={styles.chipValue()}>{chip.value}</span>
+                <button
+                  type="button"
+                  aria-label={`Remove ${chip.label} filter`}
+                  className={styles.chipRemove()}
+                  onClick={() => removeFilter(chip.key)}
+                >
+                  <CloseIcon size="sm" aria-hidden="true" />
+                </button>
+              </span>
+            ))}
+          </span>
+        ) : null}
+
+        <input
+          ref={inputRef}
+          type="text"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listboxId}
+          aria-activedescendant={
+            open && suggestions[highlightIndex]
+              ? `${id}-option-${highlightIndex}`
+              : undefined
+          }
+          aria-autocomplete="list"
+          aria-label={label}
+          value={draft}
+          placeholder={
+            pickedField
+              ? `${pickedField.label}…`
+              : chips.length
+                ? 'Add a filter…'
+                : placeholder
+          }
+          autoComplete="off"
+          spellCheck={false}
+          className={styles.input()}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setHighlighted(0);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={(event) => {
+            // Leaving for the popup is not leaving. And leaving commits
+            // nothing: half a question walked away from is not a question.
+            if (!rootRef.current?.contains(event.relatedTarget)) {
+              setOpen(false);
+              setPickedKey(null);
+            }
+          }}
+          onKeyDown={onKeyDown}
+        />
+
+        {showClear ? (
+          <button
+            type="button"
+            aria-label="Clear filters and search"
+            className={styles.clear()}
+            onClick={clearAll}
+          >
+            <CloseIcon size="md" aria-hidden="true" />
+          </button>
+        ) : null}
+      </div>
+
+      {open ? (
+        <div className={styles.popup()} data-side="bottom">
+          {activeField && activeField.variant === 'options' ? (
+            <div className={styles.groupLabel()}>{activeField.label}</div>
+          ) : null}
+          {!activeField && suggestions.some((s) => s.kind === 'field') ? (
+            <div className={styles.groupLabel()}>Filter by</div>
+          ) : null}
+
+          <div
+            role="listbox"
+            id={listboxId}
+            aria-label="Suggestions"
+            className={styles.list()}
+          >
+            {optionsPending
+              ? [0, 1, 2].map((line) => (
+                  <div
+                    key={line}
+                    aria-hidden="true"
+                    className={styles.skeleton()}
+                  />
+                ))
+              : null}
+
+            {suggestions.map((suggestion, index) => {
+              const highlightedRow = index === highlightIndex;
+              const shared = {
+                id: `${id}-option-${index}`,
+                'data-highlighted': highlightedRow,
+                className: styles.option(),
+                onMouseEnter: () => setHighlighted(index),
+                // Fires before the input's blur: the click must win.
+                onMouseDown: (event: ReactMouseEvent) => event.preventDefault(),
+                onClick: () => apply(suggestion),
+              };
+
+              if (suggestion.kind === 'field') {
+                const Icon = suggestion.field.icon ?? FacetsIcon;
+                return (
+                  <div
+                    key={`field-${suggestion.field.key}`}
+                    {...shared}
+                    role="option"
+                    // Steered from the input via aria-activedescendant.
+                    tabIndex={-1}
+                    aria-selected={false}
+                  >
+                    <Icon size="lg" className={styles.optionIcon()} />
+                    <span className={styles.optionLabel()}>
+                      {suggestion.field.label}
+                    </span>
+                    <span className={styles.optionHint()}>
+                      {suggestion.field.description ??
+                        `${suggestion.field.key}:`}
+                    </span>
+                  </div>
+                );
+              }
+
+              if (suggestion.kind === 'value') {
+                const ticked = selectedValues(suggestion.field.key).includes(
+                  suggestion.option.value,
+                );
+                return (
+                  <div
+                    key={`value-${suggestion.option.value}`}
+                    {...shared}
+                    role="option"
+                    tabIndex={-1}
+                    aria-selected={ticked}
+                  >
+                    <span
+                      aria-hidden="true"
+                      data-ticked={ticked}
+                      className={styles.optionBox()}
+                    >
+                      {ticked ? (
+                        <ResolveIcon size="sm" aria-hidden="true" />
+                      ) : null}
+                    </span>
+                    {suggestion.option.tone ? (
+                      <span
+                        aria-hidden="true"
+                        className={styles.optionDot({
+                          className: TONE_DOT[suggestion.option.tone],
+                        })}
+                      />
+                    ) : null}
+                    <span className={styles.optionLabel()}>
+                      {suggestion.option.label}
+                    </span>
+                    {suggestion.option.hint ? (
+                      <span className={styles.optionHint()}>
+                        {suggestion.option.hint}
+                      </span>
+                    ) : null}
+                    <Count>{suggestion.option.count}</Count>
+                  </div>
+                );
+              }
+
+              return (
+                <div
+                  key="search"
+                  {...shared}
+                  role="option"
+                  tabIndex={-1}
+                  aria-selected={false}
+                >
+                  <SearchIcon size="lg" className={styles.optionIcon()} />
+                  <span className={styles.optionLabel()}>
+                    Search “{suggestion.text}”
+                  </span>
+                  <Kbd>⏎</Kbd>
+                </div>
+              );
+            })}
+
+            {activeField && activeField.variant === 'range' ? (
+              <div className={styles.option()}>
+                <span className={styles.optionLabel()}>
+                  Type a range: {activeField.key}:100..500, then
+                </span>
+                <Kbd>⏎</Kbd>
+              </div>
+            ) : null}
+            {activeField && activeField.variant === 'text' ? (
+              <div className={styles.option()}>
+                <span className={styles.optionLabel()}>Type a value, then</span>
+                <Kbd>⏎</Kbd>
+              </div>
+            ) : null}
+
+            {!optionsPending &&
+            suggestions.length === 0 &&
+            activeField?.variant === 'options' ? (
+              <div className="px-2.5 py-3 text-center text-control text-fg-ghost">
+                Nothing matches
+              </div>
+            ) : null}
+          </div>
+
+          <span aria-hidden="true" className={styles.hints()}>
+            <span>↑↓ navigate</span>
+            <span>⏎ select</span>
+            <span>esc closes</span>
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+QueryBar.displayName = 'QueryBar';

--- a/packages/ui/src/components/query-bar/query-bar.tsx
+++ b/packages/ui/src/components/query-bar/query-bar.tsx
@@ -305,14 +305,21 @@ export function QueryBar({
   useEffect(() => {
     if (!pendingKey || !pendingLoad) return;
     let cancelled = false;
-    pendingLoad().then((options) => {
-      if (!cancelled) {
-        setLoadedOptions((previous) => ({
-          ...previous,
-          [pendingKey]: options,
-        }));
-      }
-    });
+    pendingLoad()
+      .then((options) => {
+        if (!cancelled) {
+          setLoadedOptions((previous) => ({
+            ...previous,
+            [pendingKey]: options,
+          }));
+        }
+      })
+      .catch(() => {
+        // An empty list ends the skeleton and reads as "nothing to offer".
+        if (!cancelled) {
+          setLoadedOptions((previous) => ({ ...previous, [pendingKey]: [] }));
+        }
+      });
     return () => {
       cancelled = true;
     };
@@ -435,6 +442,7 @@ export function QueryBar({
     }
     commitDraft(draft);
     setOpen(false);
+    setPickedKey(null);
   }
 
   function removeFilter(key: string) {
@@ -622,115 +630,116 @@ export function QueryBar({
             <div className={styles.groupLabel()}>Filter by</div>
           ) : null}
 
-          <div
-            role="listbox"
-            id={listboxId}
-            aria-label="Suggestions"
-            className={styles.list()}
-          >
-            {optionsPending
-              ? [0, 1, 2].map((line) => (
-                  <div
-                    key={line}
-                    aria-hidden="true"
-                    className={styles.skeleton()}
-                  />
-                ))
-              : null}
+          <div className={styles.list()}>
+            {optionsPending ? (
+              <div aria-hidden="true">
+                {[0, 1, 2].map((line) => (
+                  <div key={line} className={styles.skeleton()} />
+                ))}
+              </div>
+            ) : null}
 
-            {suggestions.map((suggestion, index) => {
-              const highlightedRow = index === highlightIndex;
-              const shared = {
-                id: `${id}-option-${index}`,
-                'data-highlighted': highlightedRow,
-                className: styles.option(),
-                onMouseEnter: () => setHighlighted(index),
-                // Fires before the input's blur: the click must win.
-                onMouseDown: (event: ReactMouseEvent) => event.preventDefault(),
-                onClick: () => apply(suggestion),
-              };
+            <div
+              role="listbox"
+              id={listboxId}
+              aria-label="Suggestions"
+              aria-busy={optionsPending || undefined}
+            >
+              {suggestions.map((suggestion, index) => {
+                const highlightedRow = index === highlightIndex;
+                const shared = {
+                  id: `${id}-option-${index}`,
+                  'data-highlighted': highlightedRow,
+                  className: styles.option(),
+                  onMouseEnter: () => setHighlighted(index),
+                  // Fires before the input's blur: the click must win.
+                  onMouseDown: (event: ReactMouseEvent) =>
+                    event.preventDefault(),
+                  onClick: () => apply(suggestion),
+                };
 
-              if (suggestion.kind === 'field') {
-                const Icon = suggestion.field.icon ?? FacetsIcon;
+                if (suggestion.kind === 'field') {
+                  const Icon = suggestion.field.icon ?? FacetsIcon;
+                  return (
+                    <div
+                      key={`field-${suggestion.field.key}`}
+                      {...shared}
+                      role="option"
+                      // Steered from the input via aria-activedescendant.
+                      tabIndex={-1}
+                      aria-selected={false}
+                    >
+                      <Icon size="lg" className={styles.optionIcon()} />
+                      <span className={styles.optionLabel()}>
+                        {suggestion.field.label}
+                      </span>
+                      <span className={styles.optionHint()}>
+                        {suggestion.field.description ??
+                          `${suggestion.field.key}:`}
+                      </span>
+                    </div>
+                  );
+                }
+
+                if (suggestion.kind === 'value') {
+                  const ticked = selectedValues(suggestion.field.key).includes(
+                    suggestion.option.value,
+                  );
+                  return (
+                    <div
+                      key={`value-${suggestion.option.value}`}
+                      {...shared}
+                      role="option"
+                      tabIndex={-1}
+                      aria-selected={ticked}
+                    >
+                      <span
+                        aria-hidden="true"
+                        data-ticked={ticked}
+                        className={styles.optionBox()}
+                      >
+                        {ticked ? (
+                          <ResolveIcon size="sm" aria-hidden="true" />
+                        ) : null}
+                      </span>
+                      {suggestion.option.tone ? (
+                        <span
+                          aria-hidden="true"
+                          className={styles.optionDot({
+                            className: TONE_DOT[suggestion.option.tone],
+                          })}
+                        />
+                      ) : null}
+                      <span className={styles.optionLabel()}>
+                        {suggestion.option.label}
+                      </span>
+                      {suggestion.option.hint ? (
+                        <span className={styles.optionHint()}>
+                          {suggestion.option.hint}
+                        </span>
+                      ) : null}
+                      <Count>{suggestion.option.count}</Count>
+                    </div>
+                  );
+                }
+
                 return (
                   <div
-                    key={`field-${suggestion.field.key}`}
+                    key="search"
                     {...shared}
                     role="option"
-                    // Steered from the input via aria-activedescendant.
                     tabIndex={-1}
                     aria-selected={false}
                   >
-                    <Icon size="lg" className={styles.optionIcon()} />
+                    <SearchIcon size="lg" className={styles.optionIcon()} />
                     <span className={styles.optionLabel()}>
-                      {suggestion.field.label}
+                      Search “{suggestion.text}”
                     </span>
-                    <span className={styles.optionHint()}>
-                      {suggestion.field.description ??
-                        `${suggestion.field.key}:`}
-                    </span>
+                    <Kbd>⏎</Kbd>
                   </div>
                 );
-              }
-
-              if (suggestion.kind === 'value') {
-                const ticked = selectedValues(suggestion.field.key).includes(
-                  suggestion.option.value,
-                );
-                return (
-                  <div
-                    key={`value-${suggestion.option.value}`}
-                    {...shared}
-                    role="option"
-                    tabIndex={-1}
-                    aria-selected={ticked}
-                  >
-                    <span
-                      aria-hidden="true"
-                      data-ticked={ticked}
-                      className={styles.optionBox()}
-                    >
-                      {ticked ? (
-                        <ResolveIcon size="sm" aria-hidden="true" />
-                      ) : null}
-                    </span>
-                    {suggestion.option.tone ? (
-                      <span
-                        aria-hidden="true"
-                        className={styles.optionDot({
-                          className: TONE_DOT[suggestion.option.tone],
-                        })}
-                      />
-                    ) : null}
-                    <span className={styles.optionLabel()}>
-                      {suggestion.option.label}
-                    </span>
-                    {suggestion.option.hint ? (
-                      <span className={styles.optionHint()}>
-                        {suggestion.option.hint}
-                      </span>
-                    ) : null}
-                    <Count>{suggestion.option.count}</Count>
-                  </div>
-                );
-              }
-
-              return (
-                <div
-                  key="search"
-                  {...shared}
-                  role="option"
-                  tabIndex={-1}
-                  aria-selected={false}
-                >
-                  <SearchIcon size="lg" className={styles.optionIcon()} />
-                  <span className={styles.optionLabel()}>
-                    Search “{suggestion.text}”
-                  </span>
-                  <Kbd>⏎</Kbd>
-                </div>
-              );
-            })}
+              })}
+            </div>
 
             {activeField && activeField.variant === 'range' ? (
               <div className={styles.option()}>

--- a/packages/ui/src/components/query-bar/query-bar.tsx
+++ b/packages/ui/src/components/query-bar/query-bar.tsx
@@ -1,24 +1,9 @@
-import type { ColumnFiltersState, RowData } from '@tanstack/react-table';
-import {
-  type KeyboardEvent,
-  type MouseEvent as ReactMouseEvent,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import type { ColumnFiltersState } from '@tanstack/react-table';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import { focusRingWithin } from '../../lib/focus';
 import { dropIn, interactiveTransition } from '../../lib/motion';
 import { tv } from '../../lib/tv';
 import { Count } from '../count/count';
-import type { DataTableColumnDef, FilterOption } from '../data-table/features';
-import {
-  type FilterVariants,
-  formatFilterQuery,
-  parseFilterQuery,
-} from '../data-table/query';
-import type { IconComponent } from '../icon/icon';
 import {
   CloseIcon,
   FacetsIcon,
@@ -27,6 +12,8 @@ import {
 } from '../icon/icon-catalog';
 import { Kbd } from '../kbd/kbd';
 import type { TagTone } from '../tag/tag';
+import type { QueryField } from './query-bar-parts';
+import { type Suggestion, useQueryBar } from './use-query-bar';
 
 /**
  * The query bar: one line that holds the whole question.
@@ -139,65 +126,195 @@ const TONE_DOT: Record<TagTone, string> = {
   neutral: 'bg-fg-ghost',
 };
 
-/** A field the bar can complete: what `key:` means and what it takes. */
-export interface QueryField {
-  key: string;
-  label: string;
-  icon?: IconComponent;
-  /** Read in the suggestion row: "severity of the issue". */
-  description?: string;
-  variant: 'options' | 'text' | 'range';
-  options?: readonly FilterOption[];
-  loadOptions?: () => Promise<FilterOption[]>;
-  /** Options only: whether several values can hold at once. Default true. */
-  multiple?: boolean;
+function suggestionKey(suggestion: Suggestion): string {
+  if (suggestion.kind === 'field') return `field-${suggestion.field.key}`;
+  if (suggestion.kind === 'value') return `value-${suggestion.option.value}`;
+  return 'search';
 }
 
-/**
- * The bar's fields, read straight off the table's columns so the two can
- * never disagree about what is filterable or what it is called.
- */
-export function queryFieldsFromColumns<TData extends RowData>(
-  columns: DataTableColumnDef<TData>[],
-): QueryField[] {
-  const fields: QueryField[] = [];
-  for (const column of columns) {
-    const meta = column.meta;
-    const id = column.id;
-    if (!meta?.filter || !id) continue;
-    const label =
-      meta.label ?? (typeof column.header === 'string' ? column.header : id);
-    if (meta.filter.variant === 'options') {
-      fields.push({
-        key: id,
-        label,
-        icon: meta.icon,
-        variant: 'options',
-        options: meta.filter.options,
-        loadOptions: meta.filter.loadOptions,
-        multiple: meta.filter.multiple,
-      });
-    } else {
-      fields.push({
-        key: id,
-        label,
-        icon: meta.icon,
-        variant: meta.filter.variant,
-      });
-    }
+interface SuggestionRowProps {
+  suggestion: Suggestion;
+  optionId: string;
+  highlighted: boolean;
+  ticked: boolean;
+  onHighlight: () => void;
+  onSelect: () => void;
+}
+
+/** One row of the popup: a field to pick, a value to tick, or the search itself. */
+function SuggestionRow({
+  suggestion,
+  optionId,
+  highlighted,
+  ticked,
+  onHighlight,
+  onSelect,
+}: SuggestionRowProps) {
+  const shared = {
+    id: optionId,
+    'data-highlighted': highlighted,
+    className: styles.option(),
+    onMouseEnter: onHighlight,
+    // Fires before the input's blur: the click must win.
+    onMouseDown: (event: ReactMouseEvent) => event.preventDefault(),
+    onClick: onSelect,
+  };
+
+  if (suggestion.kind === 'field') {
+    const Icon = suggestion.field.icon ?? FacetsIcon;
+    return (
+      <div
+        {...shared}
+        role="option"
+        // Steered from the input via aria-activedescendant.
+        tabIndex={-1}
+        aria-selected={false}
+      >
+        <Icon size="lg" className={styles.optionIcon()} />
+        <span className={styles.optionLabel()}>{suggestion.field.label}</span>
+        <span className={styles.optionHint()}>
+          {suggestion.field.description ?? `${suggestion.field.key}:`}
+        </span>
+      </div>
+    );
   }
-  return fields;
+
+  if (suggestion.kind === 'value') {
+    return (
+      <div {...shared} role="option" tabIndex={-1} aria-selected={ticked}>
+        <span
+          aria-hidden="true"
+          data-ticked={ticked}
+          className={styles.optionBox()}
+        >
+          {ticked ? <ResolveIcon size="sm" aria-hidden="true" /> : null}
+        </span>
+        {suggestion.option.tone ? (
+          <span
+            aria-hidden="true"
+            className={styles.optionDot({
+              className: TONE_DOT[suggestion.option.tone],
+            })}
+          />
+        ) : null}
+        <span className={styles.optionLabel()}>{suggestion.option.label}</span>
+        {suggestion.option.hint ? (
+          <span className={styles.optionHint()}>{suggestion.option.hint}</span>
+        ) : null}
+        <Count>{suggestion.option.count}</Count>
+      </div>
+    );
+  }
+
+  return (
+    <div {...shared} role="option" tabIndex={-1} aria-selected={false}>
+      <SearchIcon size="lg" className={styles.optionIcon()} />
+      <span className={styles.optionLabel()}>Search “{suggestion.text}”</span>
+      <Kbd>⏎</Kbd>
+    </div>
+  );
 }
 
-/** The variants map the codecs in `query.ts` take, from the same fields. */
-export function variantsFromFields(fields: QueryField[]): FilterVariants {
-  return Object.fromEntries(fields.map((field) => [field.key, field.variant]));
+SuggestionRow.displayName = 'SuggestionRow';
+
+interface SuggestionsPopupProps {
+  id: string;
+  listboxId: string;
+  activeField: QueryField | undefined;
+  suggestions: Suggestion[];
+  optionsPending: boolean;
+  highlightIndex: number;
+  activeFieldSelected: Set<string>;
+  onHighlight: (index: number) => void;
+  onSelect: (suggestion: Suggestion) => void;
 }
 
-type Suggestion =
-  | { kind: 'field'; field: QueryField }
-  | { kind: 'value'; field: QueryField; option: FilterOption }
-  | { kind: 'search'; text: string };
+/** The floating panel under the bar: field or value suggestions, and the footer's hints. */
+function SuggestionsPopup({
+  id,
+  listboxId,
+  activeField,
+  suggestions,
+  optionsPending,
+  highlightIndex,
+  activeFieldSelected,
+  onHighlight,
+  onSelect,
+}: SuggestionsPopupProps) {
+  return (
+    <div className={styles.popup()} data-side="bottom">
+      {activeField && activeField.variant === 'options' ? (
+        <div className={styles.groupLabel()}>{activeField.label}</div>
+      ) : null}
+      {!activeField && suggestions.some((s) => s.kind === 'field') ? (
+        <div className={styles.groupLabel()}>Filter by</div>
+      ) : null}
+
+      <div className={styles.list()}>
+        {optionsPending ? (
+          <div aria-hidden="true">
+            {[0, 1, 2].map((line) => (
+              <div key={line} className={styles.skeleton()} />
+            ))}
+          </div>
+        ) : null}
+
+        <div
+          role="listbox"
+          id={listboxId}
+          aria-label="Suggestions"
+          aria-busy={optionsPending || undefined}
+        >
+          {suggestions.map((suggestion, index) => (
+            <SuggestionRow
+              key={suggestionKey(suggestion)}
+              suggestion={suggestion}
+              optionId={`${id}-option-${index}`}
+              highlighted={index === highlightIndex}
+              ticked={
+                suggestion.kind === 'value' &&
+                activeFieldSelected.has(suggestion.option.value)
+              }
+              onHighlight={() => onHighlight(index)}
+              onSelect={() => onSelect(suggestion)}
+            />
+          ))}
+        </div>
+
+        {activeField && activeField.variant === 'range' ? (
+          <div className={styles.option()}>
+            <span className={styles.optionLabel()}>
+              Type a range: {activeField.key}:100..500, then
+            </span>
+            <Kbd>⏎</Kbd>
+          </div>
+        ) : null}
+        {activeField && activeField.variant === 'text' ? (
+          <div className={styles.option()}>
+            <span className={styles.optionLabel()}>Type a value, then</span>
+            <Kbd>⏎</Kbd>
+          </div>
+        ) : null}
+
+        {!optionsPending &&
+        suggestions.length === 0 &&
+        activeField?.variant === 'options' ? (
+          <div className="px-2.5 py-3 text-center text-control text-fg-ghost">
+            Nothing matches
+          </div>
+        ) : null}
+      </div>
+
+      <span aria-hidden="true" className={styles.hints()}>
+        <span>↑↓ navigate</span>
+        <span>⏎ select</span>
+        <span>esc closes</span>
+      </span>
+    </div>
+  );
+}
+
+SuggestionsPopup.displayName = 'SuggestionsPopup';
 
 export interface QueryBarProps {
   fields: QueryField[];
@@ -219,328 +336,30 @@ export function QueryBar({
   label = 'Filter and search',
   className,
 }: QueryBarProps) {
-  const id = useId();
-  const inputRef = useRef<HTMLInputElement>(null);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [draft, setDraft] = useState(search);
-  const [open, setOpen] = useState(false);
-  /*
-   * The field whose values the popup is offering, held as state rather than
-   * as text. Choosing "Level" used to write `level:` into the input to carry
-   * the phase; the token then sat there, fixed, beside every chip it
-   * produced. The phase is not prose, so it no longer lives in the prose --
-   * the input stays clean and the popup stays on the field's values until
-   * Escape, blur or a single-choice pick ends it. Typing `level:` by hand
-   * still works: the token form is the same question asked in writing.
-   */
-  const [pickedKey, setPickedKey] = useState<string | null>(null);
-  const [highlighted, setHighlighted] = useState(0);
-  const [loadedOptions, setLoadedOptions] = useState<
-    Record<string, FilterOption[]>
-  >({});
-
-  const variants = useMemo(() => variantsFromFields(fields), [fields]);
-
-  /*
-   * The draft belongs to the bar while it is being typed, but the committed
-   * search belongs to the owner: when it changes from outside (a cleared
-   * query, a navigated URL), the bar must show it.
-   */
-  const lastSearch = useRef(search);
-  if (search !== lastSearch.current) {
-    lastSearch.current = search;
-    setDraft(search);
-  }
-
-  /* --- Phase detection --------------------------------------------------- */
-
-  const tokenMatch = draft.match(/(^|\s)([A-Za-z0-9_.-]+):(\S*)$/);
-  const typedField = tokenMatch
-    ? fields.find((field) => field.key === tokenMatch[2])
-    : undefined;
-  const pickedField = pickedKey
-    ? fields.find((field) => field.key === pickedKey)
-    : undefined;
-  const activeField = pickedField ?? typedField;
-
-  /*
-   * Only the word under the caret is being completed; whatever stands before
-   * it is already said and survives the completion. So `timeout lev` offers
-   * Level, and taking it keeps `timeout` -- the fragment is replaced,
-   * never appended to.
-   */
-  const fragmentMatch = draft.match(/(^|\s)(\S*)$/);
-  const fragment = fragmentMatch?.[2] ?? '';
-  const fragmentPrefix = draft.slice(
-    0,
-    (fragmentMatch?.index ?? 0) + (fragmentMatch?.[1]?.length ?? 0),
-  );
-
-  // With a picked field, whatever is being typed narrows its values.
-  const valueFragment = pickedField
-    ? fragment
-    : typedField
-      ? (tokenMatch?.[3] ?? '')
-      : '';
-  const fieldNeedle = activeField ? '' : fragment.toLowerCase();
-  const prefix =
-    !pickedField && typedField
-      ? draft.slice(
-          0,
-          (tokenMatch?.index ?? 0) + (tokenMatch?.[1]?.length ?? 0),
-        )
-      : fragmentPrefix;
-
-  const fieldOptions = activeField
-    ? (activeField.options ?? loadedOptions[activeField.key])
-    : undefined;
-  const optionsPending = Boolean(
-    activeField?.loadOptions &&
-      !activeField.options &&
-      !loadedOptions[activeField.key],
-  );
-
-  const pendingKey = optionsPending ? activeField?.key : undefined;
-  const pendingLoad = optionsPending ? activeField?.loadOptions : undefined;
-  useEffect(() => {
-    if (!pendingKey || !pendingLoad) return;
-    let cancelled = false;
-    pendingLoad()
-      .then((options) => {
-        if (!cancelled) {
-          setLoadedOptions((previous) => ({
-            ...previous,
-            [pendingKey]: options,
-          }));
-        }
-      })
-      .catch(() => {
-        // An empty list ends the skeleton and reads as "nothing to offer".
-        if (!cancelled) {
-          setLoadedOptions((previous) => ({ ...previous, [pendingKey]: [] }));
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [pendingKey, pendingLoad]);
-
-  /* --- Suggestions ------------------------------------------------------- */
-
-  const selectedValues = (key: string): string[] => {
-    const filter = filters.find((f) => f.id === key);
-    return Array.isArray(filter?.value) ? (filter.value as string[]) : [];
-  };
-
-  const suggestions = useMemo<Suggestion[]>(() => {
-    if (activeField) {
-      if (activeField.variant !== 'options') return [];
-      const needle = valueFragment.split(',').pop()?.toLowerCase() ?? '';
-      return (fieldOptions ?? [])
-        .filter(
-          (option) =>
-            !needle ||
-            option.label.toLowerCase().includes(needle) ||
-            option.value.toLowerCase().includes(needle),
-        )
-        .map((option) => ({ kind: 'value', field: activeField, option }));
-    }
-
-    const matches = fields
-      .filter(
-        (field) =>
-          !fieldNeedle ||
-          field.label.toLowerCase().includes(fieldNeedle) ||
-          field.key.toLowerCase().includes(fieldNeedle),
-      )
-      .map<Suggestion>((field) => ({ kind: 'field', field }));
-
-    // The search row rides last: when fields match what was typed, the
-    // structured question is the better default under Enter.
-    return draft.trim()
-      ? [...matches, { kind: 'search', text: draft.trim() }]
-      : matches;
-  }, [activeField, valueFragment, fieldOptions, draft, fields]);
-
-  // Reaching past the end after a list shrinks parks on the last row.
-  const highlightIndex = Math.min(
-    highlighted,
-    Math.max(suggestions.length - 1, 0),
-  );
-
-  /* --- Commits ----------------------------------------------------------- */
-
-  function commitDraft(next: string) {
-    const parsed = parseFilterQuery(next, variants);
-    const untouched = filters.filter(
-      (filter) => !parsed.filters.some((f) => f.id === filter.id),
-    );
-    onChange({
-      filters: [...untouched, ...parsed.filters],
-      search: parsed.search,
-    });
-    setDraft(parsed.search);
-  }
-
-  function toggleValue(field: QueryField, option: FilterOption) {
-    const selected = selectedValues(field.key);
-    const has = selected.includes(option.value);
-    const multiple = field.multiple ?? true;
-    const nextValues = multiple
-      ? has
-        ? selected.filter((value) => value !== option.value)
-        : [...selected, option.value]
-      : has
-        ? []
-        : [option.value];
-
-    const rest = filters.filter((filter) => filter.id !== field.key);
-    onChange({
-      filters: nextValues.length
-        ? [...rest, { id: field.key, value: nextValues }]
-        : rest,
-      search,
-    });
-
-    /*
-     * The typed fragment leaves the draft the moment it is real as a chip.
-     * A multi-value field stays picked so the list stays on its values --
-     * `level:error,fatal` is two ticks in a row, not two round trips through
-     * the field list -- but the phase lives in `pickedKey`, never as a
-     * `key:` parked in the input.
-     */
-    setDraft(prefix.trimEnd() ? `${prefix.trimEnd()} ` : '');
-    if (multiple) {
-      setPickedKey(field.key);
-    } else {
-      setPickedKey(null);
-      setOpen(false);
-    }
-    inputRef.current?.focus();
-  }
-
-  function apply(suggestion: Suggestion) {
-    if (suggestion.kind === 'field') {
-      const kept = prefix.trimEnd() ? `${prefix.trimEnd()} ` : '';
-      if (suggestion.field.variant === 'options') {
-        // The phase is state; the input hands over its fragment and stays
-        // clean while the popup turns to the field's values.
-        setPickedKey(suggestion.field.key);
-        setDraft(kept);
-      } else {
-        // A text or range value is typed, so the token is started in
-        // writing: `events:` waiting for its `100..500`.
-        setDraft(`${kept}${suggestion.field.key}:`);
-      }
-      setHighlighted(0);
-      inputRef.current?.focus();
-      return;
-    }
-    if (suggestion.kind === 'value') {
-      toggleValue(suggestion.field, suggestion.option);
-      return;
-    }
-    commitDraft(draft);
-    setOpen(false);
-    setPickedKey(null);
-  }
-
-  function removeFilter(key: string) {
-    onChange({
-      filters: filters.filter((filter) => filter.id !== key),
-      search,
-    });
-    inputRef.current?.focus();
-  }
-
-  function clearAll() {
-    onChange({ filters: [], search: '' });
-    setDraft('');
-    inputRef.current?.focus();
-  }
-
-  /* --- Keyboard ---------------------------------------------------------- */
-
-  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault();
-      if (!open) {
-        setOpen(true);
-        return;
-      }
-      const delta = event.key === 'ArrowDown' ? 1 : -1;
-      const next =
-        (highlightIndex + delta + suggestions.length) %
-        Math.max(suggestions.length, 1);
-      setHighlighted(next);
-      // The list scrolls, the input keeps focus: the highlighted row has to
-      // be brought along by hand.
-      document
-        .getElementById(`${id}-option-${next}`)
-        ?.scrollIntoView({ block: 'nearest' });
-      return;
-    }
-
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      const current = suggestions[highlightIndex];
-      if (open && current) {
-        apply(current);
-      } else {
-        commitDraft(draft);
-        setOpen(false);
-        setPickedKey(null);
-      }
-      return;
-    }
-
-    if (event.key === 'Tab' && open) {
-      const current = suggestions[highlightIndex];
-      if (current && current.kind === 'field') {
-        event.preventDefault();
-        apply(current);
-      }
-      return;
-    }
-
-    if (event.key === 'Escape') {
-      if (open) {
-        setOpen(false);
-        setPickedKey(null);
-      } else if (draft) {
-        setDraft('');
-      }
-      return;
-    }
-
-    if (event.key === 'Backspace' && draft === '') {
-      // First step out of the picked field, then start eating chips.
-      if (pickedKey) {
-        setPickedKey(null);
-        return;
-      }
-      const last = filters[filters.length - 1];
-      if (last) removeFilter(last.id);
-    }
-  }
-
-  /* --- Rendering --------------------------------------------------------- */
-
-  const chips = filters
-    .map((filter) => {
-      const field = fields.find((f) => f.key === filter.id);
-      if (!field) return null;
-      const text = formatFilterQuery([filter], '', variants);
-      const value = text.startsWith(`${filter.id}:`)
-        ? text.slice(filter.id.length + 1)
-        : text;
-      if (!value) return null;
-      return { key: filter.id, label: field.label, value };
-    })
-    .filter((chip) => chip !== null);
-
-  const listboxId = `${id}-listbox`;
-  const showClear = chips.length > 0 || search !== '' || draft !== '';
+  const {
+    id,
+    inputRef,
+    rootRef,
+    draft,
+    setDraft,
+    open,
+    setOpen,
+    pickedField,
+    setPickedKey,
+    activeField,
+    setHighlighted,
+    highlightIndex,
+    suggestions,
+    optionsPending,
+    activeFieldSelected,
+    chips,
+    listboxId,
+    showClear,
+    apply,
+    removeFilter,
+    clearAll,
+    onKeyDown,
+  } = useQueryBar({ fields, filters, search, onChange });
 
   return (
     <div ref={rootRef} className={styles.root({ className })}>
@@ -622,155 +441,17 @@ export function QueryBar({
       </div>
 
       {open ? (
-        <div className={styles.popup()} data-side="bottom">
-          {activeField && activeField.variant === 'options' ? (
-            <div className={styles.groupLabel()}>{activeField.label}</div>
-          ) : null}
-          {!activeField && suggestions.some((s) => s.kind === 'field') ? (
-            <div className={styles.groupLabel()}>Filter by</div>
-          ) : null}
-
-          <div className={styles.list()}>
-            {optionsPending ? (
-              <div aria-hidden="true">
-                {[0, 1, 2].map((line) => (
-                  <div key={line} className={styles.skeleton()} />
-                ))}
-              </div>
-            ) : null}
-
-            <div
-              role="listbox"
-              id={listboxId}
-              aria-label="Suggestions"
-              aria-busy={optionsPending || undefined}
-            >
-              {suggestions.map((suggestion, index) => {
-                const highlightedRow = index === highlightIndex;
-                const shared = {
-                  id: `${id}-option-${index}`,
-                  'data-highlighted': highlightedRow,
-                  className: styles.option(),
-                  onMouseEnter: () => setHighlighted(index),
-                  // Fires before the input's blur: the click must win.
-                  onMouseDown: (event: ReactMouseEvent) =>
-                    event.preventDefault(),
-                  onClick: () => apply(suggestion),
-                };
-
-                if (suggestion.kind === 'field') {
-                  const Icon = suggestion.field.icon ?? FacetsIcon;
-                  return (
-                    <div
-                      key={`field-${suggestion.field.key}`}
-                      {...shared}
-                      role="option"
-                      // Steered from the input via aria-activedescendant.
-                      tabIndex={-1}
-                      aria-selected={false}
-                    >
-                      <Icon size="lg" className={styles.optionIcon()} />
-                      <span className={styles.optionLabel()}>
-                        {suggestion.field.label}
-                      </span>
-                      <span className={styles.optionHint()}>
-                        {suggestion.field.description ??
-                          `${suggestion.field.key}:`}
-                      </span>
-                    </div>
-                  );
-                }
-
-                if (suggestion.kind === 'value') {
-                  const ticked = selectedValues(suggestion.field.key).includes(
-                    suggestion.option.value,
-                  );
-                  return (
-                    <div
-                      key={`value-${suggestion.option.value}`}
-                      {...shared}
-                      role="option"
-                      tabIndex={-1}
-                      aria-selected={ticked}
-                    >
-                      <span
-                        aria-hidden="true"
-                        data-ticked={ticked}
-                        className={styles.optionBox()}
-                      >
-                        {ticked ? (
-                          <ResolveIcon size="sm" aria-hidden="true" />
-                        ) : null}
-                      </span>
-                      {suggestion.option.tone ? (
-                        <span
-                          aria-hidden="true"
-                          className={styles.optionDot({
-                            className: TONE_DOT[suggestion.option.tone],
-                          })}
-                        />
-                      ) : null}
-                      <span className={styles.optionLabel()}>
-                        {suggestion.option.label}
-                      </span>
-                      {suggestion.option.hint ? (
-                        <span className={styles.optionHint()}>
-                          {suggestion.option.hint}
-                        </span>
-                      ) : null}
-                      <Count>{suggestion.option.count}</Count>
-                    </div>
-                  );
-                }
-
-                return (
-                  <div
-                    key="search"
-                    {...shared}
-                    role="option"
-                    tabIndex={-1}
-                    aria-selected={false}
-                  >
-                    <SearchIcon size="lg" className={styles.optionIcon()} />
-                    <span className={styles.optionLabel()}>
-                      Search “{suggestion.text}”
-                    </span>
-                    <Kbd>⏎</Kbd>
-                  </div>
-                );
-              })}
-            </div>
-
-            {activeField && activeField.variant === 'range' ? (
-              <div className={styles.option()}>
-                <span className={styles.optionLabel()}>
-                  Type a range: {activeField.key}:100..500, then
-                </span>
-                <Kbd>⏎</Kbd>
-              </div>
-            ) : null}
-            {activeField && activeField.variant === 'text' ? (
-              <div className={styles.option()}>
-                <span className={styles.optionLabel()}>Type a value, then</span>
-                <Kbd>⏎</Kbd>
-              </div>
-            ) : null}
-
-            {!optionsPending &&
-            suggestions.length === 0 &&
-            activeField?.variant === 'options' ? (
-              <div className="px-2.5 py-3 text-center text-control text-fg-ghost">
-                Nothing matches
-              </div>
-            ) : null}
-          </div>
-
-          <span aria-hidden="true" className={styles.hints()}>
-            <span>↑↓ navigate</span>
-            <span>⏎ select</span>
-            <span>esc closes</span>
-          </span>
-        </div>
+        <SuggestionsPopup
+          id={id}
+          listboxId={listboxId}
+          activeField={activeField}
+          suggestions={suggestions}
+          optionsPending={optionsPending}
+          highlightIndex={highlightIndex}
+          activeFieldSelected={activeFieldSelected}
+          onHighlight={setHighlighted}
+          onSelect={apply}
+        />
       ) : null}
     </div>
   );

--- a/packages/ui/src/components/query-bar/use-query-bar.ts
+++ b/packages/ui/src/components/query-bar/use-query-bar.ts
@@ -338,7 +338,11 @@ export function useQueryBar({
         setOpen(false);
         setPickedKey(null);
       } else if (draft) {
+        // The popup is already closed, so this draft is exactly what is
+        // committed (nothing has been typed since). Clearing only the draft
+        // would leave the table filtered by search the bar no longer shows.
         setDraft('');
+        if (search) onChange({ filters, search: '' });
       }
       return;
     }

--- a/packages/ui/src/components/query-bar/use-query-bar.ts
+++ b/packages/ui/src/components/query-bar/use-query-bar.ts
@@ -53,6 +53,14 @@ export function useQueryBar({
   const [loadedOptions, setLoadedOptions] = useState<
     Record<string, FilterOption[]>
   >({});
+  /*
+   * The key of the field whose load most recently rejected. Kept apart from
+   * `loadedOptions` on purpose: caching `[]` there would read as "loaded, and
+   * empty" forever, so a transient failure could never be retried. Leaving
+   * and returning to the field clears it, because that is what starts a new
+   * attempt below.
+   */
+  const [failedKey, setFailedKey] = useState<string | null>(null);
 
   const variants = useMemo(() => variantsFromFields(fields), [fields]);
 
@@ -112,14 +120,17 @@ export function useQueryBar({
   const fieldOptions = activeField
     ? (activeField.options ?? loadedOptions[activeField.key])
     : undefined;
-  const optionsPending = Boolean(
-    activeField?.loadOptions &&
-      !activeField.options &&
-      !loadedOptions[activeField.key],
-  );
+  // Drives the fetch: unconditioned on a prior failure, so leaving the field
+  // and coming back -- which changes this key -- retries automatically.
+  const pendingKey =
+    activeField?.loadOptions && !activeField.options && !fieldOptions
+      ? activeField.key
+      : undefined;
+  const pendingLoad = pendingKey ? activeField?.loadOptions : undefined;
+  // Drives the skeleton: false once a failure has already been recorded, so
+  // it does not spin forever waiting for an attempt that already ended.
+  const optionsPending = Boolean(pendingKey) && failedKey !== pendingKey;
 
-  const pendingKey = optionsPending ? activeField?.key : undefined;
-  const pendingLoad = optionsPending ? activeField?.loadOptions : undefined;
   useEffect(() => {
     if (!pendingKey || !pendingLoad) return;
     let cancelled = false;
@@ -133,10 +144,7 @@ export function useQueryBar({
         }
       })
       .catch(() => {
-        // An empty list ends the skeleton and reads as "nothing to offer".
-        if (!cancelled) {
-          setLoadedOptions((previous) => ({ ...previous, [pendingKey]: [] }));
-        }
+        if (!cancelled) setFailedKey(pendingKey);
       });
     return () => {
       cancelled = true;

--- a/packages/ui/src/components/query-bar/use-query-bar.ts
+++ b/packages/ui/src/components/query-bar/use-query-bar.ts
@@ -1,0 +1,398 @@
+import type { ColumnFiltersState } from '@tanstack/react-table';
+import {
+  type KeyboardEvent,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { FilterOption } from '../data-table/features';
+import { formatFilterQuery, parseFilterQuery } from '../data-table/query';
+import { type QueryField, variantsFromFields } from './query-bar-parts';
+
+export type Suggestion =
+  | { kind: 'field'; field: QueryField }
+  | { kind: 'value'; field: QueryField; option: FilterOption }
+  | { kind: 'search'; text: string };
+
+interface UseQueryBarOptions {
+  fields: QueryField[];
+  filters: ColumnFiltersState;
+  search: string;
+  onChange: (next: { filters: ColumnFiltersState; search: string }) => void;
+}
+
+/**
+ * The bar's whole behaviour: phase detection, suggestions, commits and
+ * keyboard handling. Split from `QueryBar` so the component is left with only
+ * what it renders -- this owns what it means.
+ */
+export function useQueryBar({
+  fields,
+  filters,
+  search,
+  onChange,
+}: UseQueryBarOptions) {
+  const id = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [draft, setDraft] = useState(search);
+  const [open, setOpen] = useState(false);
+  /*
+   * The field whose values the popup is offering, held as state rather than
+   * as text. Choosing "Level" used to write `level:` into the input to carry
+   * the phase; the token then sat there, fixed, beside every chip it
+   * produced. The phase is not prose, so it no longer lives in the prose --
+   * the input stays clean and the popup stays on the field's values until
+   * Escape, blur or a single-choice pick ends it. Typing `level:` by hand
+   * still works: the token form is the same question asked in writing.
+   */
+  const [pickedKey, setPickedKey] = useState<string | null>(null);
+  const [highlighted, setHighlighted] = useState(0);
+  const [loadedOptions, setLoadedOptions] = useState<
+    Record<string, FilterOption[]>
+  >({});
+
+  const variants = useMemo(() => variantsFromFields(fields), [fields]);
+
+  /*
+   * The draft belongs to the bar while it is being typed, but the committed
+   * search belongs to the owner: when it changes from outside (a cleared
+   * query, a navigated URL), the bar must show it.
+   */
+  const lastSearch = useRef(search);
+  if (search !== lastSearch.current) {
+    // React's own adjusting-state-during-render pattern: an effect here would
+    // paint one frame of stale draft before correcting it.
+    // react-doctor-disable-next-line react-doctor/no-ref-current-in-render
+    lastSearch.current = search;
+    setDraft(search);
+  }
+
+  /* --- Phase detection --------------------------------------------------- */
+
+  const tokenMatch = draft.match(/(^|\s)([A-Za-z0-9_.-]+):(\S*)$/);
+  const typedField = tokenMatch
+    ? fields.find((field) => field.key === tokenMatch[2])
+    : undefined;
+  const pickedField = pickedKey
+    ? fields.find((field) => field.key === pickedKey)
+    : undefined;
+  const activeField = pickedField ?? typedField;
+
+  /*
+   * Only the word under the caret is being completed; whatever stands before
+   * it is already said and survives the completion. So `timeout lev` offers
+   * Level, and taking it keeps `timeout` -- the fragment is replaced,
+   * never appended to.
+   */
+  const fragmentMatch = draft.match(/(^|\s)(\S*)$/);
+  const fragment = fragmentMatch?.[2] ?? '';
+  const fragmentPrefix = draft.slice(
+    0,
+    (fragmentMatch?.index ?? 0) + (fragmentMatch?.[1]?.length ?? 0),
+  );
+
+  // With a picked field, whatever is being typed narrows its values.
+  const valueFragment = pickedField
+    ? fragment
+    : typedField
+      ? (tokenMatch?.[3] ?? '')
+      : '';
+  const fieldNeedle = activeField ? '' : fragment.toLowerCase();
+  const prefix =
+    !pickedField && typedField
+      ? draft.slice(
+          0,
+          (tokenMatch?.index ?? 0) + (tokenMatch?.[1]?.length ?? 0),
+        )
+      : fragmentPrefix;
+
+  const fieldOptions = activeField
+    ? (activeField.options ?? loadedOptions[activeField.key])
+    : undefined;
+  const optionsPending = Boolean(
+    activeField?.loadOptions &&
+      !activeField.options &&
+      !loadedOptions[activeField.key],
+  );
+
+  const pendingKey = optionsPending ? activeField?.key : undefined;
+  const pendingLoad = optionsPending ? activeField?.loadOptions : undefined;
+  useEffect(() => {
+    if (!pendingKey || !pendingLoad) return;
+    let cancelled = false;
+    pendingLoad()
+      .then((options) => {
+        if (!cancelled) {
+          setLoadedOptions((previous) => ({
+            ...previous,
+            [pendingKey]: options,
+          }));
+        }
+      })
+      .catch(() => {
+        // An empty list ends the skeleton and reads as "nothing to offer".
+        if (!cancelled) {
+          setLoadedOptions((previous) => ({ ...previous, [pendingKey]: [] }));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingKey, pendingLoad]);
+
+  /* --- Suggestions ------------------------------------------------------- */
+
+  const selectedValues = (key: string): string[] => {
+    const filter = filters.find((f) => f.id === key);
+    return Array.isArray(filter?.value) ? (filter.value as string[]) : [];
+  };
+
+  const suggestions = useMemo<Suggestion[]>(() => {
+    if (activeField) {
+      if (activeField.variant !== 'options') return [];
+      const needle = valueFragment.split(',').pop()?.toLowerCase() ?? '';
+      return (fieldOptions ?? []).reduce<Suggestion[]>((matches, option) => {
+        if (
+          !needle ||
+          option.label.toLowerCase().includes(needle) ||
+          option.value.toLowerCase().includes(needle)
+        ) {
+          matches.push({ kind: 'value', field: activeField, option });
+        }
+        return matches;
+      }, []);
+    }
+
+    const matches = fields.reduce<Suggestion[]>((acc, field) => {
+      if (
+        !fieldNeedle ||
+        field.label.toLowerCase().includes(fieldNeedle) ||
+        field.key.toLowerCase().includes(fieldNeedle)
+      ) {
+        acc.push({ kind: 'field', field });
+      }
+      return acc;
+    }, []);
+
+    // The search row rides last: when fields match what was typed, the
+    // structured question is the better default under Enter.
+    return draft.trim()
+      ? [...matches, { kind: 'search', text: draft.trim() }]
+      : matches;
+  }, [activeField, valueFragment, fieldOptions, draft, fields, fieldNeedle]);
+
+  // Reaching past the end after a list shrinks parks on the last row.
+  const highlightIndex = Math.min(
+    highlighted,
+    Math.max(suggestions.length - 1, 0),
+  );
+
+  /* --- Commits ----------------------------------------------------------- */
+
+  function commitDraft(next: string) {
+    const parsed = parseFilterQuery(next, variants);
+    const untouched = filters.filter(
+      (filter) => !parsed.filters.some((f) => f.id === filter.id),
+    );
+    onChange({
+      filters: [...untouched, ...parsed.filters],
+      search: parsed.search,
+    });
+    setDraft(parsed.search);
+  }
+
+  function toggleValue(field: QueryField, option: FilterOption) {
+    const selected = selectedValues(field.key);
+    const has = selected.includes(option.value);
+    const multiple = field.multiple ?? true;
+    const nextValues = multiple
+      ? has
+        ? selected.filter((value) => value !== option.value)
+        : [...selected, option.value]
+      : has
+        ? []
+        : [option.value];
+
+    const rest = filters.filter((filter) => filter.id !== field.key);
+    onChange({
+      filters: nextValues.length
+        ? [...rest, { id: field.key, value: nextValues }]
+        : rest,
+      search,
+    });
+
+    /*
+     * The typed fragment leaves the draft the moment it is real as a chip.
+     * A multi-value field stays picked so the list stays on its values --
+     * `level:error,fatal` is two ticks in a row, not two round trips through
+     * the field list -- but the phase lives in `pickedKey`, never as a
+     * `key:` parked in the input.
+     */
+    setDraft(prefix.trimEnd() ? `${prefix.trimEnd()} ` : '');
+    if (multiple) {
+      setPickedKey(field.key);
+    } else {
+      setPickedKey(null);
+      setOpen(false);
+    }
+    inputRef.current?.focus();
+  }
+
+  function apply(suggestion: Suggestion) {
+    if (suggestion.kind === 'field') {
+      const kept = prefix.trimEnd() ? `${prefix.trimEnd()} ` : '';
+      if (suggestion.field.variant === 'options') {
+        // The phase is state; the input hands over its fragment and stays
+        // clean while the popup turns to the field's values.
+        setPickedKey(suggestion.field.key);
+        setDraft(kept);
+      } else {
+        // A text or range value is typed, so the token is started in
+        // writing: `events:` waiting for its `100..500`.
+        setDraft(`${kept}${suggestion.field.key}:`);
+      }
+      setHighlighted(0);
+      inputRef.current?.focus();
+      return;
+    }
+    if (suggestion.kind === 'value') {
+      toggleValue(suggestion.field, suggestion.option);
+      return;
+    }
+    commitDraft(draft);
+    setOpen(false);
+    setPickedKey(null);
+  }
+
+  function removeFilter(key: string) {
+    onChange({
+      filters: filters.filter((filter) => filter.id !== key),
+      search,
+    });
+    inputRef.current?.focus();
+  }
+
+  function clearAll() {
+    onChange({ filters: [], search: '' });
+    setDraft('');
+    inputRef.current?.focus();
+  }
+
+  /* --- Keyboard ---------------------------------------------------------- */
+
+  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!open) {
+        setOpen(true);
+        return;
+      }
+      const delta = event.key === 'ArrowDown' ? 1 : -1;
+      const next =
+        (highlightIndex + delta + suggestions.length) %
+        Math.max(suggestions.length, 1);
+      setHighlighted(next);
+      // The list scrolls, the input keeps focus: the highlighted row has to
+      // be brought along by hand.
+      document
+        .getElementById(`${id}-option-${next}`)
+        ?.scrollIntoView({ block: 'nearest' });
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const current = suggestions[highlightIndex];
+      if (open && current) {
+        apply(current);
+      } else {
+        commitDraft(draft);
+        setOpen(false);
+        setPickedKey(null);
+      }
+      return;
+    }
+
+    if (event.key === 'Tab' && open) {
+      const current = suggestions[highlightIndex];
+      if (current && current.kind === 'field') {
+        event.preventDefault();
+        apply(current);
+      }
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      if (open) {
+        setOpen(false);
+        setPickedKey(null);
+      } else if (draft) {
+        setDraft('');
+      }
+      return;
+    }
+
+    if (event.key === 'Backspace' && draft === '') {
+      // First step out of the picked field, then start eating chips.
+      if (pickedKey) {
+        setPickedKey(null);
+        return;
+      }
+      const last = filters[filters.length - 1];
+      if (last) removeFilter(last.id);
+    }
+  }
+
+  /* --- Rendering ----------------------------------------------------------
+   * Everything below is data the render still needs, not behaviour.
+   */
+
+  const chips = filters
+    .map((filter) => {
+      const field = fields.find((f) => f.key === filter.id);
+      if (!field) return null;
+      const text = formatFilterQuery([filter], '', variants);
+      const value = text.startsWith(`${filter.id}:`)
+        ? text.slice(filter.id.length + 1)
+        : text;
+      if (!value) return null;
+      return { key: filter.id, label: field.label, value };
+    })
+    .filter((chip) => chip !== null);
+
+  const listboxId = `${id}-listbox`;
+  const showClear = chips.length > 0 || search !== '' || draft !== '';
+  // Hoisted out of the suggestion loop: every "value" row checks membership.
+  const activeFieldSelected = new Set(
+    activeField ? selectedValues(activeField.key) : [],
+  );
+
+  return {
+    id,
+    inputRef,
+    rootRef,
+    draft,
+    setDraft,
+    open,
+    setOpen,
+    pickedField,
+    setPickedKey,
+    activeField,
+    highlighted,
+    setHighlighted,
+    highlightIndex,
+    suggestions,
+    optionsPending,
+    activeFieldSelected,
+    chips,
+    listboxId,
+    showClear,
+    apply,
+    removeFilter,
+    clearAll,
+    onKeyDown,
+  };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -179,15 +179,13 @@ export { useDataTable } from './components/data-table/use-data-table';
 
 /* --- Query bar ----------------------------------------------------------- */
 
-export type {
-  QueryBarProps,
-  QueryField,
-} from './components/query-bar/query-bar';
+export type { QueryBarProps } from './components/query-bar/query-bar';
+export { QueryBar } from './components/query-bar/query-bar';
+export type { QueryField } from './components/query-bar/query-bar-parts';
 export {
-  QueryBar,
   queryFieldsFromColumns,
   variantsFromFields,
-} from './components/query-bar/query-bar';
+} from './components/query-bar/query-bar-parts';
 
 /* --- Shell --------------------------------------------------------------- */
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,6 +16,7 @@ export {
 } from './lib/focus';
 export {
   chevronFlip,
+  dropIn,
   interactiveTransition,
   popTransition,
   pressNudge,
@@ -128,6 +129,65 @@ export type {
 export { Tab, TabList, TabPanel, Tabs } from './components/tabs/tabs';
 export type { TooltipProps } from './components/tooltip/tooltip';
 export { Tooltip, TooltipProvider } from './components/tooltip/tooltip';
+
+/* --- Forms --------------------------------------------------------------- */
+
+export type { CheckboxProps } from './components/checkbox/checkbox';
+export { Checkbox } from './components/checkbox/checkbox';
+export type { PopoverProps } from './components/popover/popover';
+export { Popover } from './components/popover/popover';
+
+/* --- Data table ---------------------------------------------------------- */
+
+export type { DataTableColumnsButtonProps } from './components/data-table/columns-menu';
+export { DataTableColumnsButton } from './components/data-table/columns-menu';
+export type {
+  DataTableEmptyProps,
+  DataTableProps,
+} from './components/data-table/data-table';
+export { DataTable } from './components/data-table/data-table';
+export type {
+  ColumnFilterSpec,
+  DataTableColumnDef,
+  DataTableColumnMeta,
+  DataTableFeatures,
+  FilterOption,
+} from './components/data-table/features';
+export {
+  createDataTableColumnHelper,
+  dataTableFeatures,
+} from './components/data-table/features';
+export type { DataTablePaginationProps } from './components/data-table/pagination';
+export { DataTablePagination } from './components/data-table/pagination';
+export type {
+  DataTableQuery,
+  FilterVariants,
+} from './components/data-table/query';
+export {
+  DEFAULT_PAGE_SIZE,
+  emptyTableQuery,
+  formatFilterQuery,
+  parseFilterQuery,
+  parseTableQuery,
+  serializeTableQuery,
+} from './components/data-table/query';
+export type {
+  DataTableInstance,
+  UseDataTableOptions,
+} from './components/data-table/use-data-table';
+export { useDataTable } from './components/data-table/use-data-table';
+
+/* --- Query bar ----------------------------------------------------------- */
+
+export type {
+  QueryBarProps,
+  QueryField,
+} from './components/query-bar/query-bar';
+export {
+  QueryBar,
+  queryFieldsFromColumns,
+  variantsFromFields,
+} from './components/query-bar/query-bar';
 
 /* --- Shell --------------------------------------------------------------- */
 

--- a/packages/ui/src/lib/motion.ts
+++ b/packages/ui/src/lib/motion.ts
@@ -208,3 +208,15 @@ export const pressNudge = [
  * rendered string, so "2 min ago" becoming "3 min ago" does not re-animate.
  */
 export const swapAnimation = 'animate-swap-in motion-reduce:animate-none';
+
+/**
+ * `popTransition`, for a panel this package positions itself.
+ *
+ * The Base UI version rides on `data-starting-style`, which only Base UI
+ * sets. A hand-anchored popup -- the query bar's suggestions -- has no such
+ * attribute, so its entrance is the same movement written as an animation:
+ * the growth from the anchored edge, the 4 px slide out of the control, the
+ * entrance clock. Exit is unmount, deliberately: suggestions dismissed while
+ * typing must not linger over the next keystroke.
+ */
+export const dropIn = 'origin-top animate-drop-in motion-reduce:animate-none';

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -642,6 +642,26 @@
     }
   }
 
+  /*
+   * The same entrance `popTransition` gives a Base UI popup, as an animation:
+   * for a panel this package positions itself, where there is no
+   * `data-starting-style` to transition from. Same growth, same 4 px slide
+   * back toward the control that opened it, same clock.
+   */
+  --animate-drop-in: drop-in var(--transition-duration-moderate)
+    var(--ease-entrance);
+
+  @keyframes drop-in {
+    from {
+      opacity: 0;
+      transform: translateY(-4px) scale(0.97);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
   /* ---------------------------------------------------------------------- */
   /* Radii · 2 · 4 · 5 · 6 · 8 · 10 · pill                                   */
   /* 6 is the workhorse: buttons, chips, nav rows, inputs. 8 is a popup, 10  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
       '@base-ui/react':
         specifier: 1.7.0
         version: 1.7.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-table':
+        specifier: 9.1.2
+        version: 9.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -11715,12 +11718,27 @@ snapshots:
       tailwindcss: 4.3.3
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
+  '@tanstack/react-store@0.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/store': 0.11.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
   '@tanstack/react-store@0.11.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/store': 0.11.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
+
+  '@tanstack/react-table@9.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/react-store': 0.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/table-core': 9.1.2
+      react: 19.2.7
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/react-table@9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:


### PR DESCRIPTION
## What

The second pass the design system deliberately left open: the table and the filter bar, plus the two primitives they needed.

### Data table (`data-table/`)
- **TanStack Table v9 (9.1.2) in fully manual mode.** `useDataTable` registers no client row models: the server filters, sorts and paginates, and every change leaves as a pure updater on a `DataTableQuery`. Filter/sort/search changes rewind `pageIndex` atomically (manual pagination disables TanStack's auto-reset).
- **GitHub-style column headers.** Clicking a header opens one panel with the sort (worded in the column's own terms), the type-appropriate filter — `options` with counts and tone dots, `text`, `range` — and hiding. At rest the header shows state only: lime arrow when sorted, lime funnel when filtered.
- **Row actions rest in a fixed ⋯ column** (`rowMenu`, as `MenuAction[]`); hover-revealed actions were dropped as undiscoverable and touch-hostile.
- **Bulk actions take over the header on selection** (Gmail pattern): count, `bulkActions`, Clear, swapping both ways with `swapAnimation` so nothing pushes the table mid-gesture.
- Pagination footer, columns menu, loading (skeletons only when there is nothing to keep on screen), empty state with a clear-filters offer.

### Query bar (`query-bar/`)
- Token search with **two-phase autocomplete**: typing offers the fields (derived from the table's column meta, so the two can never disagree), choosing one turns the popup to its values, ticking live. The value phase lives in state, never as a `key:` parked in the input.
- Chips edit the **same `ColumnFiltersState` as the column panels** — one state, two views. The bar's text form is exactly what `parseFilterQuery` reads.
- Typed tokens commit whole (`events:100..500`), Backspace eats the last chip, async options show a skeleton, the field wraps on narrow viewports instead of clipping chips.

### Plumbing
- `query.ts`: the `DataTableQuery` model plus pure URL codecs (`parseTableQuery`/`serializeTableQuery`). The package never touches a router; the app owns the URL.
- New `Checkbox` and `Popover` primitives (Base UI), and a `drop-in` motion token for hand-anchored popups.

## How it was verified

- 138 tests: 13 codec unit tests plus stories-as-tests in real Chromium with axe — header filtering, sorting, selection→bulk swap, row menus, bar/header sync, keyboard paths, the narrow-viewport wrap.
- Reviewed live in Storybook against the 9c screen of the v8 redesign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added accessible Checkbox and Popover components.
  - Added data tables with server-side sorting, filtering, pagination, selection, column visibility, row actions, bulk actions, loading, and empty states.
  - Added Query Bar support for structured filters, search, autocomplete, and URL-synchronized queries.
  - Added reusable popup entrance animations.
- **Documentation**
  - Updated design-system guidance and documented table, filter, and query components.
- **Tests**
  - Added Storybook examples and interaction coverage for new and enhanced components.
  - Added query parsing, formatting, and URL serialization coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->