### PR TITLE
feat(ui): add form fields and the chart family

### DIFF
--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -100,9 +100,11 @@ right and the new number gets written down, or it is not.
 - import `lucide-react` anywhere except `components/icon/adapters/lucide.tsx`.
 - build classes with template literals. Tailwind extracts statically, so
   `bg-${name}` is a rule that is silently never generated.
-- reach for a chart. That is a later pass and it needs decisions this one has
-  not made. The table and the filter bar exist now: `data-table/` and
-  `query-bar/` — extend those rather than starting parallel ones.
+- start a parallel table, filter bar or chart. They exist: `data-table/`,
+  `query-bar/` and `chart/` (recharts behind `TimeSeriesChart`/`BarsChart`,
+  hand-drawn `Sparkline` for rows) — extend those. Chart colours are
+  `var(--chart-*)` and the severity tokens, validated as a palette; never
+  hand a chart a new colour without re-running that validation.
 - give the `backgrounds` addon a hex. It writes its value onto the preview body,
   so a literal pins the page to one theme while the components inside it follow
   the other. Hand it `var(--surface-canvas)`.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -207,6 +207,18 @@ project card, the seven routes, ⌘B).
 
 **Forms** · `Checkbox` `Popover`.
 
+**Forms, continued** · `Field` (`FieldLabel`/`FieldHint`/`FieldError`, wired
+by Base UI), `Input` (leading symbol, trailing `InputAction`, numeric,
+read-only, invalid), `Textarea` — all sharing one `inputShell` box.
+
+**Charts** · recharts 3 behind three components that never leak it:
+`TimeSeriesChart` (areas with gradient fills, stacked or overlaid),
+`BarsChart` (bucketed, stacked by default, 1 px surface seams between
+bands), and `Sparkline` (hand-drawn SVG for table rows: no store, no
+animation, no tooltip). Colours are `var(--chart-*)` and the severity
+tokens; both palettes pass the CVD/contrast validation. TanStack Charts was
+evaluated and parked: relaunched 2026-07, pre-alpha, to be revisited at 1.0.
+
 **Overlays** · `ToastProvider`/`useToast` (a stacked corner notice: tones
 with their own lifetimes, actions, progress, `promise`), `Dialog` with its
 `Header`/`Body`/`Footer`, `createDialog`/`DialogProvider` (modals opened by

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -230,8 +230,6 @@ column-header sort/filter panels behind them — and `QueryBar`, the token
 search with two-phase autocomplete. `data-table/query.ts` holds the shared
 query model and the URL codecs.
 
-No charts. Those are a later pass and need decisions this one does not.
-
 ### Named decisions
 
 - **`Tag` defaults to plain coloured text, not a filled pill.** An issue list is

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,7 @@
     "@tanstack/react-table": "9.1.2",
     "clsx": "2.1.1",
     "lucide-react": "1.33.0",
+    "recharts": "3.10.1",
     "tailwind-merge": "3.6.0",
     "tailwind-variants": "3.3.1"
   },

--- a/packages/ui/src/components/chart/bars-chart.stories.tsx
+++ b/packages/ui/src/components/chart/bars-chart.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fireEvent, waitFor, within } from 'storybook/test';
+import { Text } from '../text/text';
+import { BarsChart } from './bars-chart';
+
+function seed(count: number, low: number, high: number, start: number) {
+  const out: number[] = [];
+  let x = start;
+  for (let i = 0; i < count; i++) {
+    x = (x * 9301 + 49297) % 233280;
+    out.push(Math.round(low + (x / 233280) * (high - low)));
+  }
+  return out;
+}
+
+const errors = seed(28, 120, 900, 5);
+const warnings = seed(28, 40, 360, 17);
+const info = seed(28, 20, 220, 29);
+
+const DATA = Array.from({ length: 28 }, (_, i) => ({
+  day: i + 1,
+  error: errors[i] ?? 0,
+  warning: warnings[i] ?? 0,
+  info: info[i] ?? 0,
+}));
+
+/*
+ * Severity is a status, not an entity: its colours are the reserved
+ * severity tokens, never dealt from the categorical order.
+ */
+const SEVERITY_SERIES = [
+  { key: 'info', label: 'Info', color: 'var(--sev-info)' },
+  { key: 'warning', label: 'Warning', color: 'var(--sev-warning)' },
+  { key: 'error', label: 'Error', color: 'var(--sev-error)' },
+];
+
+const meta = {
+  title: 'Charts/Bars',
+  component: BarsChart,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof BarsChart>;
+
+export default meta;
+type Story = StoryObj;
+
+/** The events-by-severity column of the overview screen. */
+export const BySeverity: Story = {
+  render: () => (
+    <div className="w-160 rounded-xl border border-border-subtle bg-surface p-4">
+      <Text variant="card-title" render={<h3 />} className="pb-3">
+        Events by severity, 28 days
+      </Text>
+      <BarsChart
+        data={DATA}
+        series={SEVERITY_SERIES}
+        xKey="day"
+        height={180}
+        formatX={(value) => `d${value}`}
+        formatY={(value) =>
+          value >= 1000 ? `${(value / 1000).toFixed(1)}k` : String(value)
+        }
+        label="Events per day by severity, last 28 days"
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() =>
+      expect(
+        canvasElement.querySelectorAll('.recharts-bar').length,
+      ).toBeGreaterThan(0),
+    );
+    // Status series still get their legend: colour is never the only name.
+    await expect(canvas.getByText('Error')).toBeInTheDocument();
+    await expect(canvas.getByText('Warning')).toBeInTheDocument();
+
+    // The pointer asks for the numbers: the tooltip is the reading layer.
+    const surface = canvasElement.querySelector('.recharts-wrapper');
+    if (surface) {
+      const box = surface.getBoundingClientRect();
+      fireEvent.mouseMove(surface, {
+        clientX: box.left + box.width / 2,
+        clientY: box.top + box.height / 2,
+      });
+      await waitFor(() =>
+        expect(
+          canvas.getAllByText(/Error|Warning|Info/).length,
+        ).toBeGreaterThan(3),
+      );
+    }
+  },
+};
+
+/** One series, no stack: a log volume. */
+export const SingleSeries: Story = {
+  render: () => (
+    <div className="w-160 rounded-xl border border-border-subtle bg-surface p-4">
+      <Text variant="card-title" render={<h3 />} className="pb-3">
+        Log volume, 28 days
+      </Text>
+      <BarsChart
+        data={DATA}
+        series={[{ key: 'info', label: 'Entries' }]}
+        xKey="day"
+        height={140}
+        stacked={false}
+        formatX={(value) => `d${value}`}
+        label="Log entries per day, last 28 days"
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/chart/bars-chart.tsx
+++ b/packages/ui/src/components/chart/bars-chart.tsx
@@ -1,3 +1,8 @@
+// Not loaded through next/dynamic, deliberately: this package has no
+// framework opinion, and recharts is already the only thing that pulls
+// these primitives in -- deferring the import buys nothing a consumer's own
+// code-splitting doesn't already give it.
+// react-doctor-disable-next-line react-doctor/prefer-dynamic-import
 import {
   Bar,
   BarChart,
@@ -7,14 +12,8 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import {
-  ChartLegend,
-  type ChartSeries,
-  ChartTooltip,
-  seriesColor,
-  XTick,
-  YTick,
-} from './chart-parts';
+import { ChartLegend, ChartTooltip, XTick, YTick } from './chart-parts';
+import { type ChartSeries, seriesColor } from './chart-series';
 
 /**
  * Bucketed bars over time: the events-by-severity chart, a log volume.

--- a/packages/ui/src/components/chart/bars-chart.tsx
+++ b/packages/ui/src/components/chart/bars-chart.tsx
@@ -1,0 +1,129 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import {
+  ChartLegend,
+  type ChartSeries,
+  ChartTooltip,
+  seriesColor,
+  XTick,
+  YTick,
+} from './chart-parts';
+
+/**
+ * Bucketed bars over time: the events-by-severity chart, a log volume.
+ *
+ * Stacked by default, because that is what the product asks of it -- one
+ * column per bucket, severity as bands. The bands separate with a 1 px
+ * stroke of the surface, not a lighter shade: a real gap survives every
+ * kind of colour-blindness, which is what lets error sit next to warning.
+ * Only the top of the column is rounded; data grows from the baseline and
+ * the baseline stays sharp.
+ *
+ * When the series are severities, pass their colours (`var(--sev-error)`…):
+ * status colours are reserved and never come from the categorical order.
+ */
+export interface BarsChartProps<TDatum extends Record<string, unknown>> {
+  data: TDatum[];
+  series: ChartSeries[];
+  xKey: string;
+  height: number;
+  stacked?: boolean;
+  formatX?: (value: string | number) => string;
+  formatY?: (value: number) => string;
+  /** Pin the Y scale: `[0, 100]` for a share. Absent, it follows the data. */
+  yDomain?: [number, number];
+  /** Names the figure for screen readers; the drawing stays explorable. */
+  label: string;
+  className?: string;
+}
+
+export function BarsChart<TDatum extends Record<string, unknown>>({
+  data,
+  series,
+  xKey,
+  height,
+  stacked = true,
+  formatX,
+  formatY,
+  yDomain,
+  label,
+  className,
+}: BarsChartProps<TDatum>) {
+  return (
+    <figure className={className} aria-label={label}>
+      <ResponsiveContainer width="100%" height={height}>
+        <BarChart
+          data={data}
+          margin={{ top: 4, right: 20, bottom: 0, left: 0 }}
+          barCategoryGap="24%"
+        >
+          <CartesianGrid
+            vertical={false}
+            stroke="var(--border-divider)"
+            strokeDasharray="3 3"
+          />
+          <XAxis
+            dataKey={xKey}
+            axisLine={false}
+            tickLine={false}
+            tick={<XTick format={formatX} />}
+            interval="preserveStartEnd"
+            minTickGap={32}
+          />
+          <YAxis
+            width={40}
+            axisLine={false}
+            tickLine={false}
+            tick={
+              <YTick
+                format={formatY ? (value) => formatY(Number(value)) : undefined}
+              />
+            }
+            tickCount={4}
+            domain={yDomain}
+          />
+          <Tooltip
+            cursor={{ fill: 'var(--surface-hover)' }}
+            isAnimationActive={false}
+            content={
+              <ChartTooltip
+                series={series}
+                formatLabel={formatX}
+                formatValue={formatY}
+              />
+            }
+          />
+
+          {series.map((entry, index) => {
+            const top = index === series.length - 1;
+            return (
+              <Bar
+                key={entry.key}
+                dataKey={entry.key}
+                stackId={stacked ? 'stack' : undefined}
+                fill={seriesColor(entry, index)}
+                // The 1 px surface seam between stacked bands.
+                stroke="var(--surface)"
+                strokeWidth={1}
+                radius={top || !stacked ? [2, 2, 0, 0] : 0}
+                // See TimeSeriesChart: entry animation explains nothing.
+                isAnimationActive={false}
+              />
+            );
+          })}
+        </BarChart>
+      </ResponsiveContainer>
+
+      <ChartLegend series={series} />
+    </figure>
+  );
+}
+
+BarsChart.displayName = 'BarsChart';

--- a/packages/ui/src/components/chart/chart-parts.tsx
+++ b/packages/ui/src/components/chart/chart-parts.tsx
@@ -1,0 +1,210 @@
+import type { ReactNode } from 'react';
+import { tv } from '../../lib/tv';
+
+/**
+ * What every chart shares: the series contract, the palette order, the
+ * tooltip card, the legend row and the axis ticks.
+ *
+ * Colours are CSS variables end to end -- `var(--chart-1)`, `var(--sev-error)`
+ * -- which is what lets the same SVG follow the theme. The categorical order
+ * is **fixed**: chart-1 to chart-5, assigned by position and never cycled or
+ * re-dealt when a series is filtered away. Identity sticks to the entity;
+ * the palette was validated (CVD, chroma, contrast) as a sequence, and a
+ * sixth series is a design question, not a sixth colour.
+ */
+
+/** One drawn series: which field, what to call it, and -- rarely -- what
+ *  colour, when the series *is* a status (severity) rather than an entity. */
+export interface ChartSeries {
+  key: string;
+  label: string;
+  /** A CSS colour, `var(--token)` only. Absent: the categorical order. */
+  color?: string;
+}
+
+const CATEGORICAL = [
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+];
+
+export function seriesColor(series: ChartSeries, index: number): string {
+  return series.color ?? CATEGORICAL[index % CATEGORICAL.length] ?? '';
+}
+
+/* --- Axis ticks ----------------------------------------------------------- */
+
+/*
+ * Recharts hands tick renderers x/y plus the value. The text wears text
+ * tokens -- mono, meta ink -- because an axis is furniture: it has to be
+ * legible and forgettable at once.
+ */
+interface TickProps {
+  x?: number;
+  y?: number;
+  payload?: { value: string | number };
+  format?: (value: string | number) => string;
+}
+
+export function XTick({ x, y, payload, format }: TickProps) {
+  if (payload == null) return null;
+  return (
+    <text
+      x={x}
+      y={y}
+      dy={12}
+      textAnchor="middle"
+      className="fill-fg-ghost font-mono text-mono-sm"
+    >
+      {format ? format(payload.value) : payload.value}
+    </text>
+  );
+}
+
+XTick.displayName = 'XTick';
+
+export function YTick({ x, y, payload, format }: TickProps) {
+  if (payload == null) return null;
+  return (
+    <text
+      x={x}
+      y={y}
+      dy={3}
+      textAnchor="end"
+      className="fill-fg-ghost font-mono text-mono-sm tabular-nums"
+    >
+      {format ? format(payload.value) : payload.value}
+    </text>
+  );
+}
+
+YTick.displayName = 'YTick';
+
+/* --- Tooltip -------------------------------------------------------------- */
+
+const tooltipCard = tv({
+  slots: {
+    card: [
+      'min-w-36 rounded-md border border-border bg-surface-floating',
+      'px-2.5 py-2 shadow-overlay',
+    ],
+    label: 'pb-1.5 font-mono text-fg-subtle text-mono-sm',
+    row: 'flex items-center gap-2 py-0.5',
+    dot: 'size-dot shrink-0 rounded-pill',
+    name: 'min-w-0 flex-1 truncate text-fg-muted text-meta',
+    value: 'shrink-0 font-mono text-fg text-mono-sm tabular-nums',
+  },
+});
+
+const tipStyles = tooltipCard();
+
+/** The shape recharts passes to a custom tooltip `content`. */
+export interface ChartTooltipProps {
+  active?: boolean;
+  label?: string | number;
+  payload?: Array<{
+    dataKey?: string | number;
+    value?: number | string;
+    color?: string;
+  }>;
+  series: ChartSeries[];
+  formatLabel?: (value: string | number) => string;
+  formatValue?: (value: number) => string;
+}
+
+/**
+ * The reading layer. Values live here and in the axis, never printed on
+ * every mark: the chart shows the shape, the pointer asks for the number.
+ */
+export function ChartTooltip({
+  active,
+  label,
+  payload,
+  series,
+  formatLabel,
+  formatValue,
+}: ChartTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div className={tipStyles.card()}>
+      {label != null ? (
+        <div className={tipStyles.label()}>
+          {formatLabel ? formatLabel(label) : label}
+        </div>
+      ) : null}
+      {/* Stacks paint bottom-up but read top-down: reverse to match the
+          drawing, so the first row is the topmost band. */}
+      {[...payload].reverse().map((entry) => {
+        const meta = series.find((s) => s.key === entry.dataKey);
+        return (
+          <div key={String(entry.dataKey)} className={tipStyles.row()}>
+            <span
+              aria-hidden="true"
+              className={tipStyles.dot()}
+              style={{ background: entry.color }}
+            />
+            <span className={tipStyles.name()}>
+              {meta?.label ?? entry.dataKey}
+            </span>
+            <span className={tipStyles.value()}>
+              {typeof entry.value === 'number' && formatValue
+                ? formatValue(entry.value)
+                : entry.value}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+ChartTooltip.displayName = 'ChartTooltip';
+
+/* --- Legend --------------------------------------------------------------- */
+
+const legend = tv({
+  slots: {
+    row: 'flex flex-wrap items-center gap-x-4 gap-y-1 pt-2',
+    item: 'flex items-center gap-1.5',
+    dot: 'size-dot shrink-0 rounded-pill',
+    label: 'text-fg-muted text-meta',
+  },
+});
+
+const legendStyles = legend();
+
+/**
+ * Drawn for two series or more, never for one -- a lone series is named by
+ * the card's title, and a one-item legend is a caption pretending to be a
+ * key. Ours, not recharts': the text has to wear the system's tokens.
+ */
+export function ChartLegend({
+  series,
+  children,
+}: {
+  series: ChartSeries[];
+  children?: ReactNode;
+}) {
+  if (series.length < 2) return null;
+
+  return (
+    <div className={legendStyles.row()}>
+      {series.map((entry, index) => (
+        <span key={entry.key} className={legendStyles.item()}>
+          <span
+            aria-hidden="true"
+            className={legendStyles.dot()}
+            style={{ background: seriesColor(entry, index) }}
+          />
+          <span className={legendStyles.label()}>{entry.label}</span>
+        </span>
+      ))}
+      {children}
+    </div>
+  );
+}
+
+ChartLegend.displayName = 'ChartLegend';

--- a/packages/ui/src/components/chart/chart-parts.tsx
+++ b/packages/ui/src/components/chart/chart-parts.tsx
@@ -1,38 +1,11 @@
 import type { ReactNode } from 'react';
 import { tv } from '../../lib/tv';
+import { type ChartSeries, seriesColor } from './chart-series';
 
 /**
- * What every chart shares: the series contract, the palette order, the
- * tooltip card, the legend row and the axis ticks.
- *
- * Colours are CSS variables end to end -- `var(--chart-1)`, `var(--sev-error)`
- * -- which is what lets the same SVG follow the theme. The categorical order
- * is **fixed**: chart-1 to chart-5, assigned by position and never cycled or
- * re-dealt when a series is filtered away. Identity sticks to the entity;
- * the palette was validated (CVD, chroma, contrast) as a sequence, and a
- * sixth series is a design question, not a sixth colour.
+ * What every chart shares: the tooltip card, the legend row and the axis
+ * ticks. The series contract and the palette order live in `chart-series.ts`.
  */
-
-/** One drawn series: which field, what to call it, and -- rarely -- what
- *  colour, when the series *is* a status (severity) rather than an entity. */
-export interface ChartSeries {
-  key: string;
-  label: string;
-  /** A CSS colour, `var(--token)` only. Absent: the categorical order. */
-  color?: string;
-}
-
-const CATEGORICAL = [
-  'var(--chart-1)',
-  'var(--chart-2)',
-  'var(--chart-3)',
-  'var(--chart-4)',
-  'var(--chart-5)',
-];
-
-export function seriesColor(series: ChartSeries, index: number): string {
-  return series.color ?? CATEGORICAL[index % CATEGORICAL.length] ?? '';
-}
 
 /* --- Axis ticks ----------------------------------------------------------- */
 
@@ -129,7 +102,7 @@ export function ChartTooltip({
   if (!active || !payload?.length) return null;
 
   return (
-    <div className={tipStyles.card()}>
+    <div role="status" className={tipStyles.card()}>
       {label != null ? (
         <div className={tipStyles.label()}>
           {formatLabel ? formatLabel(label) : label}

--- a/packages/ui/src/components/chart/chart-series.ts
+++ b/packages/ui/src/components/chart/chart-series.ts
@@ -1,0 +1,35 @@
+/**
+ * The series contract and the palette order.
+ *
+ * They sit beside `chart-parts.tsx` rather than inside it because a file
+ * that exports both components and plain values is a file React Fast
+ * Refresh cannot preserve state across (`react-doctor/only-export-components`).
+ *
+ * Colours are CSS variables end to end -- `var(--chart-1)`, `var(--sev-error)`
+ * -- which is what lets the same SVG follow the theme. The categorical order
+ * is **fixed**: chart-1 to chart-5, assigned by position and never cycled or
+ * re-dealt when a series is filtered away. Identity sticks to the entity;
+ * the palette was validated (CVD, chroma, contrast) as a sequence, and a
+ * sixth series is a design question, not a sixth colour.
+ */
+
+/** One drawn series: which field, what to call it, and -- rarely -- what
+ *  colour, when the series *is* a status (severity) rather than an entity. */
+export interface ChartSeries {
+  key: string;
+  label: string;
+  /** A CSS colour, `var(--token)` only. Absent: the categorical order. */
+  color?: string;
+}
+
+const CATEGORICAL = [
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+];
+
+export function seriesColor(series: ChartSeries, index: number): string {
+  return series.color ?? CATEGORICAL[index] ?? '';
+}

--- a/packages/ui/src/components/chart/sparkline.stories.tsx
+++ b/packages/ui/src/components/chart/sparkline.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Text } from '../text/text';
+import { Sparkline } from './sparkline';
+
+function seed(count: number, low: number, high: number, start: number) {
+  const out: number[] = [];
+  let x = start;
+  for (let i = 0; i < count; i++) {
+    x = (x * 9301 + 49297) % 233280;
+    out.push(low + (x / 233280) * (high - low));
+  }
+  return out;
+}
+
+const meta = {
+  title: 'Charts/Sparkline',
+  component: Sparkline,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Sparkline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The three tones: state, not decoration. */
+export const Tones: Story = {
+  args: { values: [], label: '' },
+  render: () => (
+    <div className="flex flex-col gap-3">
+      {(
+        [
+          ['danger', 'getting worse', seed(14, 2, 14, 11)],
+          ['brand', 'being watched', seed(14, 1, 9, 41)],
+          ['neutral', 'everything else', seed(14, 1, 8, 27)],
+        ] as const
+      ).map(([tone, hint, values]) => (
+        <div key={tone} className="flex items-center gap-4">
+          <Sparkline
+            values={[...values]}
+            tone={tone}
+            label={`Events, last 14 days (${tone})`}
+          />
+          <Text variant="meta" tone="subtle">
+            {tone} — {hint}
+          </Text>
+        </div>
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const spark = canvas.getByRole('img', {
+      name: 'Events, last 14 days (danger)',
+    });
+    await expect(spark).toBeInTheDocument();
+    // One bar per bucket, zeros included: a vanished bucket reads as a hole.
+    await expect(spark.querySelectorAll('rect').length).toBe(14);
+  },
+};
+
+/** Where it lives: a table cell, dozens per page, none of them animated. */
+export const InAList: Story = {
+  args: { values: [], label: '' },
+  render: () => (
+    <div className="w-120 rounded-xl border border-border-subtle bg-panel">
+      {(
+        [
+          ['ConnectionTimeout: pool exhausted', 'danger', 11],
+          ['ValidationError: coupon not applicable', 'neutral', 27],
+          ['DeprecationWarning: legacy shipping API', 'neutral', 63],
+        ] as const
+      ).map(([title, tone, s]) => (
+        <div
+          key={title}
+          className="flex items-center gap-4 border-border-divider border-b px-4 py-3 last:border-0"
+        >
+          <Text variant="value" truncate className="flex-1">
+            {title}
+          </Text>
+          <Sparkline
+            values={seed(14, 1, 12, s)}
+            tone={tone}
+            label="Events, last 14 days"
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/chart/sparkline.tsx
+++ b/packages/ui/src/components/chart/sparkline.tsx
@@ -1,0 +1,92 @@
+import { tv, type VariantProps } from '../../lib/tv';
+
+/**
+ * The fourteen days of an issue, in a table cell.
+ *
+ * Hand-drawn SVG, not recharts: a page of fifty rows means fifty of these,
+ * and each recharts chart brings its own store, its observers and its
+ * animation. A sparkline is a shape to be skimmed, so it gets none of that
+ * -- fixed viewBox, no axes, no tooltip, no motion, and the row's own text
+ * says the numbers.
+ *
+ * The tone is state, not decoration: `danger` for the row that is getting
+ * worse, `brand` for the one being watched, `neutral` for everything else.
+ * A column where every sparkline is coloured says nothing.
+ */
+const sparkline = tv({
+  slots: {
+    svg: 'block',
+    bar: '',
+  },
+  variants: {
+    tone: {
+      neutral: { bar: 'fill-border-control' },
+      brand: { bar: 'fill-surface-brand/80' },
+      danger: { bar: 'fill-sev-error/75' },
+    },
+  },
+  defaultVariants: { tone: 'neutral' },
+});
+
+export type SparklineTone = NonNullable<VariantProps<typeof sparkline>['tone']>;
+
+export interface SparklineProps {
+  /** One figure per bucket, oldest first. */
+  values: number[];
+  tone?: SparklineTone;
+  width?: number;
+  height?: number;
+  /**
+   * What the shape stands for: "Events, last 14 days". Required -- without
+   * it a screen reader meets an unnamed image in every row.
+   */
+  label: string;
+  className?: string;
+}
+
+const VIEW_W = 100;
+const VIEW_H = 32;
+
+export function Sparkline({
+  values,
+  tone,
+  width = 110,
+  height = 28,
+  label,
+  className,
+}: SparklineProps) {
+  const styles = sparkline({ tone });
+  const max = Math.max(...values, 1);
+  const step = VIEW_W / values.length;
+
+  return (
+    <svg
+      viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+      preserveAspectRatio="none"
+      width={width}
+      height={height}
+      role="img"
+      aria-label={label}
+      className={sparkline().svg({ className })}
+    >
+      {values.map((value, index) => {
+        // Every bucket draws at least a hair of bar: a zero that vanishes
+        // reads as a missing bucket, not as a quiet day.
+        const h = Math.max((value / max) * (VIEW_H - 2), 1.2);
+        return (
+          <rect
+            // Buckets are positional by nature: index is their identity.
+            key={index}
+            x={index * step}
+            y={VIEW_H - h}
+            width={step * 0.62}
+            height={h}
+            className={styles.bar()}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+Sparkline.displayName = 'Sparkline';

--- a/packages/ui/src/components/chart/time-series-chart.stories.tsx
+++ b/packages/ui/src/components/chart/time-series-chart.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, waitFor, within } from 'storybook/test';
+import { Text } from '../text/text';
+import { TimeSeriesChart } from './time-series-chart';
+
+/** The same deterministic wiggle the design mocks used: no clock, no RNG. */
+function seed(count: number, low: number, high: number, start: number) {
+  const out: number[] = [];
+  let x = start;
+  for (let i = 0; i < count; i++) {
+    x = (x * 9301 + 49297) % 233280;
+    out.push(Math.round(low + (x / 233280) * (high - low)));
+  }
+  return out;
+}
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const events = seed(24, 400, 2400, 5);
+const users = seed(24, 60, 380, 17);
+
+const DATA = HOURS.map((hour, i) => ({
+  hour,
+  events: events[i] ?? 0,
+  users: users[i] ?? 0,
+}));
+
+const adoptionNew = seed(24, 5, 20, 7).map((v, i) => Math.min(96, v + i * 4));
+const ADOPTION = HOURS.map((hour, i) => {
+  const current = adoptionNew[i] ?? 0;
+  return { hour, current, previous: 100 - current };
+});
+
+const formatHour = (value: string | number) => `${value}:00`;
+const formatCount = (value: number) =>
+  value >= 1000 ? `${(value / 1000).toFixed(1)}k` : String(value);
+
+const meta = {
+  title: 'Charts/TimeSeries',
+  component: TimeSeriesChart,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof TimeSeriesChart>;
+
+export default meta;
+type Story = StoryObj;
+
+/** One series needs no legend: the card's title names it. */
+export const SingleSeries: Story = {
+  render: () => (
+    <div className="w-160 rounded-xl border border-border-subtle bg-surface p-4">
+      <Text variant="card-title" render={<h3 />} className="pb-3">
+        Events, last 24 h
+      </Text>
+      <TimeSeriesChart
+        data={DATA}
+        series={[{ key: 'events', label: 'Events' }]}
+        xKey="hour"
+        height={180}
+        formatX={formatHour}
+        formatY={formatCount}
+        label="Events over the last 24 hours"
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The drawing arrives once the container has measured itself.
+    await waitFor(() =>
+      expect(
+        canvasElement.querySelector('.recharts-area-curve'),
+      ).toBeInTheDocument(),
+    );
+    // One series: the title carries the name, no legend box.
+    await expect(canvas.queryByText('Events')).not.toBeInTheDocument();
+  },
+};
+
+/** Two series overlay; the legend appears on its own, in fixed order. */
+export const TwoSeries: Story = {
+  render: () => (
+    <div className="w-160 rounded-xl border border-border-subtle bg-surface p-4">
+      <Text variant="card-title" render={<h3 />} className="pb-3">
+        Volume, last 24 h
+      </Text>
+      <TimeSeriesChart
+        data={DATA}
+        series={[
+          { key: 'events', label: 'Events' },
+          { key: 'users', label: 'Affected users' },
+        ]}
+        xKey="hour"
+        height={180}
+        formatX={formatHour}
+        formatY={formatCount}
+        label="Events and affected users over the last 24 hours"
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Events')).toBeInTheDocument();
+    await expect(canvas.getByText('Affected users')).toBeInTheDocument();
+  },
+};
+
+/** Stacked areas: the release-adoption drawing from the redesign. */
+export const StackedAdoption: Story = {
+  render: () => (
+    <div className="w-160 rounded-xl border border-border-subtle bg-surface p-4">
+      <Text variant="card-title" render={<h3 />} className="pb-3">
+        Release adoption
+      </Text>
+      <TimeSeriesChart
+        data={ADOPTION}
+        series={[
+          { key: 'previous', label: '2.10.0' },
+          { key: 'current', label: '2.11.0' },
+        ]}
+        xKey="hour"
+        height={160}
+        stacked
+        formatX={formatHour}
+        formatY={(value) => `${value} %`}
+        yDomain={[0, 100]}
+        label="Share of sessions per release over the last 24 hours"
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/chart/time-series-chart.tsx
+++ b/packages/ui/src/components/chart/time-series-chart.tsx
@@ -1,4 +1,9 @@
 import { useId } from 'react';
+// Not loaded through next/dynamic, deliberately: this package has no
+// framework opinion, and recharts is already the only thing that pulls
+// these primitives in -- deferring the import buys nothing a consumer's own
+// code-splitting doesn't already give it.
+// react-doctor-disable-next-line react-doctor/prefer-dynamic-import
 import {
   Area,
   AreaChart,
@@ -8,14 +13,8 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import {
-  ChartLegend,
-  type ChartSeries,
-  ChartTooltip,
-  seriesColor,
-  XTick,
-  YTick,
-} from './chart-parts';
+import { ChartLegend, ChartTooltip, XTick, YTick } from './chart-parts';
+import { type ChartSeries, seriesColor } from './chart-series';
 
 /**
  * A time series: events over time, adoption of a release, latency.

--- a/packages/ui/src/components/chart/time-series-chart.tsx
+++ b/packages/ui/src/components/chart/time-series-chart.tsx
@@ -1,0 +1,171 @@
+import { useId } from 'react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import {
+  ChartLegend,
+  type ChartSeries,
+  ChartTooltip,
+  seriesColor,
+  XTick,
+  YTick,
+} from './chart-parts';
+
+/**
+ * A time series: events over time, adoption of a release, latency.
+ *
+ * Areas with a 2 px stroke and a gradient fill that falls to nothing -- the
+ * line carries the reading, the fill only seats it on the baseline. Stacked,
+ * the fills turn solid at low opacity instead: stacked gradients over
+ * gradients turn to mud.
+ *
+ * The grid is horizontal only and dashed: enough to carry the eye to the
+ * axis, not enough to cage the data. The crosshair and the tooltip are the
+ * reading layer -- values live there and on the axis, never printed on
+ * every point.
+ */
+export interface TimeSeriesChartProps<TDatum extends Record<string, unknown>> {
+  data: TDatum[];
+  series: ChartSeries[];
+  /** The field that carries time. */
+  xKey: string;
+  /** Fixed height in pixels; the width follows the container. */
+  height: number;
+  /** Sum the series instead of overlaying them. */
+  stacked?: boolean;
+  formatX?: (value: string | number) => string;
+  formatY?: (value: number) => string;
+  /** Pin the Y scale: `[0, 100]` for a share. Absent, it follows the data. */
+  yDomain?: [number, number];
+  /** Names the figure for screen readers; the drawing stays explorable. */
+  label: string;
+  className?: string;
+}
+
+export function TimeSeriesChart<TDatum extends Record<string, unknown>>({
+  data,
+  series,
+  xKey,
+  height,
+  stacked = false,
+  formatX,
+  formatY,
+  yDomain,
+  label,
+  className,
+}: TimeSeriesChartProps<TDatum>) {
+  // Gradient ids are document-global: with several charts on one page a
+  // shared id would paint every chart with the first one's gradient.
+  const id = useId();
+
+  return (
+    <figure className={className} aria-label={label}>
+      <ResponsiveContainer width="100%" height={height}>
+        <AreaChart
+          data={data}
+          margin={{ top: 4, right: 20, bottom: 0, left: 0 }}
+        >
+          <defs>
+            {series.map((entry, index) => (
+              <linearGradient
+                key={entry.key}
+                id={`${id}-${entry.key}`}
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="1"
+              >
+                <stop
+                  offset="0%"
+                  stopColor={seriesColor(entry, index)}
+                  stopOpacity={0.25}
+                />
+                <stop
+                  offset="100%"
+                  stopColor={seriesColor(entry, index)}
+                  stopOpacity={0}
+                />
+              </linearGradient>
+            ))}
+          </defs>
+
+          <CartesianGrid
+            vertical={false}
+            stroke="var(--border-divider)"
+            strokeDasharray="3 3"
+          />
+          <XAxis
+            dataKey={xKey}
+            axisLine={false}
+            tickLine={false}
+            tick={<XTick format={formatX} />}
+            interval="preserveStartEnd"
+            minTickGap={32}
+          />
+          <YAxis
+            width={40}
+            axisLine={false}
+            tickLine={false}
+            tick={
+              <YTick
+                format={formatY ? (value) => formatY(Number(value)) : undefined}
+              />
+            }
+            tickCount={4}
+            domain={yDomain}
+          />
+          <Tooltip
+            cursor={{ stroke: 'var(--border-strong)', strokeDasharray: '3 3' }}
+            isAnimationActive={false}
+            content={
+              <ChartTooltip
+                series={series}
+                formatLabel={formatX}
+                formatValue={formatY}
+              />
+            }
+          />
+
+          {series.map((entry, index) => (
+            <Area
+              key={entry.key}
+              dataKey={entry.key}
+              stackId={stacked ? 'stack' : undefined}
+              type="monotone"
+              stroke={seriesColor(entry, index)}
+              strokeWidth={2}
+              fill={
+                stacked ? seriesColor(entry, index) : `url(#${id}-${entry.key})`
+              }
+              fillOpacity={stacked ? 0.28 : 1}
+              // The dot only exists under the pointer: fifty resting dots
+              // are texture, one active dot is an answer.
+              dot={false}
+              activeDot={{
+                r: 3.5,
+                strokeWidth: 2,
+                stroke: 'var(--surface)',
+              }}
+              /*
+               * No entry animation, by doctrine: a series growing out of the
+               * baseline explains nothing, and motion that explains nothing
+               * is not drawn. What moves in a chart is the crosshair.
+               */
+              isAnimationActive={false}
+            />
+          ))}
+        </AreaChart>
+      </ResponsiveContainer>
+
+      <ChartLegend series={series} />
+    </figure>
+  );
+}
+
+TimeSeriesChart.displayName = 'TimeSeriesChart';

--- a/packages/ui/src/components/dialog/confirm.tsx
+++ b/packages/ui/src/components/dialog/confirm.tsx
@@ -1,8 +1,6 @@
-import { type ReactNode, useId, useState } from 'react';
-import { focusRingWithin } from '../../lib/focus';
-import { interactiveTransition } from '../../lib/motion';
-import { tv } from '../../lib/tv';
+import { type ReactNode, useState } from 'react';
 import { Button } from '../button/button';
+import { Field, FieldLabel } from '../field/field';
 import type { IconComponent } from '../icon/icon';
 import {
   DeleteIcon,
@@ -10,6 +8,7 @@ import {
   OkIcon,
   WarningIcon,
 } from '../icon/icon-catalog';
+import { Input } from '../input/input';
 import {
   DialogBody,
   DialogClose,
@@ -28,28 +27,6 @@ import { createDialog } from './dialog-manager';
  * -- choosing in a table, filling a form, showing a long process's outcome
  * -- is written with `createDialog`.
  */
-
-/*
- * The unlock field. The package has no Input primitive yet; when one
- * arrives, this recipe is what it replaces.
- */
-const phraseField = tv({
-  slots: {
-    field: [
-      'mt-2 flex h-control-md items-center rounded-md',
-      'border border-border-field bg-canvas px-2.5',
-      interactiveTransition,
-      focusRingWithin,
-    ],
-    input: [
-      'h-full w-full min-w-0 bg-transparent font-mono text-control text-fg',
-      'outline-none placeholder:text-fg-placeholder',
-    ],
-    label: 'block pt-3.5 text-fg-secondary text-label first:pt-0',
-  },
-});
-
-const phraseStyles = phraseField();
 
 export interface ConfirmOptions {
   /** What will happen, subject included: "Delete the RUSTRAK-1042 issue". */
@@ -90,7 +67,6 @@ function ConfirmContent({
   phrase,
   close,
 }: ConfirmOptions & { close: (result?: boolean) => void }) {
-  const id = useId();
   const [typed, setTyped] = useState('');
   const locked = phrase != null && typed.trim() !== phrase;
   const remaining = phrase == null ? 0 : phrase.length - typed.trim().length;
@@ -109,22 +85,21 @@ function ConfirmContent({
         <DialogBody inset>
           {details}
           {phrase ? (
-            <>
-              <label htmlFor={id} className={phraseStyles.label()}>
+            // A `Field`, which is what ties the label to the box: written by
+            // hand it would end in an `htmlFor` with no partner.
+            <Field className="pt-3.5 first:pt-0">
+              <FieldLabel>
                 Type <b className="font-mono text-fg">{phrase}</b> to continue
-              </label>
-              <div className={phraseStyles.field()}>
-                <input
-                  id={id}
-                  type="text"
-                  value={typed}
-                  onChange={(event) => setTyped(event.target.value)}
-                  autoComplete="off"
-                  spellCheck={false}
-                  className={phraseStyles.input()}
-                />
-              </div>
-            </>
+              </FieldLabel>
+              <Input
+                value={typed}
+                onChange={(event) => setTyped(event.target.value)}
+                autoComplete="off"
+                spellCheck={false}
+                size="sm"
+                className="font-mono"
+              />
+            </Field>
           ) : null}
         </DialogBody>
       ) : null}

--- a/packages/ui/src/components/field/field.tsx
+++ b/packages/ui/src/components/field/field.tsx
@@ -80,11 +80,16 @@ FieldLabel.displayName = 'FieldLabel';
 export interface FieldHintProps
   extends WithClassName<BaseField.Description.Props> {}
 
-/** The hint below the field: where the value goes, what format it takes. */
+/**
+ * The hint below the field: where the value goes, what format it takes.
+ *
+ * Hidden while the field is invalid: `FieldError` takes its place, and two
+ * lines of small print under one field is a wall, not guidance.
+ */
 export function FieldHint({ className, ...props }: FieldHintProps) {
   return (
     <BaseField.Description
-      className={cn('text-fg-subtle text-hint', className)}
+      className={cn('text-fg-subtle text-hint data-invalid:hidden', className)}
       {...props}
     />
   );

--- a/packages/ui/src/components/field/field.tsx
+++ b/packages/ui/src/components/field/field.tsx
@@ -51,7 +51,7 @@ export function FieldLabel({
 }: FieldLabelProps) {
   if (srOnly) {
     return (
-      <BaseField.Label className="sr-only" {...props}>
+      <BaseField.Label className={cn('sr-only', className)} {...props}>
         {children}
       </BaseField.Label>
     );
@@ -83,15 +83,25 @@ export interface FieldHintProps
 /**
  * The hint below the field: where the value goes, what format it takes.
  *
- * Hidden while the field is invalid: `FieldError` takes its place, and two
- * lines of small print under one field is a wall, not guidance.
+ * Unmounted while the field is invalid: `FieldError` takes its place, and two
+ * lines of small print under one field is a wall, not guidance. Hiding it
+ * with CSS alone would leave its id registered in `aria-describedby` -- the
+ * screen reader would still read a hint the eye can't see -- so this reads
+ * validity through `Field.Validity` instead of rendering `Description`
+ * unconditionally.
  */
 export function FieldHint({ className, ...props }: FieldHintProps) {
   return (
-    <BaseField.Description
-      className={cn('text-fg-subtle text-hint data-invalid:hidden', className)}
-      {...props}
-    />
+    <BaseField.Validity>
+      {({ validity }) =>
+        validity.valid === false ? null : (
+          <BaseField.Description
+            className={cn('text-fg-subtle text-hint', className)}
+            {...props}
+          />
+        )
+      }
+    </BaseField.Validity>
   );
 }
 

--- a/packages/ui/src/components/field/field.tsx
+++ b/packages/ui/src/components/field/field.tsx
@@ -1,0 +1,110 @@
+import { Field as BaseField } from '@base-ui/react/field';
+import { cn } from '../../lib/cn';
+import type { WithClassName } from '../../lib/types';
+
+/**
+ * A form field: label, control, hint and error.
+ *
+ * Base UI's `Field.Root` is what ties the three together by `id` and
+ * `aria-describedby`, and what hands `data-invalid` and `data-disabled` down.
+ * This file only adds the look and the rules the design settled:
+ *
+ *   - the label wraps to two lines and never truncates: half a label says
+ *     nothing;
+ *   - the required asterisk is decoration -- what announces it is the
+ *     control's own `required`;
+ *   - the error replaces the hint while it stands, so a field never stacks
+ *     two lines of small print.
+ */
+export interface FieldProps extends WithClassName<BaseField.Root.Props> {}
+
+export function Field({ className, ...props }: FieldProps) {
+  return (
+    <BaseField.Root
+      className={cn('flex min-w-0 flex-col gap-1.5', className)}
+      {...props}
+    />
+  );
+}
+
+Field.displayName = 'Field';
+
+export interface FieldLabelProps extends WithClassName<BaseField.Label.Props> {
+  /** Paints the asterisk. The control must carry `required` too. */
+  required?: boolean;
+  /**
+   * The label keeps existing for the screen reader but is not drawn.
+   *
+   * For a control whose name is already said nearby -- a column heading, a
+   * dialog title -- repeating it is noise, but a control with no accessible
+   * name cannot be filled without seeing the screen.
+   */
+  srOnly?: boolean;
+}
+
+export function FieldLabel({
+  required,
+  srOnly,
+  className,
+  children,
+  ...props
+}: FieldLabelProps) {
+  if (srOnly) {
+    return (
+      <BaseField.Label className="sr-only" {...props}>
+        {children}
+      </BaseField.Label>
+    );
+  }
+
+  return (
+    <BaseField.Label
+      className={cn(
+        'text-fg-secondary text-label data-disabled:text-fg-disabled',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {required ? (
+        <span aria-hidden="true" className="text-danger-fg">
+          {' *'}
+        </span>
+      ) : null}
+    </BaseField.Label>
+  );
+}
+
+FieldLabel.displayName = 'FieldLabel';
+
+export interface FieldHintProps
+  extends WithClassName<BaseField.Description.Props> {}
+
+/** The hint below the field: where the value goes, what format it takes. */
+export function FieldHint({ className, ...props }: FieldHintProps) {
+  return (
+    <BaseField.Description
+      className={cn('text-fg-subtle text-hint', className)}
+      {...props}
+    />
+  );
+}
+
+FieldHint.displayName = 'FieldHint';
+
+export interface FieldErrorProps extends WithClassName<BaseField.Error.Props> {}
+
+/**
+ * The validation error. It replaces the hint while it stands: two lines of
+ * small print under every field of a long form is a wall, not guidance.
+ */
+export function FieldError({ className, ...props }: FieldErrorProps) {
+  return (
+    <BaseField.Error
+      className={cn('text-danger-fg text-hint', className)}
+      {...props}
+    />
+  );
+}
+
+FieldError.displayName = 'FieldError';

--- a/packages/ui/src/components/input/input-shell.ts
+++ b/packages/ui/src/components/input/input-shell.ts
@@ -1,0 +1,90 @@
+import { focusRingWithin } from '../../lib/focus';
+import { interactiveTransition } from '../../lib/motion';
+import { tv } from '../../lib/tv';
+
+/**
+ * The box every text control shares.
+ *
+ * It lives apart because more than one component needs it -- the input, the
+ * textarea, whatever field comes next -- and all of them have to measure,
+ * frame and react exactly the same. If each copied the classes, in three
+ * months there would be several similar boxes and no equal ones.
+ *
+ * The box takes no state props: it reads the control it wraps. Whoever sets
+ * `disabled` -- the caller, a `<fieldset>` above, Base UI's `Field.Root`
+ * when validating -- the box finds out the same way, and there are never two
+ * sources of truth to disagree.
+ *
+ * Careful with `:read-only`: in CSS it is **not** only for form controls.
+ * Per the specification it matches anything that is not editable -- a
+ * `<span>`, a `<button>`, an icon. A bare `has-[:read-only]` painted grey
+ * any field carrying a symbol or a button inside. So the attribute is
+ * checked, and only on an `input` or `textarea`.
+ *
+ * Rule order is priority order -- they all weigh the same in CSS and the
+ * last one wins: normal, read-only, invalid, disabled.
+ */
+export const inputShell = tv({
+  slots: {
+    box: [
+      'flex w-full items-center gap-2 rounded-md border',
+      'ps-2.5 pe-1.5',
+      interactiveTransition,
+      'border-border-field bg-canvas',
+      'hover:border-border-strong',
+
+      // Read-only: the field settles into the surface. It still reads, so
+      // the text stays; what goes is the promise of a caret.
+      'has-[input[readonly]]:border-transparent',
+      'has-[input[readonly]]:bg-surface-disabled',
+      'has-[textarea[readonly]]:border-transparent',
+      'has-[textarea[readonly]]:bg-surface-disabled',
+
+      'has-[[data-invalid]]:border-danger',
+
+      'has-[input:disabled]:border-border-subtle',
+      'has-[input:disabled]:bg-surface-disabled',
+      'has-[textarea:disabled]:border-border-subtle',
+      'has-[textarea:disabled]:bg-surface-disabled',
+      // The forbidden cursor covers the whole box, not only the input: the
+      // gap between border and text is part of the field too, and pausing
+      // there with no signal is what makes a person wonder if it is broken.
+      'has-[input:disabled]:cursor-not-allowed',
+      'has-[textarea:disabled]:cursor-not-allowed',
+
+      focusRingWithin,
+      // A read-only field lighting up lime on focus promises a writing it
+      // will not accept.
+      'has-[input[readonly]]:focus-within:border-border-subtle',
+      'has-[input[readonly]]:focus-within:ring-0',
+      'has-[textarea[readonly]]:focus-within:border-border-subtle',
+      'has-[textarea[readonly]]:focus-within:ring-0',
+    ],
+    control: [
+      'min-w-0 flex-1 bg-transparent text-control text-fg outline-none',
+      'placeholder:text-fg-placeholder',
+      'read-only:cursor-default read-only:text-fg-secondary',
+      'disabled:cursor-not-allowed disabled:text-fg-disabled',
+    ],
+    adornment: 'shrink-0 text-fg-subtle',
+  },
+  variants: {
+    size: {
+      md: { box: 'h-control-lg' },
+      /** Inside dense chrome -- a filter panel, a popover -- 32 px. */
+      sm: { box: 'h-control-md' },
+    },
+    /**
+     * Figures: end-aligned and tabular, so a column of counts squares up by
+     * the digit and can be compared at a glance.
+     */
+    numeric: { true: { control: 'text-end font-mono tabular-nums' } },
+    /** Multi-line: the box grows with the text and aligns to its top. */
+    multiline: {
+      true: { box: 'h-auto items-start py-2', control: 'resize-none' },
+    },
+  },
+  defaultVariants: { size: 'md' },
+});
+
+export type InputShellSize = 'sm' | 'md';

--- a/packages/ui/src/components/input/input.stories.tsx
+++ b/packages/ui/src/components/input/input.stories.tsx
@@ -55,6 +55,16 @@ export const States: Story = {
         <Input numeric defaultValue="500" size="sm" />
         <FieldHint>Events per minute.</FieldHint>
       </Field>
+
+      <Field>
+        <FieldLabel>Resolution note</FieldLabel>
+        <Textarea
+          size="sm"
+          rows={4}
+          placeholder="What fixed it, for the next reader…"
+        />
+        <FieldHint>Kept with the issue's history.</FieldHint>
+      </Field>
     </div>
   ),
 };
@@ -92,18 +102,6 @@ export const Adorned: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Clear search' }));
     await expect(canvas.getByRole('textbox')).toHaveValue('');
   },
-};
-
-export const Multiline: Story = {
-  render: () => (
-    <div className="w-96">
-      <Field>
-        <FieldLabel>Resolution note</FieldLabel>
-        <Textarea rows={4} placeholder="What fixed it, for the next reader…" />
-        <FieldHint>Kept with the issue's history.</FieldHint>
-      </Field>
-    </div>
-  ),
 };
 
 /** The label reaches the control: clicking it is clicking the field. */

--- a/packages/ui/src/components/input/input.stories.tsx
+++ b/packages/ui/src/components/input/input.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+import { Field, FieldError, FieldHint, FieldLabel } from '../field/field';
+import { CloseIcon, SearchIcon } from '../icon/icon-catalog';
+import { Input, InputAction, Textarea } from './input';
+
+const meta = {
+  title: 'Components/Input',
+  component: Input,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj;
+
+/** Every state of the box side by side, which is what reveals drift. */
+export const States: Story = {
+  render: () => (
+    <div className="flex w-96 flex-col gap-4">
+      <Field>
+        <FieldLabel>Project name</FieldLabel>
+        <Input placeholder="checkout-api" />
+        <FieldHint>Lowercase, hyphens for spaces.</FieldHint>
+      </Field>
+
+      <Field>
+        <FieldLabel required>Alert name</FieldLabel>
+        <Input required placeholder="Fatal errors in checkout" />
+      </Field>
+
+      <Field>
+        <FieldLabel>DSN</FieldLabel>
+        <Input
+          readOnly
+          value="https://a1b2@ingest.rustrak.dev/42"
+          className="font-mono"
+        />
+        <FieldHint>Read-only: rotate it from project settings.</FieldHint>
+      </Field>
+
+      <Field disabled>
+        <FieldLabel>Organisation</FieldLabel>
+        <Input disabled value="Acme Corp" />
+      </Field>
+
+      <Field>
+        <FieldLabel>Webhook URL</FieldLabel>
+        <Input invalid defaultValue="not-a-url" />
+        <FieldError match>Must start with https://</FieldError>
+      </Field>
+
+      <Field>
+        <FieldLabel>Threshold</FieldLabel>
+        <Input numeric defaultValue="500" size="sm" />
+        <FieldHint>Events per minute.</FieldHint>
+      </Field>
+    </div>
+  ),
+};
+
+/** The box takes a leading symbol and a trailing action without breaking. */
+export const Adorned: Story = {
+  render: function AdornedStory() {
+    const [value, setValue] = useState('timeout');
+
+    return (
+      <div className="flex w-96 flex-col gap-4">
+        <Field>
+          <FieldLabel>Search issues</FieldLabel>
+          <Input
+            leading={<SearchIcon size="md" />}
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            action={
+              value ? (
+                <InputAction
+                  icon={CloseIcon}
+                  aria-label="Clear search"
+                  onClick={() => setValue('')}
+                />
+              ) : null
+            }
+          />
+        </Field>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Clear search' }));
+    await expect(canvas.getByRole('textbox')).toHaveValue('');
+  },
+};
+
+export const Multiline: Story = {
+  render: () => (
+    <div className="w-96">
+      <Field>
+        <FieldLabel>Resolution note</FieldLabel>
+        <Textarea rows={4} placeholder="What fixed it, for the next reader…" />
+        <FieldHint>Kept with the issue's history.</FieldHint>
+      </Field>
+    </div>
+  ),
+};
+
+/** The label reaches the control: clicking it is clicking the field. */
+export const Wired: Story = {
+  render: () => (
+    <div className="w-96">
+      <Field>
+        <FieldLabel>Alert name</FieldLabel>
+        <Input placeholder="Fatal errors in checkout" />
+        <FieldHint>Shown in the notification.</FieldHint>
+      </Field>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: 'Alert name' });
+
+    await userEvent.click(canvas.getByText('Alert name'));
+    await expect(input).toHaveFocus();
+
+    // The hint is part of the field's description, not loose text.
+    await expect(input).toHaveAccessibleDescription(
+      'Shown in the notification.',
+    );
+  },
+};

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -1,0 +1,143 @@
+import { Field as BaseField } from '@base-ui/react/field';
+import type {
+  ComponentPropsWithoutRef,
+  ComponentPropsWithRef,
+  ReactNode,
+} from 'react';
+import { cn } from '../../lib/cn';
+import { focusRing } from '../../lib/focus';
+import { interactiveTransition, pressScaleSmall } from '../../lib/motion';
+import type { VariantProps } from '../../lib/tv';
+import type { IconComponent } from '../icon/icon';
+import { inputShell } from './input-shell';
+
+export interface InputProps
+  extends Omit<ComponentPropsWithoutRef<'input'>, 'size'>,
+    Omit<VariantProps<typeof inputShell>, 'multiline'> {
+  /** A symbol or icon glued to the start: a search glass, a unit. */
+  leading?: ReactNode;
+  /** The button at the end: clear, reveal, open. Use `InputAction`. */
+  action?: ReactNode;
+  /** Marks the field invalid without leaning on native validation. */
+  invalid?: boolean;
+  /** Classes for the box; `className` goes to the `input` itself. */
+  boxClassName?: string;
+}
+
+/**
+ * The text field. Inside a `Field` it wires itself to the label and the
+ * error through Base UI's control; on its own it needs an `aria-label`.
+ */
+export function Input({
+  size,
+  numeric,
+  leading,
+  action,
+  invalid,
+  className,
+  boxClassName,
+  ...props
+}: InputProps) {
+  // Variants are pulled off one by one, never with a rest: whatever stays in
+  // `...props` lands on the `<input>`, and a variant that slips through
+  // paints nothing and comes back out of React as an unknown DOM attribute.
+  const styles = inputShell({ size, numeric });
+
+  return (
+    <span className={styles.box({ className: boxClassName })}>
+      {leading ? (
+        <span aria-hidden="true" className={styles.adornment()}>
+          {leading}
+        </span>
+      ) : null}
+
+      <BaseField.Control
+        aria-invalid={invalid || undefined}
+        data-invalid={invalid || undefined}
+        className={styles.control({ className })}
+        {...props}
+      />
+
+      {action}
+    </span>
+  );
+}
+
+Input.displayName = 'Input';
+
+export interface TextareaProps
+  extends ComponentPropsWithoutRef<'textarea'>,
+    Pick<VariantProps<typeof inputShell>, 'size'> {
+  invalid?: boolean;
+  boxClassName?: string;
+}
+
+/** The multi-line field, in the same box: it grows, the frame stays one. */
+export function Textarea({
+  size,
+  invalid,
+  className,
+  boxClassName,
+  rows = 3,
+  ...props
+}: TextareaProps) {
+  const styles = inputShell({ size, multiline: true });
+
+  return (
+    <span className={styles.box({ className: boxClassName })}>
+      {/* The textarea's own props ride the rendered element: `Control` is
+          typed for an input, and only its wiring belongs to it. */}
+      <BaseField.Control
+        render={
+          <textarea
+            rows={rows}
+            aria-invalid={invalid || undefined}
+            data-invalid={invalid || undefined}
+            className={styles.control({ className })}
+            {...props}
+          />
+        }
+      />
+    </span>
+  );
+}
+
+Textarea.displayName = 'Textarea';
+
+export interface InputActionProps
+  extends Omit<ComponentPropsWithRef<'button'>, 'children'> {
+  icon: IconComponent;
+  /** What the button does. Required: it carries no visible text. */
+  'aria-label': string;
+}
+
+/**
+ * The button at the field's end: the clear cross of a search, the reveal
+ * eye of a secret, the chevron of a closed list.
+ */
+export function InputAction({
+  icon: Icon,
+  className,
+  ...props
+}: InputActionProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex size-6 shrink-0 items-center justify-center rounded-sm',
+        'text-fg-ghost',
+        'hover:bg-surface-selected hover:text-fg',
+        'disabled:text-fg-disabled',
+        interactiveTransition,
+        pressScaleSmall,
+        focusRing,
+        className,
+      )}
+      {...props}
+    >
+      <Icon size="md" aria-hidden="true" />
+    </button>
+  );
+}
+
+InputAction.displayName = 'InputAction';

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -1,8 +1,11 @@
 import { Field as BaseField } from '@base-ui/react/field';
-import type {
-  ComponentPropsWithoutRef,
-  ComponentPropsWithRef,
-  ReactNode,
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentPropsWithRef,
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
 } from 'react';
 import { cn } from '../../lib/cn';
 import { focusRing } from '../../lib/focus';
@@ -25,6 +28,19 @@ export interface InputProps
 }
 
 /**
+ * The trailing action rides on the control's own `disabled`: Base UI's
+ * `Field.Root` and a bare `disabled` prop both reach `BaseField.Control` the
+ * same way, but `action` is a sibling the control knows nothing about, so
+ * without this it stays focusable and clickable on a disabled field.
+ */
+function disabledAction(action: ReactNode, disabled: boolean | undefined) {
+  if (!disabled || !isValidElement(action)) return action;
+  return cloneElement(action as ReactElement<{ disabled?: boolean }>, {
+    disabled: true,
+  });
+}
+
+/**
  * The text field. Inside a `Field` it wires itself to the label and the
  * error through Base UI's control; on its own it needs an `aria-label`.
  */
@@ -34,6 +50,7 @@ export function Input({
   leading,
   action,
   invalid,
+  disabled,
   className,
   boxClassName,
   ...props
@@ -52,13 +69,14 @@ export function Input({
       ) : null}
 
       <BaseField.Control
+        disabled={disabled}
         aria-invalid={invalid || undefined}
         data-invalid={invalid || undefined}
         className={styles.control({ className })}
         {...props}
       />
 
-      {action}
+      {disabledAction(action, disabled)}
     </span>
   );
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -201,15 +201,10 @@ export { useDataTable } from './components/data-table/use-data-table';
 
 export type { BarsChartProps } from './components/chart/bars-chart';
 export { BarsChart } from './components/chart/bars-chart';
-export type {
-  ChartSeries,
-  ChartTooltipProps,
-} from './components/chart/chart-parts';
-export {
-  ChartLegend,
-  ChartTooltip,
-  seriesColor,
-} from './components/chart/chart-parts';
+export type { ChartTooltipProps } from './components/chart/chart-parts';
+export { ChartLegend, ChartTooltip } from './components/chart/chart-parts';
+export type { ChartSeries } from './components/chart/chart-series';
+export { seriesColor } from './components/chart/chart-series';
 export type {
   SparklineProps,
   SparklineTone,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -134,6 +134,26 @@ export { Tooltip, TooltipProvider } from './components/tooltip/tooltip';
 
 export type { CheckboxProps } from './components/checkbox/checkbox';
 export { Checkbox } from './components/checkbox/checkbox';
+export type {
+  FieldErrorProps,
+  FieldHintProps,
+  FieldLabelProps,
+  FieldProps,
+} from './components/field/field';
+export {
+  Field,
+  FieldError,
+  FieldHint,
+  FieldLabel,
+} from './components/field/field';
+export type {
+  InputActionProps,
+  InputProps,
+  TextareaProps,
+} from './components/input/input';
+export { Input, InputAction, Textarea } from './components/input/input';
+export type { InputShellSize } from './components/input/input-shell';
+export { inputShell } from './components/input/input-shell';
 export type { PopoverProps } from './components/popover/popover';
 export { Popover } from './components/popover/popover';
 
@@ -176,6 +196,27 @@ export type {
   UseDataTableOptions,
 } from './components/data-table/use-data-table';
 export { useDataTable } from './components/data-table/use-data-table';
+
+/* --- Charts -------------------------------------------------------------- */
+
+export type { BarsChartProps } from './components/chart/bars-chart';
+export { BarsChart } from './components/chart/bars-chart';
+export type {
+  ChartSeries,
+  ChartTooltipProps,
+} from './components/chart/chart-parts';
+export {
+  ChartLegend,
+  ChartTooltip,
+  seriesColor,
+} from './components/chart/chart-parts';
+export type {
+  SparklineProps,
+  SparklineTone,
+} from './components/chart/sparkline';
+export { Sparkline } from './components/chart/sparkline';
+export type { TimeSeriesChartProps } from './components/chart/time-series-chart';
+export { TimeSeriesChart } from './components/chart/time-series-chart';
 
 /* --- Overlays ------------------------------------------------------------ */
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
       lucide-react:
         specifier: 1.33.0
         version: 1.33.0(react@19.2.7)
+      recharts:
+        specifier: 3.10.1
+        version: 3.10.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(redux@5.0.1)
       tailwind-merge:
         specifier: 3.6.0
         version: 3.6.0
@@ -10759,6 +10762,18 @@ snapshots:
     dependencies:
       react: 19.2.8
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 19.2.7
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -15884,6 +15899,15 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      redux: 5.0.1
+
   react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1):
     dependencies:
       '@types/use-sync-external-store': 0.0.6
@@ -15967,6 +15991,26 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  recharts@3.10.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.7)(react@19.2.7)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.49.0
+      eventemitter3: 5.0.4
+      immer: 11.1.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 19.2.7
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
 
   recharts@3.10.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.7)(react@19.2.8)(redux@5.0.1):
     dependencies:


### PR DESCRIPTION
## What

Two additions, stacked on #280.

### Form fields (`field/`, `input/`)
- `Field` + `FieldLabel`/`FieldHint`/`FieldError` over Base UI Field: label, control, hint and error wired by id/aria-describedby; the error replaces the hint while it stands.
- `Input`, `Textarea` and `InputAction` share one `inputShell` box, so every text control measures, frames and reacts identically: read-only settles into the surface (and refuses the focus ring), invalid borders in danger, disabled forbids the whole box, `numeric` end-aligns tabular mono, two sizes (36/32 px).
- The phrase-unlock confirm now uses these primitives instead of its hand-rolled field.

### Charts (`chart/`, new **Charts** section in Storybook)
- **recharts 3.10** behind components that never leak it: `TimeSeriesChart` (monotone areas with gradient fills that fall to nothing, stackable, dashed horizontal grid, crosshair + tokenized tooltip, automatic legend at ≥ 2 series, `yDomain` for shares) and `BarsChart` (bucketed stacked bars — the events-by-severity chart — with 1 px surface seams between bands that survive every kind of colour-blindness, tops-only rounding).
- `Sparkline` is hand-drawn SVG: a table page means dozens of them, and each recharts chart carries its own store and observers. No axes, no tooltip, no motion; tones (`danger`/`brand`/`neutral`) are state, not decoration.
- Colours are `var(--chart-*)` and the severity tokens end to end; both categorical palettes (dark and light) pass CVD/chroma/contrast validation. Series draw with **no entry animation**, by the system's motion doctrine — which also removed a real recharts first-paint flake.
- **Why not TanStack Charts**: relaunched 2026-07-29, pre-alpha 0.x, React-19-only, its own docs say not production-ready. Parked with a note to re-evaluate at 1.0; the public API here (series + tokens) does not expose the engine, so a later swap stays contained.

## How it was verified

159 tests across the package — new stories-as-tests in Chromium with axe: label→control wiring and accessible descriptions, clear action, severity tooltip on hover, legend presence rules (none for a single series), sparkline bucket count. Palettes validated with the dataviz checker; everything reviewed live in Storybook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable form fields, inputs, textareas, and input actions with validation, sizing, read-only, disabled, multiline, and accessibility support.
  * Added responsive time-series, bar, and sparkline charts with legends, tooltips, formatting, stacking, severity colors, and accessible labels.
  * Added Storybook examples and interaction coverage for form and chart states.
* **Improvements**
  * Updated confirmation dialogs to use shared form components.
  * Expanded UI documentation for forms and charts.
  * Improved invalid-state messaging and disabled-field behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->