### PR TITLE
feat(ui): add the trace waterfall

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -219,6 +219,13 @@ animation, no tooltip). Colours are `var(--chart-*)` and the severity
 tokens; both palettes pass the CVD/contrast validation. TanStack Charts was
 evaluated and parked: relaunched 2026-07, pre-alpha, to be revisited at 1.0.
 
+**Waterfall** · `Waterfall`, the trace view: split columns with a draggable
+divider, durations riding their bars, chevron pills carrying descendant
+counts, tree guide lines, autogrouping of identical leaf siblings (the N+1),
+optional hatched missing-instrumentation rows, and a roving-tabindex tree
+for the keyboard. Colour by kind — db / internal / http — plus the error as
+the page's only red.
+
 **Overlays** · `ToastProvider`/`useToast` (a stacked corner notice: tones
 with their own lifetimes, actions, progress, `promise`), `Dialog` with its
 `Header`/`Body`/`Footer`, `createDialog`/`DialogProvider` (modals opened by

--- a/packages/ui/src/components/waterfall/format.ts
+++ b/packages/ui/src/components/waterfall/format.ts
@@ -1,0 +1,12 @@
+/**
+ * A span's duration, in the unit that reads: microseconds under a
+ * millisecond, a decimal only while the number is small enough to need
+ * one, seconds past a thousand. Its own module because the waterfall's
+ * consumers format durations outside the trace too -- a detail panel, a
+ * summary line -- and a component file may only export components.
+ */
+export function formatSpanDuration(ms: number): string {
+  if (ms < 1) return `${Math.round(ms * 1000)} µs`;
+  if (ms < 1000) return `${ms < 10 ? ms.toFixed(1) : Math.round(ms)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}

--- a/packages/ui/src/components/waterfall/waterfall.stories.tsx
+++ b/packages/ui/src/components/waterfall/waterfall.stories.tsx
@@ -2,7 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { Text } from '../text/text';
-import { formatSpanDuration, Waterfall, type WaterfallSpan } from './waterfall';
+import { formatSpanDuration } from './format';
+import { Waterfall, type WaterfallSpan } from './waterfall';
 
 /**
  * A checkout request worth reading: auth, an N+1 of six identical queries,
@@ -328,5 +329,82 @@ export const Narrow: Story = {
     await expect(figure.scrollWidth).toBeLessThanOrEqual(
       figure.clientWidth + 1,
     );
+  },
+};
+
+/**
+ * A slow sibling that overlaps a fast one does not open a hole. The
+ * coverage frontier only moves forward, so the hatched row is the 100 ms
+ * that nobody ran in -- not the 440 ms measured from whichever span
+ * happened to finish last in the list.
+ */
+const OVERLAPPING: WaterfallSpan[] = [
+  {
+    id: 'root',
+    op: 'http.server',
+    description: 'GET /report',
+    startMs: 0,
+    endMs: 600,
+  },
+  {
+    id: 'slow',
+    parentId: 'root',
+    op: 'db.query',
+    description: 'SELECT * FROM events',
+    startMs: 0,
+    endMs: 400,
+  },
+  {
+    id: 'fast',
+    parentId: 'root',
+    op: 'cache.get',
+    description: 'report:head',
+    startMs: 10,
+    endMs: 60,
+  },
+  {
+    id: 'reply',
+    parentId: 'root',
+    op: 'fn.serialize',
+    description: 'report.rs:212',
+    startMs: 500,
+    endMs: 585,
+  },
+];
+
+export const OverlappingSiblings: Story = {
+  render: () => (
+    <Waterfall
+      spans={OVERLAPPING}
+      showMissingInstrumentation
+      label="Waterfall of GET /report"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const gap = canvas
+      .getAllByRole('treeitem')
+      .find((el) => el.textContent?.includes('missing instrumentation'));
+    if (!gap) throw new Error('gap row not found');
+
+    // 400 ms → 500 ms, measured from the slow span the fast one hid inside.
+    await expect(gap).toHaveTextContent('100 ms');
+    await expect(canvas.queryByText('440 ms')).not.toBeInTheDocument();
+  },
+};
+
+/**
+ * A trace with no spans has no clock: it says so, rather than drawing a
+ * ruler out of the infinities an empty min and max produce.
+ */
+export const EmptyTrace: Story = {
+  render: () => <Waterfall spans={[]} label="Waterfall of GET /health" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('No spans')).toBeInTheDocument();
+    await expect(canvasElement.querySelector('[role="tree"]')).toBeNull();
+    await expect(canvas.queryByText('0 µs')).not.toBeInTheDocument();
   },
 };

--- a/packages/ui/src/components/waterfall/waterfall.stories.tsx
+++ b/packages/ui/src/components/waterfall/waterfall.stories.tsx
@@ -1,0 +1,332 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { Text } from '../text/text';
+import { formatSpanDuration, Waterfall, type WaterfallSpan } from './waterfall';
+
+/**
+ * A checkout request worth reading: auth, an N+1 of six identical queries,
+ * a render that throws, the handler that reports it, and a slow-provider
+ * hole between response and reply.
+ */
+const TRACE: WaterfallSpan[] = [
+  {
+    id: 'root',
+    op: 'http.server',
+    description: 'POST /checkout/summary',
+    startMs: 0,
+    endMs: 612,
+    status: 'internal_error',
+  },
+  {
+    id: 'auth',
+    parentId: 'root',
+    op: 'middleware.auth',
+    description: 'session u_884210',
+    startMs: 6,
+    endMs: 30,
+  },
+  {
+    id: 'db-main',
+    parentId: 'root',
+    op: 'db.query',
+    description: 'SELECT carts WHERE user_id = $1',
+    startMs: 37,
+    endMs: 96,
+  },
+  // The N+1: six identical item lookups, one per cart line.
+  ...Array.from({ length: 6 }, (_, index) => ({
+    id: `db-item-${index}`,
+    parentId: 'db-main',
+    op: 'db.query',
+    description: 'SELECT items WHERE id = $1',
+    startMs: 44 + index * 8,
+    endMs: 50 + index * 8,
+  })),
+  {
+    id: 'cache',
+    parentId: 'root',
+    op: 'cache.get',
+    description: 'summary:8842',
+    startMs: 101,
+    endMs: 109,
+  },
+  {
+    id: 'render',
+    parentId: 'root',
+    op: 'fn.renderTotals',
+    description: 'summary.tsx:118',
+    startMs: 171,
+    endMs: 173,
+    status: 'internal_error',
+  },
+  {
+    id: 'handler',
+    parentId: 'root',
+    op: 'error.handler',
+    description: 'capture + report to Rustrak',
+    startMs: 179,
+    endMs: 219,
+  },
+  {
+    id: 'response',
+    parentId: 'root',
+    op: 'http.response',
+    description: '500 · summary fallback',
+    startMs: 440,
+    endMs: 612,
+  },
+];
+
+function Harness({
+  spans = TRACE,
+  showMissingInstrumentation = false,
+}: {
+  spans?: WaterfallSpan[];
+  showMissingInstrumentation?: boolean;
+}) {
+  const [selected, setSelected] = useState<WaterfallSpan | null>(null);
+
+  return (
+    <div className="w-full max-w-260 rounded-xl border border-border-subtle bg-surface pb-3">
+      <Waterfall
+        spans={spans}
+        selectedId={selected?.id ?? null}
+        onSelect={setSelected}
+        showMissingInstrumentation={showMissingInstrumentation}
+        label="Waterfall of POST /checkout/summary"
+        renderDetail={(span) => (
+          <dl
+            data-testid="detail"
+            className="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-1"
+          >
+            {(
+              [
+                ['Op', span.op ?? '—'],
+                ['Description', span.description ?? '—'],
+                ['Status', span.status ?? 'ok'],
+                ['Duration', formatSpanDuration(span.endMs - span.startMs)],
+              ] as const
+            ).map(([term, value]) => (
+              <div key={term} className="contents">
+                <dt>
+                  <Text variant="meta" tone="subtle">
+                    {term}
+                  </Text>
+                </dt>
+                <dd>
+                  <Text variant="mono-sm" truncate>
+                    {value}
+                  </Text>
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Components/Waterfall',
+  component: Waterfall,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Waterfall>;
+
+export default meta;
+type Story = StoryObj;
+
+/**
+ * The whole reading at once: the ruler scaling the track, the N+1 folded
+ * into one ×6 row, and the broken span carrying the only red on the page.
+ */
+export const Trace: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The total appears twice by design: the ruler's end and the root
+    // span's own duration riding its bar.
+    await expect(canvas.getAllByText('612 ms').length).toBeGreaterThan(1);
+
+    // Six identical leaf siblings arrive as one autogrouped row.
+    await expect(canvas.getByText('db.query ×6')).toBeInTheDocument();
+    await expect(
+      canvas.queryAllByText('SELECT items WHERE id = $1').length,
+    ).toBe(1);
+
+    // The legend names every kind present, error last.
+    await expect(canvas.getByText('internal')).toBeInTheDocument();
+    await expect(canvas.getByText('error')).toBeInTheDocument();
+  },
+};
+
+/** Selecting a row opens its detail inside the trace; again closes it. */
+export const Selection: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const row = canvas
+      .getAllByRole('treeitem')
+      .find((el) => el.textContent?.includes('fn.renderTotals'));
+    if (!row) throw new Error('row not found');
+
+    await userEvent.click(row);
+    await expect(canvas.getByTestId('detail')).toBeInTheDocument();
+    await expect(row).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.click(row);
+    await waitFor(() =>
+      expect(canvas.queryByTestId('detail')).not.toBeInTheDocument(),
+    );
+  },
+};
+
+/**
+ * The pill folds a subtree without selecting, and says what it holds; the
+ * autogroup opens the same way and shows its members.
+ */
+export const FoldsAndGroups: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Opening the autogroup replaces ×6 with the six real rows.
+    const group = canvas
+      .getAllByRole('treeitem')
+      .find((el) => el.textContent?.includes('db.query ×6'));
+    if (!group) throw new Error('group not found');
+    await userEvent.click(group);
+    await waitFor(() =>
+      expect(canvas.queryByText('db.query ×6')).not.toBeInTheDocument(),
+    );
+    await expect(canvas.getAllByText('SELECT items WHERE id = $1').length).toBe(
+      6,
+    );
+
+    // Folding db-main hides its children; no selection happened.
+    const parent = canvas
+      .getAllByRole('treeitem')
+      .find((el) => el.textContent?.includes('SELECT carts'));
+    if (!parent) throw new Error('parent not found');
+    await expect(parent).toHaveAttribute('aria-expanded', 'true');
+    await userEvent.keyboard('{Escape}');
+    await userEvent.click(parent);
+    // Clicking a span row selects it; folding is the pill's.
+    const pill = parent.querySelector('[data-chevron]');
+    if (!pill) throw new Error('pill not found');
+    await userEvent.click(pill as HTMLElement);
+    await waitFor(() =>
+      expect(parent).toHaveAttribute('aria-expanded', 'false'),
+    );
+    await expect(
+      canvas.queryByText('SELECT items WHERE id = $1'),
+    ).not.toBeInTheDocument();
+  },
+};
+
+/** One tab stop; inside, the arrows walk the tree and fold it. */
+export const Keyboard: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const rows = canvas.getAllByRole('treeitem');
+    const first = rows[0] as HTMLElement;
+
+    first.focus();
+    await userEvent.keyboard('{ArrowDown}');
+    await expect(rows[1]).toHaveFocus();
+
+    await userEvent.keyboard('{End}');
+    const focused = document.activeElement as HTMLElement;
+    await expect(focused.textContent).toContain('http.response');
+
+    await userEvent.keyboard('{Home}');
+    await expect(first).toHaveFocus();
+
+    // Left folds the focused parent; Right unfolds it.
+    await userEvent.keyboard('{ArrowLeft}');
+    await expect(first).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.keyboard('{ArrowRight}');
+    await expect(first).toHaveAttribute('aria-expanded', 'true');
+  },
+};
+
+/** Unclaimed time surfaces as a hatched row when asked for. */
+export const MissingInstrumentation: Story = {
+  render: () => <Harness showMissingInstrumentation />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 219 ms → 440 ms: nobody claims those 221 ms, and now the row says so.
+    await expect(
+      canvas.getByText('missing instrumentation'),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('221 ms')).toBeInTheDocument();
+  },
+};
+
+/** Above ~670 px of container, the split is a real, keyboard-able control. */
+export const ResizableSplit: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const divider = canvas.getByRole('separator', {
+      name: 'Resize the name column',
+    });
+
+    const before = divider.getAttribute('aria-valuenow');
+    divider.focus();
+    await userEvent.keyboard('{ArrowRight}');
+    await waitFor(() =>
+      expect(divider.getAttribute('aria-valuenow')).not.toBe(before),
+    );
+  },
+};
+
+/**
+ * At phone width the rows stack: the name line above, the bar below at full
+ * width. Nothing is crammed into a 120 px gutter, and the divider -- which
+ * would resize columns that no longer exist -- is gone.
+ */
+export const Narrow: Story = {
+  render: () => (
+    <div className="w-90">
+      <Harness />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The divider has nothing to resize here: display none takes it out of
+    // the accessibility tree entirely.
+    const divider = canvasElement.querySelector('[role="separator"]');
+    await expect(divider).not.toBeVisible();
+
+    // Every span still reads, and its bar gets the full row width below it.
+    const row = canvas
+      .getAllByRole('treeitem')
+      .find((el) => el.textContent?.includes('middleware.auth'));
+    if (!row) throw new Error('row not found');
+    const gutter = row.firstElementChild as HTMLElement;
+    const track = gutter.nextElementSibling as HTMLElement;
+    await expect(
+      Math.round(gutter.getBoundingClientRect().width),
+    ).toBeGreaterThan(300);
+    await expect(track.getBoundingClientRect().top).toBeGreaterThan(
+      gutter.getBoundingClientRect().top + 10,
+    );
+
+    // Opening a detail must not widen the trace: what does not fit scrolls
+    // inside the detail's own box.
+    await userEvent.click(row);
+    await canvas.findByTestId('detail');
+    const figure = canvasElement.querySelector('figure');
+    if (!figure) throw new Error('figure not found');
+    await expect(figure.scrollWidth).toBeLessThanOrEqual(
+      figure.clientWidth + 1,
+    );
+  },
+};

--- a/packages/ui/src/components/waterfall/waterfall.tsx
+++ b/packages/ui/src/components/waterfall/waterfall.tsx
@@ -1,0 +1,901 @@
+import {
+  type CSSProperties,
+  type KeyboardEvent,
+  type MouseEvent,
+  type PointerEvent,
+  type ReactNode,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { focusRingInset } from '../../lib/focus';
+import { interactiveTransition } from '../../lib/motion';
+import { tv } from '../../lib/tv';
+import { ChevronDownIcon, ChevronRightIcon } from '../icon/icon-catalog';
+import { Tag } from '../tag/tag';
+
+/**
+ * The request, drawn: every span a bar on one shared clock.
+ *
+ * The reading it must give up in one glance is *where the time went and what
+ * broke*. The shape follows the best tracers, not any one mock:
+ *
+ *   - two columns split by a draggable divider -- the tree names, the
+ *     timeline measures -- because a fixed gutter is always wrong for
+ *     somebody's span names;
+ *   - the duration rides beside its own bar, outside until the bar is wide
+ *     enough to hold it, so the number never has to be hunted across the
+ *     row;
+ *   - the chevron is a pill that carries the descendant count: what a fold
+ *     hides is written on the fold;
+ *   - runs of identical leaf siblings collapse into one autogrouped row --
+ *     an N+1 of forty queries is one line saying ×40, not forty lines
+ *     saying nothing;
+ *   - a gap of unaccounted time between siblings can surface as a hatched
+ *     "missing instrumentation" row, because time nobody claimed is a
+ *     finding too.
+ *
+ * Colour is spent by *kind* -- `db` in chart-1, `http` in quiet grey, the
+ * rest as our own code in chart-3 -- plus the error, which is the only red
+ * on the page: bar, duration and row tint at once. Not one hue per op: the
+ * gutter already names the op, and the question a waterfall answers is "is
+ * the time in the database, on the wire, or in us".
+ */
+const waterfall = tv({
+  slots: {
+    /*
+     * `@container`: the layout answers to the box it lives in, not to the
+     * viewport. Past ~670 px the trace is two columns with a draggable
+     * divider; below, each row stacks -- name line above, bar below, full
+     * width -- because a 120 px gutter is not a smaller version of the
+     * reading, it is no reading.
+     */
+    root: '@container relative flex min-w-0 flex-col font-mono',
+    /*
+     * The ruler: what a pixel is worth. It scrolls with the trace on
+     * purpose -- stuck to the viewport it escapes whatever card the app
+     * drew the trace in, opaque corners and all. When the app gives the
+     * trace its own scroll box, that is the right place to pin a copy.
+     */
+    ruler: [
+      'flex h-6.5 shrink-0 items-center',
+      'border-border-divider border-b ps-4 pe-4',
+    ],
+    rulerTrack: [
+      'flex min-w-0 flex-1 justify-between',
+      'text-fg-ghost text-mono-sm',
+    ],
+    /*
+     * The divider between names and time. A real control: it drags, it
+     * takes the keyboard, and it clamps -- neither column may vanish.
+     */
+    divider: [
+      'absolute inset-y-0 z-20 w-1.5 -translate-x-1/2 cursor-ew-resize',
+      '@max-2xl:hidden',
+      'outline-none',
+      'after:absolute after:inset-y-0 after:start-1/2 after:w-px',
+      'after:bg-border-divider',
+      'hover:after:bg-border-strong focus-visible:after:bg-border-brand',
+    ],
+    row: [
+      'group/row relative flex min-h-9 w-full shrink-0 flex-wrap items-center',
+      'ps-4 pe-4',
+      '@max-2xl:h-auto @max-2xl:py-1.5',
+      'border-border-divider border-b text-start',
+      interactiveTransition,
+      'hover:bg-surface-hover',
+      'cursor-pointer outline-none',
+      focusRingInset,
+      'aria-selected:bg-surface-raised',
+      // The broken span is the row the eye lands on before reading.
+      'data-[failed=true]:bg-sev-error-surface/40',
+    ],
+    gutter: [
+      'flex h-9 min-w-0 shrink-0 items-center gap-2 pe-3',
+      'w-(--wf-gutter)',
+      '@max-2xl:h-6 @max-2xl:w-full @max-2xl:pe-0',
+    ],
+    /** One indent step; carries its ancestor's guide line when it has one. */
+    guide: 'relative h-full w-4 shrink-0',
+    guideLine: 'absolute inset-y-0 start-1.75 w-px bg-border-divider',
+    /*
+     * The fold and its size in one pill: a chevron that also says how many
+     * rows it is holding shut.
+     */
+    pill: [
+      'flex h-4.5 shrink-0 items-center gap-0.5 rounded-pill',
+      'bg-surface-chip ps-0.5 pe-1.5 text-fg-subtle text-mono-sm',
+      interactiveTransition,
+      'hover:bg-surface-selected hover:text-fg',
+    ],
+    pillGap: 'w-4.5 shrink-0',
+    op: 'shrink-0 whitespace-nowrap font-medium text-fg-secondary text-mono-sm',
+    description: 'min-w-0 truncate text-fg-ghost text-mono-sm',
+    track: ['relative h-9 min-w-0 flex-1', '@max-2xl:h-6 @max-2xl:min-w-full'],
+    gridline: 'absolute inset-y-0 w-px bg-border-divider/50',
+    bar: [
+      'absolute top-1/2 h-4 -translate-y-1/2 rounded-2xs',
+      interactiveTransition,
+      'group-hover/row:brightness-125',
+    ],
+    /*
+     * The figure rides its bar: outside its right end while there is room,
+     * stepping inside once the bar is wide enough to hold it. It never sits
+     * in a far column the eye has to travel to.
+     */
+    duration: [
+      'absolute top-1/2 flex h-4 -translate-y-1/2 items-center whitespace-nowrap',
+      'text-fg-subtle text-mono-sm tabular-nums',
+      'data-[failed=true]:text-sev-error-fg',
+      'data-[inside=true]:text-fg data-[inside=true]:font-medium',
+    ],
+    /* Unclaimed time, in the established language for it: hatching. */
+    gapBar: [
+      'absolute top-1/2 h-4 -translate-y-1/2 rounded-2xs',
+      'bg-[repeating-linear-gradient(135deg,var(--border-raised)_0px,var(--border-raised)_3px,transparent_3px,transparent_6px)]',
+    ],
+    gapLabel: 'text-fg-ghost text-mono-sm italic',
+    /*
+     * The selected span's detail, opened inside the trace under its row:
+     * what was clicked and what answers stay in one scroll. The app
+     * composes the content; the component owns the seam.
+     */
+    detail: [
+      // `basis-full min-w-0`: a flex child's min-width is its content, and
+      // a long attribute value would otherwise widen the whole trace. What
+      // does not fit scrolls here, inside its own box.
+      'min-w-0 basis-full overflow-x-auto',
+      'cursor-default border-border-divider border-t bg-panel',
+      'mt-1.5 px-3 py-3 font-sans',
+      '@max-2xl:px-1',
+    ],
+    legend: [
+      'flex shrink-0 flex-wrap items-center gap-4 ps-4 pe-4 pt-2.5',
+      'text-fg-subtle text-mono-sm',
+    ],
+    legendItem: 'inline-flex items-center gap-1.5',
+    legendSwatch: 'size-2 rounded-2xs',
+  },
+});
+
+const styles = waterfall();
+
+/**
+ * One span, in the units the caller already has: milliseconds relative to
+ * anything. The component only reads differences.
+ */
+export interface WaterfallSpan {
+  id: string;
+  parentId?: string | null;
+  /** The operation: `db.query`, `http.server`, `cache.get`. */
+  op?: string;
+  /** What it did it to: the statement, the URL, the key. */
+  description?: string;
+  startMs: number;
+  endMs: number;
+  /** Anything other than `ok` or absent reads as failed. */
+  status?: string;
+}
+
+/** The three kinds time divides into, plus the one that broke. */
+type SpanKind = 'db' | 'http' | 'internal' | 'error';
+
+/*
+ * A static map, never `bg-${kind}`: Tailwind extracts class names from the
+ * source text, so a composed name is a rule that is silently not generated.
+ */
+const KIND_BAR: Record<SpanKind, string> = {
+  db: 'bg-chart-1',
+  http: 'bg-border-control',
+  internal: 'bg-chart-3',
+  error: 'bg-sev-error',
+};
+
+function spanKind(span: WaterfallSpan): SpanKind {
+  if (span.status && span.status !== 'ok') return 'error';
+  const op = (span.op ?? '').toLowerCase();
+  if (op.startsWith('db') || op.startsWith('cache')) return 'db';
+  if (op.startsWith('http') || op.startsWith('resource')) return 'http';
+  return 'internal';
+}
+
+export function formatSpanDuration(ms: number): string {
+  if (ms < 1) return `${Math.round(ms * 1000)} µs`;
+  if (ms < 1000) return `${ms < 10 ? ms.toFixed(1) : Math.round(ms)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+/* --- The tree ------------------------------------------------------------- */
+
+interface TreeNode {
+  span: WaterfallSpan;
+  children: TreeNode[];
+}
+
+/**
+ * Built from `parentId` links. An orphan -- parent never arrived, or the
+ * link is cyclic -- attaches to the root rather than disappearing: a
+ * dropped span is exactly the one someone is looking for.
+ */
+function buildTree(spans: WaterfallSpan[]): TreeNode[] {
+  const known = new Set(spans.map((span) => span.id));
+  const byParent = new Map<string, WaterfallSpan[]>();
+
+  for (const span of spans) {
+    const parent =
+      span.parentId && known.has(span.parentId) && span.parentId !== span.id
+        ? span.parentId
+        : '__root__';
+    const list = byParent.get(parent) ?? [];
+    list.push(span);
+    byParent.set(parent, list);
+  }
+
+  const visited = new Set<string>();
+  const build = (parent: string): TreeNode[] => {
+    const children = (byParent.get(parent) ?? []).sort(
+      (a, b) => a.startMs - b.startMs,
+    );
+    const nodes: TreeNode[] = [];
+    for (const span of children) {
+      if (visited.has(span.id)) continue;
+      visited.add(span.id);
+      nodes.push({ span, children: build(span.id) });
+    }
+    return nodes;
+  };
+
+  const roots = build('__root__');
+  for (const span of spans) {
+    if (!visited.has(span.id)) roots.push({ span, children: [] });
+  }
+  return roots;
+}
+
+function descendants(node: TreeNode): number {
+  return node.children.reduce((acc, c) => acc + 1 + descendants(c), 0);
+}
+
+/** How many identical leaf siblings in a row become one line. */
+const AUTOGROUP_MIN = 5;
+/** Unclaimed time between siblings worth its own row, in ms. */
+const GAP_MIN_MS = 100;
+
+type Row =
+  | {
+      kind: 'span';
+      id: string;
+      span: WaterfallSpan;
+      depth: number;
+      guides: boolean[];
+      hasChildren: boolean;
+      collapsed: boolean;
+      count: number;
+    }
+  | {
+      kind: 'group';
+      id: string;
+      op: string;
+      description?: string;
+      spans: WaterfallSpan[];
+      depth: number;
+      guides: boolean[];
+      failed: boolean;
+    }
+  | {
+      kind: 'gap';
+      id: string;
+      depth: number;
+      guides: boolean[];
+      startMs: number;
+      endMs: number;
+    };
+
+interface FlattenState {
+  collapsed: Set<string>;
+  openGroups: Set<string>;
+  showGaps: boolean;
+}
+
+/**
+ * The tree, walked into rows, with the two transforms real traces need:
+ *
+ * Runs of `AUTOGROUP_MIN`+ consecutive *leaf* siblings sharing op and
+ * description fold into one autogrouped row (the N+1 case), reopened from
+ * its pill. And, when asked, a gap of `GAP_MIN_MS`+ between siblings
+ * becomes a hatched row: time inside the parent that no child claims.
+ *
+ * `guides` says, per ancestor level, whether that ancestor still has
+ * siblings below -- which is exactly where a vertical guide line belongs.
+ */
+function flatten(nodes: TreeNode[], state: FlattenState): Row[] {
+  const rows: Row[] = [];
+
+  const walk = (list: TreeNode[], depth: number, guides: boolean[]) => {
+    // First pass: partition the sibling list into single nodes and groups.
+    const units: Array<
+      { unit: 'node'; node: TreeNode } | { unit: 'run'; nodes: TreeNode[] }
+    > = [];
+    let index = 0;
+    while (index < list.length) {
+      const node = list[index] as TreeNode;
+      const key = `${node.span.op} ${node.span.description}`;
+      let end = index;
+      while (end + 1 < list.length) {
+        const next = list[end + 1] as TreeNode;
+        if (
+          next.children.length > 0 ||
+          node.children.length > 0 ||
+          `${next.span.op} ${next.span.description}` !== key
+        ) {
+          break;
+        }
+        end += 1;
+      }
+      if (end - index + 1 >= AUTOGROUP_MIN) {
+        units.push({ unit: 'run', nodes: list.slice(index, end + 1) });
+        index = end + 1;
+      } else {
+        units.push({ unit: 'node', node });
+        index += 1;
+      }
+    }
+
+    let previousEnd: number | null = null;
+    units.forEach((entry, unitIndex) => {
+      const last = unitIndex === units.length - 1;
+      const first =
+        entry.unit === 'node'
+          ? entry.node.span
+          : (entry.nodes[0] as TreeNode).span;
+
+      if (
+        state.showGaps &&
+        previousEnd != null &&
+        first.startMs - previousEnd >= GAP_MIN_MS
+      ) {
+        rows.push({
+          kind: 'gap',
+          id: `gap-${first.id}`,
+          depth,
+          guides: [...guides, true],
+          startMs: previousEnd,
+          endMs: first.startMs,
+        });
+      }
+
+      if (entry.unit === 'run') {
+        const spans = entry.nodes.map((n) => n.span);
+        const head = spans[0] as WaterfallSpan;
+        const groupId = `group-${head.id}`;
+        if (state.openGroups.has(groupId)) {
+          for (const node of entry.nodes) {
+            rows.push({
+              kind: 'span',
+              id: node.span.id,
+              span: node.span,
+              depth,
+              guides: [...guides, !last],
+              hasChildren: false,
+              collapsed: false,
+              count: 0,
+            });
+          }
+        } else {
+          rows.push({
+            kind: 'group',
+            id: groupId,
+            op: head.op ?? 'span',
+            description: head.description,
+            spans,
+            depth,
+            guides: [...guides, !last],
+            failed: spans.some((s) => s.status && s.status !== 'ok'),
+          });
+        }
+        previousEnd = Math.max(...spans.map((s) => s.endMs));
+        return;
+      }
+
+      const node = entry.node;
+      const isCollapsed = state.collapsed.has(node.span.id);
+      rows.push({
+        kind: 'span',
+        id: node.span.id,
+        span: node.span,
+        depth,
+        guides: [...guides, !last],
+        hasChildren: node.children.length > 0,
+        collapsed: isCollapsed,
+        count: descendants(node),
+      });
+      if (node.children.length > 0 && !isCollapsed) {
+        walk(node.children, depth + 1, [...guides, !last]);
+      }
+      previousEnd = node.span.endMs;
+    });
+  };
+
+  walk(nodes, 0, []);
+  return rows;
+}
+
+/* --- The component -------------------------------------------------------- */
+
+export interface WaterfallProps {
+  spans: WaterfallSpan[];
+  /**
+   * The selected span, controlled: selection is a place the app may hold
+   * in its own state or in the URL.
+   */
+  selectedId?: string | null;
+  onSelect?: (span: WaterfallSpan | null) => void;
+  /**
+   * The selected span's detail, drawn inside the trace under its row --
+   * attributes, links, the stack. The component owns where it opens; the
+   * app owns what it says.
+   */
+  renderDetail?: (span: WaterfallSpan) => ReactNode;
+  /** Surfaces the hatched rows for unclaimed time between siblings. */
+  showMissingInstrumentation?: boolean;
+  /** Names the figure: "Waterfall of POST /checkout/summary". */
+  label: string;
+  className?: string;
+}
+
+const MIN_SPLIT = 0.15;
+const MAX_SPLIT = 0.85;
+
+export function Waterfall({
+  spans,
+  selectedId,
+  onSelect,
+  renderDetail,
+  showMissingInstrumentation = false,
+  label,
+  className,
+}: WaterfallProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [openGroups, setOpenGroups] = useState<Set<string>>(new Set());
+  /*
+   * The split as a fraction, not pixels: the same trace reads on a phone
+   * and on an ultrawide, and the divider means the same thing on both.
+   */
+  const [split, setSplit] = useState(0.4);
+
+  const tree = useMemo(() => buildTree(spans), [spans]);
+  const rows = useMemo(
+    () =>
+      flatten(tree, {
+        collapsed,
+        openGroups,
+        showGaps: showMissingInstrumentation,
+      }),
+    [tree, collapsed, openGroups, showMissingInstrumentation],
+  );
+
+  const start = Math.min(...spans.map((span) => span.startMs));
+  const end = Math.max(...spans.map((span) => span.endMs));
+  const total = Math.max(end - start, 1);
+
+  const kinds = useMemo(() => {
+    const present = new Set<SpanKind>();
+    for (const span of spans) present.add(spanKind(span));
+    return (['db', 'internal', 'http', 'error'] as const).filter((kind) =>
+      present.has(kind),
+    );
+  }, [spans]);
+
+  const toggleSet =
+    (set: (updater: (previous: Set<string>) => Set<string>) => void) =>
+    (id: string) => {
+      set((previous) => {
+        const next = new Set(previous);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+    };
+  const toggleCollapsed = toggleSet(setCollapsed);
+  const toggleGroup = toggleSet(setOpenGroups);
+
+  /* --- Divider ----------------------------------------------------------- */
+
+  const onDividerPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    const root = rootRef.current;
+    if (!root) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    const box = root.getBoundingClientRect();
+    const move = (pointer: globalThis.PointerEvent) => {
+      const fraction = (pointer.clientX - box.left) / box.width;
+      setSplit(Math.min(Math.max(fraction, MIN_SPLIT), MAX_SPLIT));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  const onDividerKeyDown = (event: KeyboardEvent) => {
+    const step =
+      event.key === 'ArrowLeft' ? -0.03 : event.key === 'ArrowRight' ? 0.03 : 0;
+    if (step === 0) return;
+    event.preventDefault();
+    setSplit((previous) =>
+      Math.min(Math.max(previous + step, MIN_SPLIT), MAX_SPLIT),
+    );
+  };
+
+  /* --- Keyboard ---------------------------------------------------------- */
+
+  /*
+   * A roving walk: the arrows move between rows, Left/Right fold and
+   * unfold, Enter and Space answer. One tab stop for the whole tree.
+   */
+  const moveFocus = (from: HTMLElement, delta: number | 'home' | 'end') => {
+    const all = Array.from(
+      rootRef.current?.querySelectorAll<HTMLElement>('[data-wf-row]') ?? [],
+    );
+    const index = all.indexOf(from);
+    const target =
+      delta === 'home'
+        ? all[0]
+        : delta === 'end'
+          ? all[all.length - 1]
+          : all[index + delta];
+    target?.focus();
+  };
+
+  const gutterWidth = `${split * 100}%`;
+
+  return (
+    <figure
+      ref={rootRef}
+      style={{ '--wf-gutter': gutterWidth } as CSSProperties}
+      className={styles.root({ className })}
+      aria-label={label}
+    >
+      <div className={styles.ruler()} aria-hidden="true">
+        <div className="w-(--wf-gutter) shrink-0 @max-2xl:hidden" />
+        <div className={styles.rulerTrack()}>
+          {[0, 0.25, 0.5, 0.75, 1].map((fraction) => (
+            <span key={fraction}>{formatSpanDuration(total * fraction)}</span>
+          ))}
+        </div>
+      </div>
+
+      <div role="tree" aria-label={label}>
+        {rows.map((row, rowIndex) => {
+          const indent = row.guides.slice(0, -1);
+          const guides = (
+            <>
+              {indent.map((line, level) => (
+                <span
+                  // Levels are positional by construction.
+                  key={level}
+                  aria-hidden="true"
+                  className={styles.guide()}
+                >
+                  {line ? <span className={styles.guideLine()} /> : null}
+                </span>
+              ))}
+            </>
+          );
+
+          const gridlines = (
+            <>
+              {[25, 50, 75].map((position) => (
+                <span
+                  key={position}
+                  aria-hidden="true"
+                  style={{ left: `${position}%` }}
+                  className={styles.gridline()}
+                />
+              ))}
+            </>
+          );
+
+          if (row.kind === 'gap') {
+            const left = ((row.startMs - start) / total) * 100;
+            const width = ((row.endMs - row.startMs) / total) * 100;
+            return (
+              <div
+                key={row.id}
+                role="treeitem"
+                tabIndex={-1}
+                aria-level={row.depth + 1}
+                aria-selected={false}
+                aria-disabled="true"
+                className={styles.row({ className: 'cursor-default' })}
+              >
+                <div className={styles.gutter()}>
+                  {guides}
+                  <span className={styles.pillGap()} />
+                  <span className={styles.gapLabel()}>
+                    missing instrumentation
+                  </span>
+                </div>
+                <div className={styles.track()}>
+                  {gridlines}
+                  <span
+                    aria-hidden="true"
+                    style={{ left: `${left}%`, width: `${width}%` }}
+                    className={styles.gapBar()}
+                  />
+                  <DurationLabel
+                    left={left}
+                    width={width}
+                    ms={row.endMs - row.startMs}
+                  />
+                </div>
+              </div>
+            );
+          }
+
+          const spansOfRow = row.kind === 'group' ? row.spans : [row.span];
+          const rowStart = Math.min(...spansOfRow.map((s) => s.startMs));
+          const rowEnd = Math.max(...spansOfRow.map((s) => s.endMs));
+          const failed =
+            row.kind === 'group' ? row.failed : spanKind(row.span) === 'error';
+          const kind: SpanKind =
+            row.kind === 'group'
+              ? failed
+                ? 'error'
+                : spanKind(row.spans[0] as WaterfallSpan)
+              : spanKind(row.span);
+          const isSelected = row.kind === 'span' && selectedId === row.id;
+          const left = ((rowStart - start) / total) * 100;
+          // A 2 ms span in a 600 ms trace still has to be visible: it may
+          // be the one that threw.
+          const width = Math.min(
+            Math.max(((rowEnd - rowStart) / total) * 100, 0.6),
+            100 - left,
+          );
+
+          const expandable =
+            row.kind === 'group' || (row.kind === 'span' && row.hasChildren);
+          const isOpen =
+            row.kind === 'group'
+              ? false
+              : row.kind === 'span' && row.hasChildren && !row.collapsed;
+          const toggle = () => {
+            if (row.kind === 'group') toggleGroup(row.id);
+            else if (row.kind === 'span' && row.hasChildren)
+              toggleCollapsed(row.id);
+          };
+          const select = () => {
+            if (row.kind !== 'span') {
+              toggle();
+              return;
+            }
+            onSelect?.(selectedId === row.id ? null : row.span);
+          };
+
+          const onRowKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+            switch (event.key) {
+              case 'Enter':
+              case ' ':
+                event.preventDefault();
+                select();
+                break;
+              case 'ArrowDown':
+                event.preventDefault();
+                moveFocus(event.currentTarget, 1);
+                break;
+              case 'ArrowUp':
+                event.preventDefault();
+                moveFocus(event.currentTarget, -1);
+                break;
+              case 'Home':
+                event.preventDefault();
+                moveFocus(event.currentTarget, 'home');
+                break;
+              case 'End':
+                event.preventDefault();
+                moveFocus(event.currentTarget, 'end');
+                break;
+              case 'ArrowRight':
+                if (expandable && !isOpen) toggle();
+                break;
+              case 'ArrowLeft':
+                if (expandable && isOpen) toggle();
+                break;
+            }
+          };
+
+          const onRowClick = (event: MouseEvent) => {
+            const target = event.target as HTMLElement;
+            if (
+              target.closest('[data-chevron]') ||
+              target.closest('[data-wf-detail]')
+            ) {
+              return;
+            }
+            select();
+          };
+
+          const count = row.kind === 'group' ? row.spans.length : row.count;
+
+          return (
+            <div
+              key={row.id}
+              role="treeitem"
+              // The tree is one tab stop; inside, the arrows take over.
+              tabIndex={rowIndex === 0 ? 0 : -1}
+              data-wf-row
+              aria-level={row.depth + 1}
+              aria-selected={isSelected}
+              aria-expanded={expandable ? isOpen : undefined}
+              data-failed={failed || undefined}
+              onClick={onRowClick}
+              onKeyDown={onRowKeyDown}
+              className={styles.row()}
+            >
+              <div className={styles.gutter()}>
+                {guides}
+                {expandable ? (
+                  /* A pointer shortcut for the treeitem's own expand; the
+                     state is announced by aria-expanded above. */
+                  <span
+                    aria-hidden="true"
+                    data-chevron
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      toggle();
+                    }}
+                    className={styles.pill()}
+                  >
+                    {isOpen ? (
+                      <ChevronDownIcon size="sm" aria-hidden="true" />
+                    ) : (
+                      <ChevronRightIcon size="sm" aria-hidden="true" />
+                    )}
+                    {count}
+                  </span>
+                ) : (
+                  <span className={styles.pillGap()} />
+                )}
+                <span className={styles.op()}>
+                  {row.kind === 'group'
+                    ? `${row.op} ×${row.spans.length}`
+                    : (row.span.op ?? 'span')}
+                </span>
+                <span className={styles.description()}>
+                  {row.kind === 'group'
+                    ? row.description
+                    : row.span.description}
+                </span>
+                {failed ? (
+                  <Tag tone="error" className="shrink-0">
+                    {row.kind === 'span'
+                      ? (row.span.status ?? 'error')
+                      : 'error'}
+                  </Tag>
+                ) : null}
+              </div>
+
+              <div className={styles.track()}>
+                {gridlines}
+                {row.kind === 'group' ? (
+                  spansOfRow.map((span) => {
+                    const segLeft = ((span.startMs - start) / total) * 100;
+                    const segWidth = Math.max(
+                      ((span.endMs - span.startMs) / total) * 100,
+                      0.4,
+                    );
+                    return (
+                      <span
+                        key={span.id}
+                        aria-hidden="true"
+                        style={{
+                          left: `${segLeft}%`,
+                          width: `${segWidth}%`,
+                        }}
+                        className={styles.bar({
+                          className: KIND_BAR[kind],
+                        })}
+                      />
+                    );
+                  })
+                ) : (
+                  <span
+                    aria-hidden="true"
+                    style={{ left: `${left}%`, width: `${width}%` }}
+                    className={styles.bar({ className: KIND_BAR[kind] })}
+                  />
+                )}
+                <DurationLabel
+                  left={left}
+                  width={width}
+                  ms={
+                    row.kind === 'group'
+                      ? spansOfRow.reduce(
+                          (acc, s) => acc + (s.endMs - s.startMs),
+                          0,
+                        )
+                      : rowEnd - rowStart
+                  }
+                  failed={failed}
+                />
+              </div>
+
+              {isSelected && renderDetail && row.kind === 'span' ? (
+                <div data-wf-detail className={styles.detail()}>
+                  {renderDetail(row.span)}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* biome-ignore lint/a11y/useSemanticElements: a window splitter is
+          ARIA-only -- <hr> cannot drag, focus or resize anything */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize the name column"
+        aria-valuenow={Math.round(split * 100)}
+        aria-valuemin={MIN_SPLIT * 100}
+        aria-valuemax={MAX_SPLIT * 100}
+        tabIndex={0}
+        style={{ left: `calc(16px + (100% - 32px) * ${split})` }}
+        onPointerDown={onDividerPointerDown}
+        onKeyDown={onDividerKeyDown}
+        className={styles.divider()}
+      />
+
+      <div className={styles.legend()}>
+        {kinds.map((kind) => (
+          <span key={kind} className={styles.legendItem()}>
+            <span
+              aria-hidden="true"
+              className={styles.legendSwatch({ className: KIND_BAR[kind] })}
+            />
+            {kind}
+          </span>
+        ))}
+      </div>
+    </figure>
+  );
+}
+
+Waterfall.displayName = 'Waterfall';
+
+/**
+ * The duration beside its bar: outside its right end with room to spare,
+ * inside the bar once the bar reaches far enough that "outside" would fall
+ * off the edge.
+ */
+function DurationLabel({
+  left,
+  width,
+  ms,
+  failed,
+}: {
+  left: number;
+  width: number;
+  ms: number;
+  failed?: boolean;
+}) {
+  const inside = left + width > 82;
+  return (
+    <span
+      data-failed={failed || undefined}
+      data-inside={inside || undefined}
+      style={
+        inside
+          ? { right: `${Math.max(100 - left - width, 0)}%`, paddingRight: 6 }
+          : { left: `${left + width}%`, paddingLeft: 6 }
+      }
+      className={styles.duration()}
+    >
+      {formatSpanDuration(ms)}
+    </span>
+  );
+}
+
+DurationLabel.displayName = 'DurationLabel';

--- a/packages/ui/src/components/waterfall/waterfall.tsx
+++ b/packages/ui/src/components/waterfall/waterfall.tsx
@@ -11,8 +11,14 @@ import {
 import { focusRingInset } from '../../lib/focus';
 import { interactiveTransition } from '../../lib/motion';
 import { tv } from '../../lib/tv';
-import { ChevronDownIcon, ChevronRightIcon } from '../icon/icon-catalog';
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  EmptyIcon,
+} from '../icon/icon-catalog';
 import { Tag } from '../tag/tag';
+import { Text } from '../text/text';
+import { formatSpanDuration } from './format';
 
 /**
  * The request, drawn: every span a bar on one shared clock.
@@ -155,6 +161,11 @@ const waterfall = tv({
     ],
     legendItem: 'inline-flex items-center gap-1.5',
     legendSwatch: 'size-2 rounded-2xs',
+    /* A trace with no spans: the figure says so in words, in font-sans. */
+    empty: [
+      'flex flex-col items-center justify-center gap-3',
+      'px-6 py-16 text-center font-sans',
+    ],
   },
 });
 
@@ -197,12 +208,6 @@ function spanKind(span: WaterfallSpan): SpanKind {
   if (op.startsWith('db') || op.startsWith('cache')) return 'db';
   if (op.startsWith('http') || op.startsWith('resource')) return 'http';
   return 'internal';
-}
-
-export function formatSpanDuration(ms: number): string {
-  if (ms < 1) return `${Math.round(ms * 1000)} µs`;
-  if (ms < 1000) return `${ms < 10 ? ms.toFixed(1) : Math.round(ms)} ms`;
-  return `${(ms / 1000).toFixed(2)} s`;
 }
 
 /* --- The tree ------------------------------------------------------------- */
@@ -295,6 +300,18 @@ interface FlattenState {
   collapsed: Set<string>;
   openGroups: Set<string>;
   showGaps: boolean;
+}
+
+/**
+ * The coverage frontier, which only ever moves forward.
+ *
+ * Siblings overlap -- a slow query still running while a fast one starts
+ * and finishes inside it -- so taking the last unit's end as the frontier
+ * would walk it backwards and hatch time the slow span demonstrably
+ * covered. The gap is only what *nobody* claimed.
+ */
+function advance(frontier: number | null, ...ends: number[]): number {
+  return Math.max(frontier ?? Number.NEGATIVE_INFINITY, ...ends);
 }
 
 /**
@@ -393,7 +410,7 @@ function flatten(nodes: TreeNode[], state: FlattenState): Row[] {
             failed: spans.some((s) => s.status && s.status !== 'ok'),
           });
         }
-        previousEnd = Math.max(...spans.map((s) => s.endMs));
+        previousEnd = advance(previousEnd, ...spans.map((s) => s.endMs));
         return;
       }
 
@@ -412,13 +429,28 @@ function flatten(nodes: TreeNode[], state: FlattenState): Row[] {
       if (node.children.length > 0 && !isCollapsed) {
         walk(node.children, depth + 1, [...guides, !last]);
       }
-      previousEnd = node.span.endMs;
+      previousEnd = advance(previousEnd, node.span.endMs);
     });
   };
 
   walk(nodes, 0, []);
   return rows;
 }
+
+/**
+ * Flip one id in a set of ids: what a fold and an autogroup both do. Built
+ * once, at module scope -- it closes over nothing but its setter.
+ */
+const toggleSet =
+  (set: (updater: (previous: Set<string>) => Set<string>) => void) =>
+  (id: string) => {
+    set((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
 /* --- The component -------------------------------------------------------- */
 
@@ -487,18 +519,29 @@ export function Waterfall({
     );
   }, [spans]);
 
-  const toggleSet =
-    (set: (updater: (previous: Set<string>) => Set<string>) => void) =>
-    (id: string) => {
-      set((previous) => {
-        const next = new Set(previous);
-        if (next.has(id)) next.delete(id);
-        else next.add(id);
-        return next;
-      });
-    };
   const toggleCollapsed = toggleSet(setCollapsed);
   const toggleGroup = toggleSet(setOpenGroups);
+
+  /*
+   * No spans, no clock. `Math.min` of nothing is Infinity, so a ruler drawn
+   * here would be a scale invented out of two infinities -- a trace that
+   * measured nothing is a thing to say, not a thing to draw.
+   */
+  if (spans.length === 0) {
+    return (
+      <figure className={styles.root({ className })} aria-label={label}>
+        <div className={styles.empty()}>
+          <EmptyIcon size="2xl" aria-hidden="true" className="text-fg-ghost" />
+          <div className="flex flex-col gap-1">
+            <Text variant="card-title">No spans</Text>
+            <Text variant="meta" tone="subtle">
+              This trace carries no timing to draw.
+            </Text>
+          </div>
+        </div>
+      </figure>
+    );
+  }
 
   /* --- Divider ----------------------------------------------------------- */
 
@@ -568,268 +611,24 @@ export function Waterfall({
       </div>
 
       <div role="tree" aria-label={label}>
-        {rows.map((row, rowIndex) => {
-          const indent = row.guides.slice(0, -1);
-          const guides = (
-            <>
-              {indent.map((line, level) => (
-                <span
-                  // Levels are positional by construction.
-                  key={level}
-                  aria-hidden="true"
-                  className={styles.guide()}
-                >
-                  {line ? <span className={styles.guideLine()} /> : null}
-                </span>
-              ))}
-            </>
-          );
-
-          const gridlines = (
-            <>
-              {[25, 50, 75].map((position) => (
-                <span
-                  key={position}
-                  aria-hidden="true"
-                  style={{ left: `${position}%` }}
-                  className={styles.gridline()}
-                />
-              ))}
-            </>
-          );
-
-          if (row.kind === 'gap') {
-            const left = ((row.startMs - start) / total) * 100;
-            const width = ((row.endMs - row.startMs) / total) * 100;
-            return (
-              <div
-                key={row.id}
-                role="treeitem"
-                tabIndex={-1}
-                aria-level={row.depth + 1}
-                aria-selected={false}
-                aria-disabled="true"
-                className={styles.row({ className: 'cursor-default' })}
-              >
-                <div className={styles.gutter()}>
-                  {guides}
-                  <span className={styles.pillGap()} />
-                  <span className={styles.gapLabel()}>
-                    missing instrumentation
-                  </span>
-                </div>
-                <div className={styles.track()}>
-                  {gridlines}
-                  <span
-                    aria-hidden="true"
-                    style={{ left: `${left}%`, width: `${width}%` }}
-                    className={styles.gapBar()}
-                  />
-                  <DurationLabel
-                    left={left}
-                    width={width}
-                    ms={row.endMs - row.startMs}
-                  />
-                </div>
-              </div>
-            );
-          }
-
-          const spansOfRow = row.kind === 'group' ? row.spans : [row.span];
-          const rowStart = Math.min(...spansOfRow.map((s) => s.startMs));
-          const rowEnd = Math.max(...spansOfRow.map((s) => s.endMs));
-          const failed =
-            row.kind === 'group' ? row.failed : spanKind(row.span) === 'error';
-          const kind: SpanKind =
-            row.kind === 'group'
-              ? failed
-                ? 'error'
-                : spanKind(row.spans[0] as WaterfallSpan)
-              : spanKind(row.span);
-          const isSelected = row.kind === 'span' && selectedId === row.id;
-          const left = ((rowStart - start) / total) * 100;
-          // A 2 ms span in a 600 ms trace still has to be visible: it may
-          // be the one that threw.
-          const width = Math.min(
-            Math.max(((rowEnd - rowStart) / total) * 100, 0.6),
-            100 - left,
-          );
-
-          const expandable =
-            row.kind === 'group' || (row.kind === 'span' && row.hasChildren);
-          const isOpen =
-            row.kind === 'group'
-              ? false
-              : row.kind === 'span' && row.hasChildren && !row.collapsed;
-          const toggle = () => {
-            if (row.kind === 'group') toggleGroup(row.id);
-            else if (row.kind === 'span' && row.hasChildren)
-              toggleCollapsed(row.id);
-          };
-          const select = () => {
-            if (row.kind !== 'span') {
-              toggle();
-              return;
-            }
-            onSelect?.(selectedId === row.id ? null : row.span);
-          };
-
-          const onRowKeyDown = (event: KeyboardEvent<HTMLElement>) => {
-            switch (event.key) {
-              case 'Enter':
-              case ' ':
-                event.preventDefault();
-                select();
-                break;
-              case 'ArrowDown':
-                event.preventDefault();
-                moveFocus(event.currentTarget, 1);
-                break;
-              case 'ArrowUp':
-                event.preventDefault();
-                moveFocus(event.currentTarget, -1);
-                break;
-              case 'Home':
-                event.preventDefault();
-                moveFocus(event.currentTarget, 'home');
-                break;
-              case 'End':
-                event.preventDefault();
-                moveFocus(event.currentTarget, 'end');
-                break;
-              case 'ArrowRight':
-                if (expandable && !isOpen) toggle();
-                break;
-              case 'ArrowLeft':
-                if (expandable && isOpen) toggle();
-                break;
-            }
-          };
-
-          const onRowClick = (event: MouseEvent) => {
-            const target = event.target as HTMLElement;
-            if (
-              target.closest('[data-chevron]') ||
-              target.closest('[data-wf-detail]')
-            ) {
-              return;
-            }
-            select();
-          };
-
-          const count = row.kind === 'group' ? row.spans.length : row.count;
-
-          return (
-            <div
+        {rows.map((row, rowIndex) =>
+          row.kind === 'gap' ? (
+            <GapRow key={row.id} row={row} start={start} total={total} />
+          ) : (
+            <SpanRow
               key={row.id}
-              role="treeitem"
-              // The tree is one tab stop; inside, the arrows take over.
-              tabIndex={rowIndex === 0 ? 0 : -1}
-              data-wf-row
-              aria-level={row.depth + 1}
-              aria-selected={isSelected}
-              aria-expanded={expandable ? isOpen : undefined}
-              data-failed={failed || undefined}
-              onClick={onRowClick}
-              onKeyDown={onRowKeyDown}
-              className={styles.row()}
-            >
-              <div className={styles.gutter()}>
-                {guides}
-                {expandable ? (
-                  /* A pointer shortcut for the treeitem's own expand; the
-                     state is announced by aria-expanded above. */
-                  <span
-                    aria-hidden="true"
-                    data-chevron
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      toggle();
-                    }}
-                    className={styles.pill()}
-                  >
-                    {isOpen ? (
-                      <ChevronDownIcon size="sm" aria-hidden="true" />
-                    ) : (
-                      <ChevronRightIcon size="sm" aria-hidden="true" />
-                    )}
-                    {count}
-                  </span>
-                ) : (
-                  <span className={styles.pillGap()} />
-                )}
-                <span className={styles.op()}>
-                  {row.kind === 'group'
-                    ? `${row.op} ×${row.spans.length}`
-                    : (row.span.op ?? 'span')}
-                </span>
-                <span className={styles.description()}>
-                  {row.kind === 'group'
-                    ? row.description
-                    : row.span.description}
-                </span>
-                {failed ? (
-                  <Tag tone="error" className="shrink-0">
-                    {row.kind === 'span'
-                      ? (row.span.status ?? 'error')
-                      : 'error'}
-                  </Tag>
-                ) : null}
-              </div>
-
-              <div className={styles.track()}>
-                {gridlines}
-                {row.kind === 'group' ? (
-                  spansOfRow.map((span) => {
-                    const segLeft = ((span.startMs - start) / total) * 100;
-                    const segWidth = Math.max(
-                      ((span.endMs - span.startMs) / total) * 100,
-                      0.4,
-                    );
-                    return (
-                      <span
-                        key={span.id}
-                        aria-hidden="true"
-                        style={{
-                          left: `${segLeft}%`,
-                          width: `${segWidth}%`,
-                        }}
-                        className={styles.bar({
-                          className: KIND_BAR[kind],
-                        })}
-                      />
-                    );
-                  })
-                ) : (
-                  <span
-                    aria-hidden="true"
-                    style={{ left: `${left}%`, width: `${width}%` }}
-                    className={styles.bar({ className: KIND_BAR[kind] })}
-                  />
-                )}
-                <DurationLabel
-                  left={left}
-                  width={width}
-                  ms={
-                    row.kind === 'group'
-                      ? spansOfRow.reduce(
-                          (acc, s) => acc + (s.endMs - s.startMs),
-                          0,
-                        )
-                      : rowEnd - rowStart
-                  }
-                  failed={failed}
-                />
-              </div>
-
-              {isSelected && renderDetail && row.kind === 'span' ? (
-                <div data-wf-detail className={styles.detail()}>
-                  {renderDetail(row.span)}
-                </div>
-              ) : null}
-            </div>
-          );
-        })}
+              row={row}
+              start={start}
+              total={total}
+              tabStop={rowIndex === 0}
+              selected={row.kind === 'span' && selectedId === row.id}
+              onSelect={onSelect}
+              renderDetail={renderDetail}
+              onToggle={row.kind === 'group' ? toggleGroup : toggleCollapsed}
+              moveFocus={moveFocus}
+            />
+          ),
+        )}
       </div>
 
       {/* biome-ignore lint/a11y/useSemanticElements: a window splitter is
@@ -864,6 +663,331 @@ export function Waterfall({
 }
 
 Waterfall.displayName = 'Waterfall';
+
+/* --- The rows ------------------------------------------------------------- */
+
+/** One indent step per ancestor, carrying a guide line where one belongs. */
+function RowGuides({ guides }: { guides: boolean[] }) {
+  return (
+    <>
+      {guides.slice(0, -1).map((line, level) => (
+        <span
+          // Levels are positional by construction.
+          key={level}
+          aria-hidden="true"
+          className={styles.guide()}
+        >
+          {line ? <span className={styles.guideLine()} /> : null}
+        </span>
+      ))}
+    </>
+  );
+}
+
+RowGuides.displayName = 'RowGuides';
+
+/** The ruler's quarters, repeated down every track so bars stay readable. */
+function RowGridlines() {
+  return (
+    <>
+      {[25, 50, 75].map((position) => (
+        <span
+          key={position}
+          aria-hidden="true"
+          style={{ left: `${position}%` }}
+          className={styles.gridline()}
+        />
+      ))}
+    </>
+  );
+}
+
+RowGridlines.displayName = 'RowGridlines';
+
+/** Time inside the parent that no child claimed, hatched and named. */
+function GapRow({
+  row,
+  start,
+  total,
+}: {
+  row: Extract<Row, { kind: 'gap' }>;
+  start: number;
+  total: number;
+}) {
+  const left = ((row.startMs - start) / total) * 100;
+  const width = ((row.endMs - row.startMs) / total) * 100;
+  return (
+    <div
+      role="treeitem"
+      tabIndex={-1}
+      aria-level={row.depth + 1}
+      aria-selected={false}
+      aria-disabled="true"
+      className={styles.row({ className: 'cursor-default' })}
+    >
+      <div className={styles.gutter()}>
+        <RowGuides guides={row.guides} />
+        <span className={styles.pillGap()} />
+        <span className={styles.gapLabel()}>missing instrumentation</span>
+      </div>
+      <div className={styles.track()}>
+        <RowGridlines />
+        <span
+          aria-hidden="true"
+          style={{ left: `${left}%`, width: `${width}%` }}
+          className={styles.gapBar()}
+        />
+        <DurationLabel left={left} width={width} ms={row.endMs - row.startMs} />
+      </div>
+    </div>
+  );
+}
+
+GapRow.displayName = 'GapRow';
+
+type SpanRowData = Extract<Row, { kind: 'span' } | { kind: 'group' }>;
+
+/** What the row names: the op, what it did it to, and its error if it broke. */
+function RowLabel({ row, failed }: { row: SpanRowData; failed: boolean }) {
+  return (
+    <>
+      <span className={styles.op()}>
+        {row.kind === 'group'
+          ? `${row.op} ×${row.spans.length}`
+          : (row.span.op ?? 'span')}
+      </span>
+      <span className={styles.description()}>
+        {row.kind === 'group' ? row.description : row.span.description}
+      </span>
+      {failed ? (
+        <Tag tone="error" className="shrink-0">
+          {row.kind === 'span' ? (row.span.status ?? 'error') : 'error'}
+        </Tag>
+      ) : null}
+    </>
+  );
+}
+
+RowLabel.displayName = 'RowLabel';
+
+/**
+ * The bars: one for a span, one per member for an autogroup -- forty
+ * queries as forty marks on one line is the reading that says N+1.
+ */
+function RowBars({
+  row,
+  kind,
+  start,
+  total,
+  left,
+  width,
+}: {
+  row: SpanRowData;
+  kind: SpanKind;
+  start: number;
+  total: number;
+  left: number;
+  width: number;
+}) {
+  if (row.kind === 'group') {
+    return (
+      <>
+        {row.spans.map((span) => (
+          <span
+            key={span.id}
+            aria-hidden="true"
+            style={{
+              left: `${((span.startMs - start) / total) * 100}%`,
+              width: `${Math.max(((span.endMs - span.startMs) / total) * 100, 0.4)}%`,
+            }}
+            className={styles.bar({ className: KIND_BAR[kind] })}
+          />
+        ))}
+      </>
+    );
+  }
+  return (
+    <span
+      aria-hidden="true"
+      style={{ left: `${left}%`, width: `${width}%` }}
+      className={styles.bar({ className: KIND_BAR[kind] })}
+    />
+  );
+}
+
+RowBars.displayName = 'RowBars';
+
+/** One span, or one autogrouped run of them, on the shared clock. */
+function SpanRow({
+  row,
+  start,
+  total,
+  tabStop,
+  selected,
+  onSelect,
+  renderDetail,
+  onToggle,
+  moveFocus,
+}: {
+  row: SpanRowData;
+  start: number;
+  total: number;
+  tabStop: boolean;
+  selected: boolean;
+  onSelect?: (span: WaterfallSpan | null) => void;
+  renderDetail?: (span: WaterfallSpan) => ReactNode;
+  onToggle: (id: string) => void;
+  moveFocus: (from: HTMLElement, delta: number | 'home' | 'end') => void;
+}) {
+  const spans = row.kind === 'group' ? row.spans : [row.span];
+  const rowStart = Math.min(...spans.map((s) => s.startMs));
+  const rowEnd = Math.max(...spans.map((s) => s.endMs));
+  const failed =
+    row.kind === 'group' ? row.failed : spanKind(row.span) === 'error';
+  const kind: SpanKind =
+    row.kind === 'group'
+      ? failed
+        ? 'error'
+        : spanKind(row.spans[0] as WaterfallSpan)
+      : spanKind(row.span);
+
+  const left = ((rowStart - start) / total) * 100;
+  // A 2 ms span in a 600 ms trace still has to be visible: it may be the
+  // one that threw.
+  const width = Math.min(
+    Math.max(((rowEnd - rowStart) / total) * 100, 0.6),
+    100 - left,
+  );
+
+  const expandable = row.kind === 'group' || row.hasChildren;
+  const isOpen = row.kind === 'span' && row.hasChildren && !row.collapsed;
+  const toggle = () => {
+    if (expandable) onToggle(row.id);
+  };
+  const select = () => {
+    if (row.kind !== 'span') {
+      toggle();
+      return;
+    }
+    onSelect?.(selected ? null : row.span);
+  };
+
+  const onRowKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    switch (event.key) {
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        select();
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        moveFocus(event.currentTarget, 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        moveFocus(event.currentTarget, -1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        moveFocus(event.currentTarget, 'home');
+        break;
+      case 'End':
+        event.preventDefault();
+        moveFocus(event.currentTarget, 'end');
+        break;
+      case 'ArrowRight':
+        if (expandable && !isOpen) toggle();
+        break;
+      case 'ArrowLeft':
+        if (expandable && isOpen) toggle();
+        break;
+    }
+  };
+
+  const onRowClick = (event: MouseEvent) => {
+    const target = event.target as HTMLElement;
+    if (
+      target.closest('[data-chevron]') ||
+      target.closest('[data-wf-detail]')
+    ) {
+      return;
+    }
+    select();
+  };
+
+  return (
+    <div
+      role="treeitem"
+      // The tree is one tab stop; inside, the arrows take over.
+      tabIndex={tabStop ? 0 : -1}
+      data-wf-row
+      aria-level={row.depth + 1}
+      aria-selected={selected}
+      aria-expanded={expandable ? isOpen : undefined}
+      data-failed={failed || undefined}
+      onClick={onRowClick}
+      onKeyDown={onRowKeyDown}
+      className={styles.row()}
+    >
+      <div className={styles.gutter()}>
+        <RowGuides guides={row.guides} />
+        {expandable ? (
+          /* A pointer shortcut for the treeitem's own expand; the state is
+             announced by aria-expanded above. */
+          <span
+            aria-hidden="true"
+            data-chevron
+            onClick={(event) => {
+              event.stopPropagation();
+              toggle();
+            }}
+            className={styles.pill()}
+          >
+            {isOpen ? (
+              <ChevronDownIcon size="sm" aria-hidden="true" />
+            ) : (
+              <ChevronRightIcon size="sm" aria-hidden="true" />
+            )}
+            {row.kind === 'group' ? row.spans.length : row.count}
+          </span>
+        ) : (
+          <span className={styles.pillGap()} />
+        )}
+        <RowLabel row={row} failed={failed} />
+      </div>
+
+      <div className={styles.track()}>
+        <RowGridlines />
+        <RowBars
+          row={row}
+          kind={kind}
+          start={start}
+          total={total}
+          left={left}
+          width={width}
+        />
+        <DurationLabel
+          left={left}
+          width={width}
+          ms={
+            row.kind === 'group'
+              ? spans.reduce((acc, s) => acc + (s.endMs - s.startMs), 0)
+              : rowEnd - rowStart
+          }
+          failed={failed}
+        />
+      </div>
+
+      {selected && renderDetail && row.kind === 'span' ? (
+        <div data-wf-detail className={styles.detail()}>
+          {renderDetail(row.span)}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+SpanRow.displayName = 'SpanRow';
 
 /**
  * The duration beside its bar: outside its right end with room to spare,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -215,14 +215,12 @@ export { TimeSeriesChart } from './components/chart/time-series-chart';
 
 /* --- Waterfall ------------------------------------------------------------ */
 
+export { formatSpanDuration } from './components/waterfall/format';
 export type {
   WaterfallProps,
   WaterfallSpan,
 } from './components/waterfall/waterfall';
-export {
-  formatSpanDuration,
-  Waterfall,
-} from './components/waterfall/waterfall';
+export { Waterfall } from './components/waterfall/waterfall';
 
 /* --- Overlays ------------------------------------------------------------ */
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -218,6 +218,17 @@ export { Sparkline } from './components/chart/sparkline';
 export type { TimeSeriesChartProps } from './components/chart/time-series-chart';
 export { TimeSeriesChart } from './components/chart/time-series-chart';
 
+/* --- Waterfall ------------------------------------------------------------ */
+
+export type {
+  WaterfallProps,
+  WaterfallSpan,
+} from './components/waterfall/waterfall';
+export {
+  formatSpanDuration,
+  Waterfall,
+} from './components/waterfall/waterfall';
+
 /* --- Overlays ------------------------------------------------------------ */
 
 export type {


### PR DESCRIPTION
## What

The span waterfall, replacing webview-ui's old one. Stacked on #281. Designed from a source-level study of the strongest tracers (Sentry's new trace view, Datadog, Honeycomb, Tempo/Jaeger, Chrome DevTools) rather than copying any mock.

### The shape
- **Split columns with a draggable divider** (Sentry/Honeycomb model): tree on the left, timeline on the right. The divider is a real control — pointer drag, arrow keys (`role=separator` with aria values), clamped 15–85 % — and the split is a fraction, so it means the same thing at every width.
- **Durations ride their bars**: outside the bar's right end while there is room, stepping inside once the bar reaches the edge (Sentry's exact placement). Never a far-away column.
- **Chevron pills carry descendant counts** over per-depth tree guide lines: what a fold hides is written on the fold.
- **Autogrouping**: five-plus consecutive identical leaf siblings (op + description) fold into one `db.query ×6` row with a segmented bar — the N+1 that makes real traces unreadable. Opens from the pill or the row.
- **Missing instrumentation** (opt-in, like Sentry): sibling gaps ≥ 100 ms surface as a hatched row with their duration.
- **Colour by kind** — db (chart-1), internal (chart-3), http (quiet grey) — plus the error as the page's only red (bar, figure and row tint); legend only for kinds present. One hue per op was rejected as confetti: the gutter already names the op.

### Interaction
- **Roving-tabindex tree**: one tab stop; ↑↓ walk, ←→ fold/unfold, Home/End, Enter selects. `tree`/`treeitem` semantics with level, expanded and selected announced.
- **Selection is controlled** (`selectedId`/`onSelect`) and the detail opens **inside the trace** under its row via `renderDetail` — the component owns the seam, the app owns the content. Clicks inside the detail never deselect.

### Responsive
- `@container` queries, not viewport: below ~670 px of container each row stacks — name line above at full width, bar + duration below — the ruler spans the whole width, and the divider (with nothing left to resize) disappears.
- The detail is `min-w-0 basis-full overflow-x-auto`: long values scroll inside their own box instead of widening the trace.
- The ruler scrolls with the content — sticky was escaping the app's rounded card on page scroll.

## How it was verified

166 tests across the package — 7 waterfall stories-as-tests in Chromium with axe: autogroup fold/unfold, selection round-trip, pill-vs-row click separation, full keyboard walk, missing-instrumentation row with its 221 ms, divider keyboard resize, and the narrow layout's geometry (stacked lines, hidden divider, no horizontal growth when a detail opens).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Waterfall trace visualization with hierarchical spans, collapsible descendants, duration bars, selection details, error styling, legends, and empty states.
  - Added draggable and keyboard-accessible column resizing and tree navigation.
  - Added optional missing-instrumentation indicators and automatic grouping of leaf spans.
  - Added human-readable span duration formatting.
- **Documentation**
  - Documented the Waterfall component and its capabilities.
- **Tests**
  - Added comprehensive interactive Storybook examples covering accessibility, responsiveness, grouping, selection, and empty traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->